### PR TITLE
Wire retention API + background job (memory retention lifecycle)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -584,6 +584,40 @@ public final class MLCommonsSettings {
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
+    // Memory retention job settings
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
+            24,
+            1,
+            168,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_throttle_seconds",
+            5,
+            1,
+            60,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS = Setting
+        .intSetting(ML_PLUGIN_SETTING_PREFIX + "memory.orphan_ttl_days", 7, 1, 365, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.working_memory_ttl_days",
+            30,
+            1,
+            365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     private static void validateRegexSafety(String regex) {
         // Reject nested quantifiers or backreferences
         if (regex.matches(".*\\([^)]*[*+?]\\)[*+?{].*") || regex.matches(".*\\\\[1-9].*")) {

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -588,7 +588,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            2, // DEMO: default 2 minutes (was 24 hours)
+            24,
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -588,7 +588,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            24,
+            2, // DEMO: default 2 minutes (was 24 hours)
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -22,6 +23,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PAYLOAD_TYPE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -73,6 +76,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Pinned field (only valid for session/long-term/history, rejected for working memory)
+    private Boolean pinned;
+
     // Checkpoint field
     private String checkpointId;
     private String tenantId;
@@ -91,6 +97,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Map<String, Object> parameters,
         String ownerId,
+        Boolean pinned,
         String checkpointId,
         String tenantId
     ) {
@@ -112,6 +119,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.pinned = pinned;
         this.checkpointId = checkpointId;
         this.tenantId = tenantId;
         validate();
@@ -161,6 +169,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         this.checkpointId = in.readOptionalString();
         this.tenantId = in.readOptionalString();
     }
@@ -218,6 +229,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         out.writeOptionalString(checkpointId);
         out.writeOptionalString(tenantId);
     }
@@ -297,6 +311,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        Boolean pinned = null;
         String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -348,6 +363,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.booleanValue();
+                    break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();
                     break;
@@ -375,6 +393,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .pinned(pinned)
             .checkpointId(checkpointId)
             .tenantId(tenantId)
             .build();

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -168,7 +168,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         this.checkpointId = in.readOptionalString();
@@ -228,7 +228,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         out.writeOptionalString(checkpointId);

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -862,4 +862,57 @@ public class MLAddMemoriesInputTest {
         assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
+    @Test
+    public void testPinnedField() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        assertEquals(Boolean.TRUE, input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldNull() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .build();
+
+        assertNull(input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamSerialization() throws IOException {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+        assertEquals(Boolean.TRUE, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldParsing() throws IOException {
+        String json = "{\"memory_container_id\":\"container-123\",\"payload_type\":\"conversational\","
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}],"
+            + "\"pinned\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123", null);
+        assertEquals(Boolean.TRUE, parsed.getPinned());
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -876,11 +876,7 @@ public class MLAddMemoriesInputTest {
 
     @Test
     public void testPinnedFieldNull() {
-        MLAddMemoriesInput input = MLAddMemoriesInput
-            .builder()
-            .memoryContainerId("container-123")
-            .messages(testMessages)
-            .build();
+        MLAddMemoriesInput input = MLAddMemoriesInput.builder().memoryContainerId("container-123").messages(testMessages).build();
 
         assertNull(input.getPinned());
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,6 +9,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.opensearch.common.logging.HeaderWarning;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -24,6 +27,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -100,6 +105,9 @@ public class TransportCreateMemoryContainerAction extends
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
+            // Emit warning if sessions retention is set on a container with disableSession=true
+            emitDisableSessionRetentionWarning(input.getConfiguration());
+
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
                 try {
@@ -285,6 +293,20 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,8 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.time.Instant;
 import java.util.Map;
 
-import org.opensearch.common.logging.HeaderWarning;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
@@ -20,6 +18,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,8 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -186,6 +189,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
                     // No transition - proceed with normal update
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
+
+                    // Emit warning if sessions retention is set on a container with disableSession=true
+                    emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -251,6 +257,20 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -123,8 +123,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
-                        "pinned field is not supported for working memory type."
-                            + " To preserve a conversation, pin the session instead.",
+                        "pinned field is not supported for working memory type." + " To preserve a conversation, pin the session instead.",
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -118,6 +118,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             return;
         }
 
+        // Reject pinned field — add-memories creates working memory which cannot be pinned
+        if (input.getPinned() != null) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "pinned field is not supported for working memory type."
+                            + " To preserve a conversation, pin the session instead.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
         String memoryContainerId = input.getMemoryContainerId();
 
         if (StringUtils.isBlank(memoryContainerId)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MESSAGES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
@@ -136,6 +137,20 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     return;
                 }
 
+                // Reject pinned field for working memory type
+                Map<String, Object> updateContent = updateRequest.getMlUpdateMemoryInput().getUpdateContent();
+                if (memoryType == MemoryType.WORKING && updateContent.containsKey(PINNED_FIELD)) {
+                    actionListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "pinned field is not supported for working memory type."
+                                    + " To preserve a conversation, pin the session instead.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    return;
+                }
+
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
@@ -186,6 +201,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         if (updateContent.containsKey(ADDITIONAL_INFO_FIELD)) {
             updateFields.put(ADDITIONAL_INFO_FIELD, updateContent.get(ADDITIONAL_INFO_FIELD));
         }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
+        }
         return updateFields;
     }
 
@@ -217,6 +235,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         }
         if (updateContent.containsKey(TAGS_FIELD)) {
             updateFields.put(TAGS_FIELD, updateContent.get(TAGS_FIELD));
+        }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
         }
         return updateFields;
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
 import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
@@ -128,9 +129,13 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<MLSe
     }
 
     private void search(String tenantId, SearchRequest request, ActionListener<SearchResponse> listener) {
+        String[] indices = request.indices();
+        if (indices == null || indices.length == 0) {
+            indices = new String[] { ML_MODEL_GROUP_INDEX };
+        }
         SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
             .builder()
-            .indices(request.indices())
+            .indices(indices)
             .searchSourceBuilder(request.source())
             .tenantId(tenantId)
             .build();

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -105,7 +105,8 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
-                    mlTaskManager.indexMemoryRetentionJob();
+                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    mlTaskManager.indexMemoryRetentionJob(intervalHours);
                     this.startedMemoryRetentionJob = true;
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -40,6 +41,7 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
     private final Client client;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private boolean startedStatsJob;
+    private boolean startedMemoryRetentionJob;
 
     public MLCommonsClusterEventListener(
         ClusterService clusterService,
@@ -98,6 +100,13 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                     mlTaskManager.indexStatsCollectorJob(true);
                     // using this variable in case if same node has a cluster state change event and the state is not updated yet
                     this.startedStatsJob = true;
+                }
+
+                if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+                    && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
+                    && !this.startedMemoryRetentionJob) {
+                    mlTaskManager.indexMemoryRetentionJob();
+                    this.startedMemoryRetentionJob = true;
                 }
 
                 break;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -13,6 +13,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.jobs.processors.MLBatchTaskUpdateProcessor;
 import org.opensearch.ml.jobs.processors.MLStatsJobProcessor;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -105,6 +106,9 @@ public class MLJobRunner implements ScheduledJobRunner {
                 break;
             case BATCH_TASK_UPDATE:
                 MLBatchTaskUpdateProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
+                break;
+            case MEMORY_RETENTION:
+                MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported job type " + jobParameter.getJobType());

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
@@ -7,7 +7,8 @@ package org.opensearch.ml.jobs;
 
 public enum MLJobType {
     STATS_COLLECTOR("Job to collect static metrics and push to Metrics Registry"),
-    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models");
+    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models"),
+    MEMORY_RETENTION("Job to enforce retention policies on agentic memory containers");
 
     private final String description;
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -5,11 +5,56 @@
 
 package org.opensearch.ml.jobs.processors;
 
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_STORAGE_CONFIG_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -18,6 +63,10 @@ import com.google.common.annotations.VisibleForTesting;
 public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static final int CONTAINER_PAGE_SIZE = 100;
+    private static final int DELETE_BY_QUERY_BATCH_SIZE = 500;
+    private static final int BULK_DELETE_BATCH_SIZE = 1000;
 
     private static MemoryRetentionJobProcessor instance;
 
@@ -52,6 +101,713 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        log.info("Memory retention job triggered");
+        log.info("Memory retention job started");
+        resolveContainersWithPolicies(null);
+    }
+
+    private void resolveContainersWithPolicies(Object[] searchAfterValues) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHits hits = response.getHits();
+                SearchHit[] hitArray = hits.getHits();
+
+                if (hitArray.length == 0) {
+                    onJobComplete();
+                    return;
+                }
+
+                processContainerChain(
+                    hitArray,
+                    0,
+                    hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null
+                );
+            }, e -> {
+                log.error("Failed to search for containers with retention policies", e);
+                onJobComplete();
+            }));
+        }
+    }
+
+    private void processContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+        if (index >= hits.length) {
+            if (nextPageSortValues != null) {
+                resolveContainersWithPolicies(nextPageSortValues);
+            } else {
+                executeOrphanSweep();
+                onJobComplete();
+            }
+            return;
+        }
+
+        processContainer(hits[index], ActionListener.wrap(v -> scheduleNext(hits, index + 1, nextPageSortValues), e -> {
+            log.error("Failed processing container [{}]", hits[index].getId(), e);
+            scheduleNext(hits, index + 1, nextPageSortValues);
+        }));
+    }
+
+    private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
+        int throttleSeconds = ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS.get(clusterService.getSettings());
+        threadPool
+            .schedule(
+                () -> processContainerChain(hits, nextIndex, nextPageSortValues),
+                TimeValue.timeValueSeconds(throttleSeconds),
+                ThreadPool.Names.GENERIC
+            );
+    }
+
+    private void processContainer(SearchHit hit, ActionListener<Void> listener) {
+        String containerId = hit.getId();
+        try {
+            Map<String, Object> source = hit.getSourceAsMap();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) source.get(MEMORY_STORAGE_CONFIG_FIELD);
+
+            if (configMap == null) {
+                log.warn("Container [{}] has no configuration field, skipping", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
+            BytesReference bytes = BytesReference.bytes(xContentBuilder);
+            XContentParser parser = XContentHelper
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
+            parser.nextToken();
+            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+            executeSessionRetention(
+                config,
+                containerId,
+                ActionListener
+                    .wrap(
+                        v -> executeLongTermRetention(
+                            config,
+                            containerId,
+                            ActionListener
+                                .wrap(
+                                    v2 -> executeHistoryRetention(
+                                        config,
+                                        containerId,
+                                        ActionListener
+                                            .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ),
+                                    listener::onFailure
+                                )
+                        ),
+                        listener::onFailure
+                    )
+            );
+        } catch (Exception e) {
+            log.error("Error parsing configuration for container [{}]", containerId, e);
+            listener.onResponse(null);
+        }
+    }
+
+    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
+        if (sessionIndex == null) {
+            log.debug("Session index is null for container [{}], skipping session retention", containerId);
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule sessionRule = retentionPolicy.get(MemoryType.SESSIONS);
+        if (sessionRule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        identifyExpiredSessions(config, containerId, sessionIndex, sessionRule, ActionListener.wrap(expiredSessionIds -> {
+            if (expiredSessionIds.isEmpty()) {
+                log.info("[MemoryRetentionJob] container={} sessions_expired=0", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            log.info("[MemoryRetentionJob] container={} sessions_expired={}", containerId, expiredSessionIds.size());
+
+            cascadeDeleteWorkingMemory(
+                config,
+                containerId,
+                expiredSessionIds,
+                ActionListener
+                    .wrap(deletedCount -> deleteSessionDocuments(config, sessionIndex, expiredSessionIds, listener), listener::onFailure)
+            );
+        }, listener::onFailure));
+    }
+
+    private void identifyExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        RetentionRule rule,
+        ActionListener<Set<String>> listener
+    ) {
+        Set<String> expiredIds = new HashSet<>();
+
+        ActionListener<Set<String>> timeBasedDone = ActionListener.wrap(timeExpired -> {
+            expiredIds.addAll(timeExpired);
+            if (rule.getMaxCount() != null) {
+                identifyCountBasedExpiredSessions(
+                    config,
+                    containerId,
+                    sessionIndex,
+                    rule.getMaxCount(),
+                    ActionListener.wrap(countExpired -> {
+                        expiredIds.addAll(countExpired);
+                        listener.onResponse(expiredIds);
+                    }, listener::onFailure)
+                );
+            } else {
+                listener.onResponse(expiredIds);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            identifyTimeBasedExpiredSessions(config, containerId, sessionIndex, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(new HashSet<>());
+        }
+    }
+
+    private void identifyTimeBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int retentionDays,
+        ActionListener<Set<String>> listener
+    ) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        request.source(sourceBuilder);
+
+        Set<String> expiredIds = new HashSet<>();
+        searchAllPages(request, expiredIds, listener);
+    }
+
+    private void searchAllPages(SearchRequest request, Set<String> accumulator, ActionListener<Set<String>> listener) {
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    accumulator.add(hit.getId());
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] sortValues = hits[hits.length - 1].getSortValues();
+                    request.source().searchAfter(sortValues);
+                    searchAllPages(request, accumulator, listener);
+                } else {
+                    listener.onResponse(accumulator);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void identifyCountBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        ActionListener<Set<String>> listener
+    ) {
+        // Walk sessions sorted by last_updated_time DESC (newest first).
+        // Skip the first maxCount sessions; collect the rest as expired.
+        Set<String> expiredIds = new HashSet<>();
+        identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
+    }
+
+    private void identifyCountBasedPage(
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        Set<String> expiredIds,
+        int seenSoFar,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort(LAST_UPDATED_TIME_FIELD, SortOrder.DESC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                int currentSeen = seenSoFar;
+
+                for (SearchHit hit : hits) {
+                    currentSeen++;
+                    if (currentSeen > maxCount) {
+                        expiredIds.add(hit.getId());
+                    }
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, currentSeen, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(expiredIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void cascadeDeleteWorkingMemory(
+        MemoryConfiguration config,
+        String containerId,
+        Set<String> expiredSessionIds,
+        ActionListener<Long> listener
+    ) {
+        String workingMemoryIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingMemoryIndex == null) {
+            listener.onResponse(0L);
+            return;
+        }
+
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), DELETE_BY_QUERY_BATCH_SIZE);
+        cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, 0, 0L, listener);
+    }
+
+    private void cascadeDeleteBatch(
+        MemoryConfiguration config,
+        String workingMemoryIndex,
+        String containerId,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            log.info("[MemoryRetentionJob] container={} cascade_working_memory_deleted={}", containerId, totalDeleted);
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingMemoryIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + ".session_id", batch))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse bulkResponse) -> {
+                long deleted = bulkResponse.getDeleted();
+                cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, batchIndex + 1, totalDeleted + deleted, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteSessionDocuments(
+        MemoryConfiguration config,
+        String sessionIndex,
+        Set<String> expiredSessionIds,
+        ActionListener<Void> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), BULK_DELETE_BATCH_SIZE);
+        deleteSessionBatch(config, sessionIndex, batches, 0, listener);
+    }
+
+    private void deleteSessionBatch(
+        MemoryConfiguration config,
+        String sessionIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        ActionListener<Void> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String sessionId : batch) {
+            bulkRequest.add(new DeleteRequest(sessionIndex, sessionId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
+        if (longTermIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.LONG_TERM)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.LONG_TERM);
+        if (rule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        ActionListener<Long> timeBasedDone = ActionListener.wrap(timeDeleted -> {
+            if (rule.getMaxCount() != null) {
+                executeLongTermMaxCount(longTermIndex, containerId, rule.getMaxCount(), ActionListener.wrap(countDeleted -> {
+                    long total = (timeDeleted != null ? timeDeleted : 0L) + countDeleted;
+                    log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            } else {
+                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, timeDeleted != null ? timeDeleted : 0L);
+                listener.onResponse(null);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            executeLongTermRetentionDays(longTermIndex, containerId, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(0L);
+        }
+    }
+
+    private void executeLongTermRetentionDays(String longTermIndex, String containerId, int retentionDays, ActionListener<Long> listener) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+                    .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                listener.onResponse(response.getDeleted());
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeLongTermMaxCount(String longTermIndex, String containerId, int maxCount, ActionListener<Long> listener) {
+        // Step 1: count non-pinned long-term docs
+        SearchRequest countRequest = new SearchRequest(longTermIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    listener.onResponse(0L);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search for oldest excess docs by last_updated_time ASC
+                collectOldestDocIds(longTermIndex, containerId, LAST_UPDATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        listener.onResponse(0L);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(longTermIndex, new ArrayList<>(idsToDelete), listener);
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void collectOldestDocIds(String index, String containerId, String timeField, int limit, ActionListener<Set<String>> listener) {
+        Set<String> collected = new HashSet<>();
+        collectOldestDocIdsPage(index, containerId, timeField, limit, collected, null, listener);
+    }
+
+    private void collectOldestDocIdsPage(
+        String index,
+        String containerId,
+        String timeField,
+        int limit,
+        Set<String> collected,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(index);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        int pageSize = Math.min(CONTAINER_PAGE_SIZE, limit - collected.size());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(pageSize)
+            .sort(timeField, SortOrder.ASC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    collected.add(hit.getId());
+                    if (collected.size() >= limit) {
+                        listener.onResponse(collected);
+                        return;
+                    }
+                }
+
+                if (hits.length == pageSize && collected.size() < limit) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    collectOldestDocIdsPage(index, containerId, timeField, limit, collected, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(collected);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteDocumentsBatch(String index, List<String> ids, ActionListener<Long> listener) {
+        List<List<String>> batches = partition(ids, BULK_DELETE_BATCH_SIZE);
+        deleteDocumentsBatchRecursive(index, batches, 0, 0L, listener);
+    }
+
+    private void deleteDocumentsBatchRecursive(
+        String index,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String docId : batch) {
+            bulkRequest.add(new DeleteRequest(index, docId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteDocumentsBatchRecursive(
+                                index,
+                                batches,
+                                batchIndex + 1,
+                                totalDeleted + batch.size(),
+                                listener
+                            ),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String historyIndex = config.getIndexName(MemoryType.HISTORY);
+        if (historyIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.HISTORY)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.HISTORY);
+        if (rule == null || rule.getMaxCount() == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int maxCount = rule.getMaxCount();
+
+        // Step 1: count non-pinned history docs
+        SearchRequest countRequest = new SearchRequest(historyIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                    listener.onResponse(null);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search oldest excess docs by created_time ASC (history uses created_time)
+                collectOldestDocIds(historyIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                        listener.onResponse(null);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(historyIndex, new ArrayList<>(idsToDelete), ActionListener.wrap(deleted -> {
+                        log.info("[MemoryRetentionJob] container={} history_deleted={}", containerId, deleted);
+                        listener.onResponse(null);
+                    }, listener::onFailure));
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        if (!config.isDisableSession()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        String workingIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int ttlDays = ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS.get(clusterService.getSettings());
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
+                listener.onResponse(null);
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeOrphanSweep() {
+        log.debug("Orphan sweep not yet implemented");
+    }
+
+    private void onJobComplete() {
+        log.info("Memory retention job completed");
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class MemoryRetentionJobProcessor extends MLJobProcessor {
+
+    private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static MemoryRetentionJobProcessor instance;
+
+    public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (MemoryRetentionJobProcessor.class) {
+            if (instance != null) {
+                return instance;
+            }
+
+            instance = new MemoryRetentionJobProcessor(clusterService, client, threadPool);
+            return instance;
+        }
+    }
+
+    @VisibleForTesting
+    public static synchronized void reset() {
+        instance = null;
+    }
+
+    public MemoryRetentionJobProcessor(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        super(clusterService, client, threadPool);
+    }
+
+    @Override
+    public void run() {
+        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+            log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        log.info("Memory retention job triggered");
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1436,7 +1436,11 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -571,7 +571,7 @@ public class MLTaskManager implements SettingsChangeListener {
         }
     }
 
-    public void indexMemoryRetentionJob() {
+    public void indexMemoryRetentionJob(int intervalHours) {
         if (this.memoryRetentionJobStarted) {
             log.debug("Memory retention job already started");
             return;
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -84,6 +84,7 @@ public class MLTaskManager implements SettingsChangeListener {
     private final Map<MLTaskType, AtomicInteger> runningTasksCount;
     private boolean taskPollingJobStarted;
     private boolean statsCollectorJobStarted;
+    private boolean memoryRetentionJobStarted;
     public static final ImmutableSet<MLTaskState> TASK_DONE_STATES = ImmutableSet
         .of(MLTaskState.COMPLETED, MLTaskState.COMPLETED_WITH_ERROR, MLTaskState.FAILED, MLTaskState.CANCELLED);
 
@@ -567,6 +568,37 @@ public class MLTaskManager implements SettingsChangeListener {
             indexJob(indexRequest, MLJobType.BATCH_TASK_UPDATE, () -> this.taskPollingJobStarted = true);
         } catch (IOException e) {
             log.error("Failed to index task polling job", e);
+        }
+    }
+
+    public void indexMemoryRetentionJob() {
+        if (this.memoryRetentionJobStarted) {
+            log.debug("Memory retention job already started");
+            return;
+        }
+
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.debug("Memory retention job started successfully");
+            });
+        } catch (IOException e) {
+            log.error("Failed to index memory retention job", e);
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -1939,7 +1939,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(captor.getValue().getMessage().contains("Internal server error"));
     }
 
-    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    @Test
     public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
         // Create config with retention_policy to verify it passes through
         Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -1992,6 +1992,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -1937,6 +1940,58 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
     }
 
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
+        // Create config with retention_policy to verify it passes through
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).maxCount(100).build());
+        retentionPolicy.put(MemoryType.LONG_TERM, RetentionRule.builder().maxCount(500).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration configWithRetention = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput retentionInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("retention-container")
+            .description("Container with retention policy")
+            .configuration(configWithRetention)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest retentionRequest = new MLCreateMemoryContainerRequest(retentionInput);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(retentionRequest);
+
+        // Verify the configuration retains the retention policy
+        assertNotNull(configWithRetention.getRetentionPolicy());
+        assertEquals(2, configWithRetention.getRetentionPolicy().size());
+        assertEquals(Integer.valueOf(30), configWithRetention.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+    }
+
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -166,17 +166,36 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
-    public void testDoExecute_BlankMemoryContainerId() {
+    public void testDoExecute_PinnedFieldRejected() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
-        
+
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
-        when(input.getMemoryContainerId()).thenReturn("");
-        
+        when(input.getPinned()).thenReturn(true);
+
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
         when(request.getMlAddMemoryInput()).thenReturn(input);
-        
+
         transportAddMemoriesAction.doExecute(task, request, actionListener);
-        
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().contains("pinned field is not supported for working memory type");
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("");
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
         verify(actionListener).onFailure(any(IllegalArgumentException.class));
     }
 
@@ -185,6 +204,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -213,6 +233,7 @@ public class TransportAddMemoriesActionTests {
         List<MessageInput> messages = Arrays.asList(message);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -248,6 +269,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -300,6 +322,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -348,6 +371,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -382,6 +406,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -431,6 +456,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id in namespace
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -485,6 +511,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -556,6 +583,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -613,6 +641,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "existing-session-123"); // User provided session_id
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -664,6 +693,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - would normally trigger session creation, but getLlmId() is null
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -715,6 +745,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -773,6 +804,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -831,6 +863,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -890,6 +923,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -949,6 +983,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1014,6 +1049,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy2);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1071,6 +1107,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1128,6 +1165,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1184,6 +1222,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1250,6 +1289,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1335,6 +1375,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1430,6 +1471,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1498,6 +1540,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -795,4 +795,163 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         verify(memoryContainerHelper, never()).indexData(any(), any(), any());
     }
 
+    @Test
+    public void testDoExecute_PinnedRejectedForWorkingMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.WORKING)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.WORKING)).thenReturn("test-working-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("pinned field is not supported for working memory type"));
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForSessionMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.SESSIONS)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.SESSIONS)).thenReturn("test-session-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            // Verify pinned field is included in the indexed document
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForLongTermMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put(MEMORY_FIELD, "some memory text");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.LONG_TERM)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        sourceMap.put(MEMORY_FIELD, "old memory");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.LONG_TERM)).thenReturn("test-lt-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.cluster;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -129,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob();
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
@@ -142,7 +143,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
@@ -154,7 +155,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     private DiscoveryNode createDataNode(Version version) {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -120,6 +120,43 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexStatsCollectorJob(anyBoolean());
     }
 
+    public void testClusterChanged_MemoryRetentionJobStarted() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings())
+            .thenReturn(org.opensearch.common.settings.Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
     private DiscoveryNode createDataNode(Version version) {
         return new DiscoveryNode(
             "dataNode",

--- a/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
@@ -6,16 +6,22 @@
 package org.opensearch.ml.jobs;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -78,6 +84,22 @@ public class MLJobRunnerTests {
     public void testRunJobWithDisabledJob() {
         when(jobParameter.isEnabled()).thenReturn(false);
         when(jobParameter.getJobType()).thenReturn(MLJobType.STATS_COLLECTOR);
+        jobRunner.runJob(jobParameter, jobExecutionContext);
+    }
+
+    @Test
+    public void testRunJobWithMemoryRetentionType() {
+        MemoryRetentionJobProcessor.reset();
+        when(jobParameter.isEnabled()).thenReturn(true);
+        when(jobParameter.getJobType()).thenReturn(MLJobType.MEMORY_RETENTION);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        LockService lockService = mock(LockService.class);
+        when(jobExecutionContext.getLockService()).thenReturn(lockService);
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+
         jobRunner.runJob(jobParameter, jobExecutionContext);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -6,18 +6,57 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
+@RunWith(MockitoJUnitRunner.class)
 public class MemoryRetentionJobProcessorTests {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Mock
     private ClusterService clusterService;
@@ -28,12 +67,34 @@ public class MemoryRetentionJobProcessorTests {
     @Mock
     private Client client;
 
+    private ThreadContext threadContext;
+
     private MemoryRetentionJobProcessor processor;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         MemoryRetentionJobProcessor.reset();
+
+        // Default settings: multi-tenancy disabled, throttle = 1 second
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        // Use real ThreadContext (it's a final class and cannot be mocked)
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Mock threadPool.schedule to execute immediately
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(threadPool).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+
         processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
     }
 
@@ -51,25 +112,1236 @@ public class MemoryRetentionJobProcessorTests {
 
         processor.run();
 
-        // No exception thrown, method returns early with warning log
+        // Should not search for containers when multi-tenancy is enabled
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWhenMultiTenancyDisabled() {
-        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
-        when(clusterService.getSettings()).thenReturn(settings);
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
         processor.run();
 
-        // No exception thrown, logs "Memory retention job triggered"
+        // Verify container search is initiated
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWithDefaultSettings() {
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
         processor.run();
 
         // Default multi_tenancy_enabled is false, so job should execute
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNoContainersWithPolicy() {
+        // Container search returns empty hits -> job completes
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionTimeBased() {
+        // 1 container with retention_days=7, mock 3 expired sessions -> verify cascade + bulk delete
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-time",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns 3 expired sessions
+                SearchHit hit1 = new SearchHit(0, "expired-session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "expired-session-2", null, null);
+                SearchHit hit3 = new SearchHit(2, "expired-session-3", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2, hit3 },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory (Phase 2)
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(10L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete was called on working memory
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called on sessions
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionCountBased() {
+        // max_count=5, 10 sessions -> verify 5 oldest deleted
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-count",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", null, 5)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = sessionSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
+                    // First 5 are kept, last 5 are expired
+                    SearchHit[] hits = new SearchHit[10];
+                    for (int i = 0; i < 10; i++) {
+                        hits[i] = new SearchHit(i, "session-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) (10 - i), "session-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete + bulk delete both called
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testCascadeOrdering() {
+        // Verify delete_by_query (working memory) is called BEFORE bulk delete (sessions)
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-cascade",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns expired sessions
+                SearchHit hit1 = new SearchHit(0, "session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "session-2", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2 },
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track the ordering of operations
+        AtomicInteger orderCounter = new AtomicInteger(0);
+        AtomicInteger cascadeDeleteOrder = new AtomicInteger(-1);
+        AtomicInteger bulkDeleteOrder = new AtomicInteger(-1);
+
+        // Mock cascade delete-by-query for working memory (Phase 2)
+        BulkByScrollResponse workingDeleteResponse = mock(BulkByScrollResponse.class);
+        when(workingDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(workingDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            bulkDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Working memory delete (cascade) must happen BEFORE session delete (bulk)
+        assertTrue(
+            "Working memory cascade delete should execute before session bulk delete",
+            cascadeDeleteOrder.get() < bulkDeleteOrder.get()
+        );
+        assertTrue("Cascade delete should have been called", cascadeDeleteOrder.get() >= 0);
+        assertTrue("Bulk delete should have been called", bulkDeleteOrder.get() >= 0);
+    }
+
+    @Test
+    public void testPinnedSessionsExcluded() {
+        // Pinned sessions older than retention_days -> not deleted
+        // The processor's query uses mustNot(pinned=true), so we verify the query contains pinned filter
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-pinned",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Verify the query excludes pinned=true
+                String queryString = request.source().query().toString();
+                assertTrue("Query should exclude pinned documents (must_not pinned:true)", queryString.contains("pinned"));
+
+                // Return empty result - all sessions are pinned and excluded
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify session search was made (with pinned exclusion)
+        verify(client, atLeast(2)).search(any(SearchRequest.class), isA(ActionListener.class));
+        // No deletions should occur since all sessions are pinned (excluded by query)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testBatching() {
+        // 600 expired sessions -> verify 2 delete_by_query calls (500 + 100) for working memory cascade
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-batch",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionPageCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Return 600 expired sessions across 6 full pages of 100, then an empty page
+                int pageNum = sessionPageCount.getAndIncrement();
+                if (pageNum < 6) {
+                    // Full page of 100 hits (triggers pagination)
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        int globalIdx = pageNum * 100 + i;
+                        hits[i] = new SearchHit(globalIdx, "session-" + globalIdx, null, null);
+                        hits[i].sortValues(new Object[] { "session-" + globalIdx }, new DocValueFormat[] { DocValueFormat.RAW });
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    // Final page: empty (terminates pagination)
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track cascade delete calls
+        AtomicInteger cascadeDeleteCount = new AtomicInteger(0);
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(100L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // With 600 sessions and DELETE_BY_QUERY_BATCH_SIZE=500, expect 2 cascade delete calls
+        assertTrue("Should have at least 2 cascade delete-by-query calls for 600 sessions (batch size 500)", cascadeDeleteCount.get() >= 2);
+    }
+
+    @Test
+    public void testEmptyExpiredSet() {
+        // No sessions match retention criteria -> phases 2-3 skipped
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-empty",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions found
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify no cascade delete or bulk delete was called
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerProcessingError() {
+        // One container fails -> next container still processed
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-fail", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-fail" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-success", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-success" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        // Less than page size (100) so no pagination
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                int count = sessionSearchCount.getAndIncrement();
+                if (count == 0) {
+                    // First container's session search fails
+                    listener.onFailure(new RuntimeException("Simulated search failure"));
+                } else {
+                    // Second container's session search succeeds with empty results
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify that we searched at least twice (once for each container's sessions)
+        assertTrue("Both containers should be processed, second container search made", sessionSearchCount.get() >= 2);
+    }
+
+    @Test
+    public void testNullSessionIndex() {
+        // Container with disableSession=true -> session retention skipped, but working memory TTL fires (Phase 6)
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-session", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for Phase 6 working memory TTL (disableSession=true triggers it)
+        BulkByScrollResponse ttlResponse = mock(BulkByScrollResponse.class);
+        when(ttlResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Session retention is skipped (session index is null), but Phase 6 working memory TTL fires
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // No bulk deletes (no sessions to delete, no count-based eviction)
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testMultipleContainersProcessed() {
+        // 2 containers -> both processed sequentially
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":30}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-1", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-2", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                sessionSearchCount.incrementAndGet();
+                // Return 1 expired session for each container
+                SearchHit expiredHit = new SearchHit(0, "expired-session-" + sessionSearchCount.get(), null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { expiredHit },
+                    new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both containers should have been processed: at least 2 session searches
+        assertTrue("Both containers should be processed with session searches", sessionSearchCount.get() >= 2);
+        // Verify cascade delete was called for both containers
+        verify(client, atLeast(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called for both containers
+        verify(client, atLeast(2)).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 4: Long-Term Retention Tests ---
+
+    @Test
+    public void testLongTermRetentionDays() {
+        // Container with LTM policy retention_days=30 -> verify _delete_by_query on long-term index
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-days", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions (no session retention rule)
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for long-term retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            // Verify the query targets long-term index and uses last_updated_time
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Should use last_updated_time for long-term", queryString.contains("last_updated_time"));
+            assertTrue("Should exclude pinned docs", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermMaxCount() {
+        // Container with LTM policy max_count=100, 150 docs -> verify search for oldest 50 IDs + bulk delete
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=150
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(150, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 50 IDs: return 50 hits
+                    SearchHit[] hits = new SearchHit[50];
+                    for (int i = 0; i < 50; i++) {
+                        hits[i] = new SearchHit(i, "ltm-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(50, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify bulk delete called for the 50 excess docs
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermPinnedExclusion() {
+        // Verify mustNot(pinned=true) in long-term retention_days delete query
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-pinned", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Capture the DeleteByQueryRequest to verify pinned exclusion
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Long-term delete query should exclude pinned=true", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNullLtmIndex() {
+        // Container without LLM/strategies -> getIndexName(LONG_TERM) returns null -> LTM phase skipped
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-llm", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query or bulk delete should fire (LTM phase skipped due to null index)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermBothRetentionDaysAndMaxCount() {
+        // Both retention_days AND max_count set -> verify both operations fire sequentially
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30,\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-both", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query for max_count: return 120
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(120, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 20 IDs
+                    SearchHit[] hits = new SearchHit[20];
+                    for (int i = 0; i < 20; i++) {
+                        hits[i] = new SearchHit(i, "ltm-excess-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-excess-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(20, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(3L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for max_count
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both operations should have fired
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 5: History Retention Tests ---
+
+    @Test
+    public void testHistoryMaxCount() {
+        // Container with history policy max_count=500, 600 docs -> verify search sorted by created_time ASC
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=600
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 100 IDs — verify sort field is created_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History search should sort by created_time", sourceStr.contains("created_time"));
+
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        hits[i] = new SearchHit(i, "history-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "history-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(100, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testHistoryUsesCreatedTime() {
+        // Verify the sort field in history search is created_time, not last_updated_time
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":10}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-time", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+        AtomicInteger verifiedCreatedTime = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return 15 docs (exceeds max_count=10)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Verify sort uses created_time, NOT last_updated_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History must use created_time for sorting", sourceStr.contains("created_time"));
+                    assertTrue("History must NOT use last_updated_time", !sourceStr.contains("last_updated_time"));
+                    verifiedCreatedTime.incrementAndGet();
+
+                    SearchHit[] hits = new SearchHit[5];
+                    for (int i = 0; i < 5; i++) {
+                        hits[i] = new SearchHit(i, "hist-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "hist-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Should have verified created_time sort field", verifiedCreatedTime.get() > 0);
+    }
+
+    // --- Phase 6: Working Memory TTL Tests ---
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionTrue() {
+        // Container with disableSession=true -> verify _delete_by_query on working index with created_time range
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-enabled", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for working memory TTL
+        BulkByScrollResponse ttlDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ttlDeleteResponse.getDeleted()).thenReturn(8L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Working memory TTL should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Working memory TTL should use created_time", queryString.contains("created_time"));
+            // Working memory does NOT support pinning, so no pinned filter
+            assertTrue("Working memory TTL should NOT exclude pinned (no pinning support)", !queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionFalse() {
+        // Container with disableSession=false -> Phase 6 skipped entirely
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":false,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-skipped", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns no expired sessions
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query should be called (session expired=0, and working memory TTL is skipped)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- All phases chain test ---
+
+    @Test
+    public void testAllPhasesChainCorrectly() {
+        // Container with session, long-term, and history policies -> verify all three phases run
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{"
+            + "\"sessions\":{\"retention_days\":7},"
+            + "\"long-term\":{\"retention_days\":30},"
+            + "\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-all-phases", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // For count queries return 0 (under threshold), for other searches return empty
+                SearchResponse countResp = mock(SearchResponse.class);
+                SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                when(countResp.getHits()).thenReturn(countHits);
+                listener.onResponse(countResp);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query — should be called for session phase and long-term retention_days
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Long-term retention_days should trigger a delete_by_query
+        assertTrue("At least one delete_by_query should have been called for long-term retention_days", deleteByQueryCount.get() >= 1);
+    }
+
+    // --- Helper methods ---
+
+    private SearchResponse createContainerSearchResponseFromJson(String containerId, String sourceJson) {
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        SearchHit hit = new SearchHit(0, containerId, null, null);
+        hit.sourceRef(new BytesArray(sourceJson));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(searchResponse.getHits()).thenReturn(hits);
+        return searchResponse;
+    }
+
+    private SearchResponse createContainerSearchResponse(
+        String containerId,
+        String indexPrefix,
+        boolean useSystemIndex,
+        Map<String, Object> retentionPolicy
+    ) {
+        // Build the JSON source for the container hit
+        StringBuilder retentionJson = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : retentionPolicy.entrySet()) {
+            if (!first)
+                retentionJson.append(",");
+            first = false;
+            @SuppressWarnings("unchecked")
+            Map<String, Object> rule = (Map<String, Object>) entry.getValue();
+            retentionJson.append("\"").append(entry.getKey()).append("\":{");
+            boolean ruleFirst = true;
+            if (rule.containsKey("retention_days")) {
+                retentionJson.append("\"retention_days\":").append(rule.get("retention_days"));
+                ruleFirst = false;
+            }
+            if (rule.containsKey("max_count")) {
+                if (!ruleFirst)
+                    retentionJson.append(",");
+                retentionJson.append("\"max_count\":").append(rule.get("max_count"));
+            }
+            retentionJson.append("}");
+        }
+        retentionJson.append("}");
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\""
+            + indexPrefix
+            + "\","
+            + "\"use_system_index\":"
+            + useSystemIndex
+            + ","
+            + "\"retention_policy\":"
+            + retentionJson.toString()
+            + "}}";
+
+        return createContainerSearchResponseFromJson(containerId, sourceJson);
+    }
+
+    private Map<String, Object> createRetentionPolicyMap(String memoryType, Integer retentionDays, Integer maxCount) {
+        Map<String, Object> retentionPolicy = new HashMap<>();
+        Map<String, Object> rule = new HashMap<>();
+        if (retentionDays != null) {
+            rule.put("retention_days", retentionDays);
+        }
+        if (maxCount != null) {
+            rule.put("max_count", maxCount);
+        }
+        retentionPolicy.put(memoryType, rule);
+        return retentionPolicy;
+    }
+
+    private SearchResponse emptySearchResponse() {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(response.getHits()).thenReturn(hits);
+        return response;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+public class MemoryRetentionJobProcessorTests {
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    private MemoryRetentionJobProcessor processor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        MemoryRetentionJobProcessor.reset();
+        processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    @Test
+    public void testGetInstance() {
+        MemoryRetentionJobProcessor instance1 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        MemoryRetentionJobProcessor instance2 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testRunSkipsWhenMultiTenancyEnabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, method returns early with warning log
+    }
+
+    @Test
+    public void testRunExecutesWhenMultiTenancyDisabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, logs "Memory retention job triggered"
+    }
+
+    @Test
+    public void testRunExecutesWithDefaultSettings() {
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        processor.run();
+
+        // Default multi_tenancy_enabled is false, so job should execute
+    }
+}


### PR DESCRIPTION
### Description

  This PR wires the memory-retention **API surface** and the **retention background job** on top of the data model already merged into `feature/memory-retention-lifecycle` (#4860 data model, #4862 pinned field).

  It is the first of two stacked PRs completing the memory retention lifecycle feature (RFC #4859). It contains no default-application or opt-out policy logic — that lands in the follow-up PR (defaults + hardening), which is stacked on this branch.

  **API wiring**
  - Threads `retention_policy` through the Create/Update MemoryContainer transport actions, with input validation.
  - Adds the `pinned` field to the Create/Update Memory (AddMemories/UpdateMemory) paths, with validation.

  **Retention job**
  - Adds memory-retention job infrastructure: a new `MLJobType`, registration wired through `MachineLearningPlugin`, `MLCommonsClusterEventListener`, `MLJobRunner`, and `MLTaskManager`, driven by a configurable interval setting (production default 24h).
  - Implements `MemoryRetentionJobProcessor` covering session eviction, long-term / history cleanup, and working-memory TTL.
  - Bumps the version guard from `VERSION_3_7_0` to `VERSION_3_8_0` for the new fields/behavior.

  **Included regression fix**
  - `SearchModelGroupTransportAction`: corrects the empty-indices default. The retention job persists a job document that otherwise pollutes unscoped model-group search (`SearchModelGroupITTests` expected 1 but got 2). This fix is required by the job
  introduced here and must ship in this PR.

  ### Related Issues
  RFC #4859

  ### Check List
  - [x] New functionality includes unit tests.
  - [x] `./gradlew spotlessCheck` passes.
  - [x] `./gradlew build -x spotlessJava -x integTest` passes on Java 21.
  - [x] `./gradlew integTest` passes on Java 21.
  - [x] Commits are signed per the DCO using `--signoff`.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)