### PR TITLE
Add default retention policies, opt-out, and hardening

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -685,7 +685,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                         ? incoming.getRetentionDays()
                         : existing.getRetentionDays();
                     Integer mergedCount = incoming.isMaxCountExplicitlySet() ? incoming.getMaxCount() : existing.getMaxCount();
-                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                    // Carry the explicit-set flags through the merge so toXContent() emits
+                    // explicit nulls for cleared fields and the partial-update doc merge
+                    // removes them from storage
+                    boolean mergedDaysExplicitlySet = incoming.isRetentionDaysExplicitlySet() || existing.isRetentionDaysExplicitlySet();
+                    boolean mergedCountExplicitlySet = incoming.isMaxCountExplicitlySet() || existing.isMaxCountExplicitlySet();
+                    this.retentionPolicy
+                        .put(type, new RetentionRule(mergedDays, mergedCount, mergedDaysExplicitlySet, mergedCountExplicitlySet));
                 }
             }
         }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -82,7 +82,12 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
     private boolean useSystemIndex;
     private String tenantId;
     private Map<MemoryType, RetentionRule> retentionPolicy;
-    private transient boolean retentionPolicyExplicitlyNull = false;
+    /**
+     * True when the user explicitly set "retention_policy": null (opt-out of retention).
+     * Persisted as an explicit null field in toXContent() so the opt-out round-trips through
+     * the container index and survives partial-update merges; distinct from field absence.
+     */
+    private boolean retentionPolicyExplicitlyNull = false;
 
     @Builder
     public MemoryConfiguration(
@@ -186,6 +191,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 }
             }
         }
+        if (input.getVersion().onOrAfter(VERSION_3_8_0)) {
+            this.retentionPolicyExplicitlyNull = input.readBoolean();
+        }
     }
 
     @Override
@@ -229,6 +237,9 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             } else {
                 out.writeBoolean(false);
             }
+        }
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
+            out.writeBoolean(retentionPolicyExplicitlyNull);
         }
     }
 
@@ -287,6 +298,11 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 entry.getValue().toXContent(builder, params);
             }
             builder.endObject();
+        } else if (retentionPolicyExplicitlyNull) {
+            // Persist the explicit opt-out as "retention_policy": null so it (a) round-trips
+            // through the container index (parse() maps VALUE_NULL back to this flag) and
+            // (b) removes any previously stored policy during partial-update merges.
+            builder.nullField(RETENTION_POLICY_FIELD);
         }
         builder.endObject();
         return builder;
@@ -644,7 +660,13 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
         // Merge retention policy with field-level semantics within each type
         if (updateContent.isRetentionPolicyExplicitlyNull()) {
             this.retentionPolicy = null;
+            // Propagate the opt-out so toXContent() persists "retention_policy": null,
+            // which removes the stored policy during the partial-update merge and lets
+            // the retention job distinguish opt-out from "never configured"
+            this.retentionPolicyExplicitlyNull = true;
         } else if (updateContent.getRetentionPolicy() != null) {
+            // Providing a concrete policy opts back in
+            this.retentionPolicyExplicitlyNull = false;
             validateRetentionPolicy(updateContent.getRetentionPolicy());
             if (this.retentionPolicy == null) {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryConfiguration.java
@@ -641,7 +641,7 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
             // Only update dimension for TEXT_EMBEDDING if provided
             this.dimension = updateContent.getDimension();
         }
-        // Merge retention policy
+        // Merge retention policy with field-level semantics within each type
         if (updateContent.isRetentionPolicyExplicitlyNull()) {
             this.retentionPolicy = null;
         } else if (updateContent.getRetentionPolicy() != null) {
@@ -650,7 +650,21 @@ public class MemoryConfiguration implements ToXContentObject, Writeable {
                 this.retentionPolicy = new EnumMap<>(MemoryType.class);
             }
             for (Map.Entry<MemoryType, RetentionRule> entry : updateContent.getRetentionPolicy().entrySet()) {
-                this.retentionPolicy.put(entry.getKey(), entry.getValue());
+                MemoryType type = entry.getKey();
+                RetentionRule incoming = entry.getValue();
+                RetentionRule existing = this.retentionPolicy.get(type);
+
+                if (existing == null) {
+                    // No existing rule for this type: use incoming as-is
+                    this.retentionPolicy.put(type, incoming);
+                } else {
+                    // Field-level merge: only override fields that were explicitly set in the request
+                    Integer mergedDays = incoming.isRetentionDaysExplicitlySet()
+                        ? incoming.getRetentionDays()
+                        : existing.getRetentionDays();
+                    Integer mergedCount = incoming.isMaxCountExplicitlySet() ? incoming.getMaxCount() : existing.getMaxCount();
+                    this.retentionPolicy.put(type, new RetentionRule(mergedDays, mergedCount));
+                }
             }
         }
         // Note: indexPrefix and other structural fields are intentionally not updated

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -30,8 +30,26 @@ public class RetentionRule implements ToXContentObject, Writeable {
     private final Integer retentionDays;
     private final Integer maxCount;
 
+    /**
+     * Transient parse-time metadata: true when retention_days was explicitly present in the
+     * parsed JSON (even if value was null, meaning "remove it"). Not serialized.
+     */
+    @EqualsAndHashCode.Exclude
+    private final transient boolean retentionDaysExplicitlySet;
+
+    /**
+     * Transient parse-time metadata: true when max_count was explicitly present in the
+     * parsed JSON (even if value was null, meaning "remove it"). Not serialized.
+     */
+    @EqualsAndHashCode.Exclude
+    private final transient boolean maxCountExplicitlySet;
+
     @Builder
     public RetentionRule(Integer retentionDays, Integer maxCount) {
+        this(retentionDays, maxCount, false, false);
+    }
+
+    public RetentionRule(Integer retentionDays, Integer maxCount, boolean retentionDaysExplicitlySet, boolean maxCountExplicitlySet) {
         if (retentionDays != null && retentionDays <= 0) {
             throw new IllegalArgumentException("retention_days must be a positive integer or null");
         }
@@ -40,11 +58,15 @@ public class RetentionRule implements ToXContentObject, Writeable {
         }
         this.retentionDays = retentionDays;
         this.maxCount = maxCount;
+        this.retentionDaysExplicitlySet = retentionDaysExplicitlySet;
+        this.maxCountExplicitlySet = maxCountExplicitlySet;
     }
 
     public RetentionRule(StreamInput in) throws IOException {
         this.retentionDays = in.readOptionalInt();
         this.maxCount = in.readOptionalInt();
+        this.retentionDaysExplicitlySet = false;
+        this.maxCountExplicitlySet = false;
     }
 
     @Override
@@ -69,6 +91,8 @@ public class RetentionRule implements ToXContentObject, Writeable {
     public static RetentionRule parse(XContentParser parser) throws IOException {
         Integer retentionDays = null;
         Integer maxCount = null;
+        boolean retentionDaysExplicitlySet = false;
+        boolean maxCountExplicitlySet = false;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -77,6 +101,7 @@ public class RetentionRule implements ToXContentObject, Writeable {
 
             switch (fieldName) {
                 case RETENTION_DAYS_FIELD:
+                    retentionDaysExplicitlySet = true;
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         retentionDays = null;
                     } else {
@@ -84,6 +109,7 @@ public class RetentionRule implements ToXContentObject, Writeable {
                     }
                     break;
                 case MAX_COUNT_FIELD:
+                    maxCountExplicitlySet = true;
                     if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                         maxCount = null;
                     } else {
@@ -96,6 +122,6 @@ public class RetentionRule implements ToXContentObject, Writeable {
             }
         }
 
-        return new RetentionRule(retentionDays, maxCount);
+        return new RetentionRule(retentionDays, maxCount, retentionDaysExplicitlySet, maxCountExplicitlySet);
     }
 }

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/RetentionRule.java
@@ -80,9 +80,14 @@ public class RetentionRule implements ToXContentObject, Writeable {
         builder.startObject();
         if (retentionDays != null) {
             builder.field(RETENTION_DAYS_FIELD, retentionDays);
+        } else if (retentionDaysExplicitlySet) {
+            // Persist the explicit null so the partial-update doc merge removes the stored value
+            builder.nullField(RETENTION_DAYS_FIELD);
         }
         if (maxCount != null) {
             builder.field(MAX_COUNT_FIELD, maxCount);
+        } else if (maxCountExplicitlySet) {
+            builder.nullField(MAX_COUNT_FIELD);
         }
         builder.endObject();
         return builder;

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -584,6 +584,40 @@ public final class MLCommonsSettings {
     public static final String ML_COMMONS_AG_UI_DISABLED_MESSAGE =
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
+    // Memory retention job settings
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
+            24,
+            1,
+            168,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_throttle_seconds",
+            5,
+            1,
+            60,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS = Setting
+        .intSetting(ML_PLUGIN_SETTING_PREFIX + "memory.orphan_ttl_days", 7, 1, 365, Setting.Property.NodeScope, Setting.Property.Dynamic);
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.working_memory_ttl_days",
+            30,
+            1,
+            365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     private static void validateRegexSafety(String regex) {
         // Reject nested quantifiers or backreferences
         if (regex.matches(".*\\([^)]*[*+?]\\)[*+?{].*") || regex.matches(".*\\\\[1-9].*")) {

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -588,7 +588,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            2, // DEMO: default 2 minutes (was 24 hours)
+            24,
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -585,6 +585,14 @@ public final class MLCommonsSettings {
         "The AG-UI agent feature is not enabled. To enable, please update the setting " + ML_COMMONS_AG_UI_ENABLED.getKey();
 
     // Memory retention job settings
+    public static final Setting<Boolean> ML_COMMONS_MEMORY_RETENTION_ENABLED = Setting
+        .boolSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled",
+            true,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
@@ -614,6 +622,46 @@ public final class MLCommonsSettings {
             30,
             1,
             365,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_session_retention_days",
+            90,
+            1,
+            3650,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_session_max_count",
+            5000,
+            1,
+            1000000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_long_term_max_count",
+            2000,
+            1,
+            1000000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT = Setting
+        .intSetting(
+            ML_PLUGIN_SETTING_PREFIX + "memory.default_history_max_count",
+            100000,
+            1,
+            10000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -588,7 +588,7 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.retention_job_interval_hours",
-            24,
+            2, // DEMO: default 2 minutes (was 24 hours)
             1,
             168,
             Setting.Property.NodeScope,

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -586,12 +586,7 @@ public final class MLCommonsSettings {
 
     // Memory retention job settings
     public static final Setting<Boolean> ML_COMMONS_MEMORY_RETENTION_ENABLED = Setting
-        .boolSetting(
-            ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled",
-            true,
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-        );
+        .boolSetting(ML_PLUGIN_SETTING_PREFIX + "memory.retention_enabled", true, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     public static final Setting<Integer> ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS = Setting
         .intSetting(
@@ -629,8 +624,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_session_retention_days",
-            90,
-            1,
+            -1,
+            -1,
             3650,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -639,8 +634,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_session_max_count",
-            5000,
-            1,
+            -1,
+            -1,
             1000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -649,8 +644,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_long_term_max_count",
-            2000,
-            1,
+            -1,
+            -1,
             1000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
@@ -659,8 +654,8 @@ public final class MLCommonsSettings {
     public static final Setting<Integer> ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT = Setting
         .intSetting(
             ML_PLUGIN_SETTING_PREFIX + "memory.default_history_max_count",
-            100000,
-            1,
+            -1,
+            -1,
             10000000,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,6 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -22,6 +23,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETERS_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PAYLOAD_TYPE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -73,6 +76,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
     private Map<String, Object> parameters;
     private String ownerId;
 
+    // Pinned field (only valid for session/long-term/history, rejected for working memory)
+    private Boolean pinned;
+
     // Checkpoint field
     private String checkpointId;
     private String tenantId;
@@ -91,6 +97,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags,
         Map<String, Object> parameters,
         String ownerId,
+        Boolean pinned,
         String checkpointId,
         String tenantId
     ) {
@@ -112,6 +119,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters.putAll(parameters);
         }
         this.ownerId = ownerId;
+        this.pinned = pinned;
         this.checkpointId = checkpointId;
         this.tenantId = tenantId;
         validate();
@@ -161,6 +169,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
+        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+            this.pinned = in.readOptionalBoolean();
+        }
         this.checkpointId = in.readOptionalString();
         this.tenantId = in.readOptionalString();
     }
@@ -218,6 +229,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
+        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+            out.writeOptionalBoolean(pinned);
+        }
         out.writeOptionalString(checkpointId);
         out.writeOptionalString(tenantId);
     }
@@ -297,6 +311,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
         Map<String, String> tags = null;
         Map<String, Object> parameters = null;
         String ownerId = null;
+        Boolean pinned = null;
         String checkpointId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -348,6 +363,9 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
                 case OWNER_ID_FIELD:
                     ownerId = parser.text();
                     break;
+                case PINNED_FIELD:
+                    pinned = parser.booleanValue();
+                    break;
                 case CHECKPOINT_ID_FIELD:
                     checkpointId = parser.text();
                     break;
@@ -375,6 +393,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             .tags(tags)
             .parameters(parameters)
             .ownerId(ownerId)
+            .pinned(pinned)
             .checkpointId(checkpointId)
             .tenantId(tenantId)
             .build();

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInput.java
@@ -7,7 +7,7 @@ package org.opensearch.ml.common.transport.memorycontainer.memory;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.ml.common.CommonValue.TENANT_ID_FIELD;
-import static org.opensearch.ml.common.CommonValue.VERSION_3_7_0;
+import static org.opensearch.ml.common.CommonValue.VERSION_3_8_0;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.BINARY_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CHECKPOINT_ID_FIELD;
@@ -168,7 +168,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             this.parameters = in.readMap();
         }
         this.ownerId = in.readOptionalString();
-        if (in.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (in.getVersion().onOrAfter(VERSION_3_8_0)) {
             this.pinned = in.readOptionalBoolean();
         }
         this.checkpointId = in.readOptionalString();
@@ -228,7 +228,7 @@ public class MLAddMemoriesInput implements ToXContentObject, Writeable {
             out.writeBoolean(false);
         }
         out.writeOptionalString(ownerId);
-        if (out.getVersion().onOrAfter(VERSION_3_7_0)) {
+        if (out.getVersion().onOrAfter(VERSION_3_8_0)) {
             out.writeOptionalBoolean(pinned);
         }
         out.writeOptionalString(checkpointId);

--- a/common/src/main/resources/index-mappings/ml_memory_working.json
+++ b/common/src/main/resources/index-mappings/ml_memory_working.json
@@ -1,9 +1,12 @@
 {
   "_meta": {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "owner_id": {
+      "type": "keyword"
+    },
+    "session_id": {
       "type": "keyword"
     },
     "memory_container_id": {

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1415,6 +1415,96 @@ public class MemoryConfigurationTests {
     }
 
     @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullFieldRemovalPersists() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // Simulate parsing an update that explicitly clears max_count
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"max_count\":null}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        // Merged rule: retention_days preserved, max_count cleared with the explicit-set flag carried through
+        RetentionRule mergedRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertEquals(Integer.valueOf(30), mergedRule.getRetentionDays());
+        assertNull(mergedRule.getMaxCount());
+        assertTrue(mergedRule.isMaxCountExplicitlySet());
+
+        // Serialized update doc must emit the explicit null so the partial-update merge removes it
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null max_count in: " + serialized, serialized.contains("\"max_count\":null"));
+        assertTrue("expected retention_days preserved in: " + serialized, serialized.contains("\"retention_days\":30"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_ExplicitNullRetentionDaysPersists() throws Exception {
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"retention_days\":null}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        RetentionRule mergedRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
+        assertNull(mergedRule.getRetentionDays());
+        assertEquals(Integer.valueOf(100), mergedRule.getMaxCount());
+        assertTrue(mergedRule.isRetentionDaysExplicitlySet());
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null retention_days in: " + serialized, serialized.contains("\"retention_days\":null"));
+        assertTrue("expected max_count preserved in: " + serialized, serialized.contains("\"max_count\":100"));
+    }
+
+    @Test
+    public void testUpdate_RetentionPolicy_AbsentFieldsOmittedAfterMerge() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+
+        // Update introduces a rule that only mentions max_count; retention_days was never mentioned
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":{\"sessions\":{\"max_count\":200}}}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected max_count in: " + serialized, serialized.contains("\"max_count\":200"));
+        assertFalse("never-mentioned retention_days must be omitted in: " + serialized, serialized.contains("retention_days"));
+    }
+
+    @Test
     public void testRetentionPolicyExplicitNull_RoundTripsThroughXContent() throws Exception {
         // Parse a config with explicit "retention_policy": null (opt-out)
         String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1413,4 +1413,112 @@ public class MemoryConfigurationTests {
         assertNotNull(config.getRetentionPolicy());
         assertEquals(1, config.getRetentionPolicy().size());
     }
+
+    @Test
+    public void testRetentionPolicyExplicitNull_RoundTripsThroughXContent() throws Exception {
+        // Parse a config with explicit "retention_policy": null (opt-out)
+        String json = "{\"index_prefix\":\"test\",\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration config = MemoryConfiguration.parse(parser);
+        assertTrue(config.isRetentionPolicyExplicitlyNull());
+
+        // Serialize: the opt-out marker must be written as an explicit null field
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertTrue("expected explicit null marker in: " + serialized, serialized.contains("\"retention_policy\":null"));
+
+        // Parse back (simulates reading the container document from the index)
+        org.opensearch.core.xcontent.XContentParser reparser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                serialized
+            );
+        reparser.nextToken();
+        MemoryConfiguration roundTripped = MemoryConfiguration.parse(reparser);
+
+        // Opt-out must survive the round trip so the retention job skips backfill
+        assertTrue(roundTripped.isRetentionPolicyExplicitlyNull());
+        assertNull(roundTripped.getRetentionPolicy());
+    }
+
+    @Test
+    public void testToXContent_NoRetentionPolicy_OmitsField() throws Exception {
+        // "Never had a policy" must remain field-absence (no null marker)
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        String serialized = builder.toString();
+        assertFalse("retention_policy should be absent in: " + serialized, serialized.contains("retention_policy"));
+    }
+
+    @Test
+    public void testUpdate_ExplicitNull_PropagatesOptOutFlagForPersistence() throws Exception {
+        // Existing stored config with a policy
+        Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
+
+        // PUT with "retention_policy": null
+        String json = "{\"retention_policy\":null}";
+        org.opensearch.core.xcontent.XContentParser parser = org.opensearch.common.xcontent.XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            );
+        parser.nextToken();
+        MemoryConfiguration updateContent = MemoryConfiguration.parse(parser);
+
+        config.update(updateContent);
+
+        // Merged config must carry the opt-out so serialization writes the null marker,
+        // which removes the old policy during the partial-update doc merge
+        assertNull(config.getRetentionPolicy());
+        assertTrue(config.isRetentionPolicyExplicitlyNull());
+
+        org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+        config.toXContent(builder, org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS);
+        assertTrue(builder.toString().contains("\"retention_policy\":null"));
+    }
+
+    @Test
+    public void testUpdate_NewPolicyClearsOptOutFlag() throws Exception {
+        // Config previously opted out
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        config.setRetentionPolicyExplicitlyNull(true);
+
+        // PUT with a concrete policy opts back in
+        Map<MemoryType, RetentionRule> newPolicy = new java.util.EnumMap<>(MemoryType.class);
+        newPolicy.put(MemoryType.SESSIONS, new RetentionRule(7, 50));
+        MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(newPolicy).build();
+
+        config.update(updateContent);
+
+        assertFalse(config.isRetentionPolicyExplicitlyNull());
+        assertNotNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testRetentionPolicyExplicitNull_RoundTripsThroughStream() throws Exception {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").build();
+        config.setRetentionPolicyExplicitlyNull(true);
+
+        org.opensearch.common.io.stream.BytesStreamOutput out = new org.opensearch.common.io.stream.BytesStreamOutput();
+        config.writeTo(out);
+        MemoryConfiguration deserialized = new MemoryConfiguration(out.bytes().streamInput());
+
+        assertTrue(deserialized.isRetentionPolicyExplicitlyNull());
+        assertNull(deserialized.getRetentionPolicy());
+    }
 }

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/MemoryConfigurationTests.java
@@ -1252,23 +1252,24 @@ public class MemoryConfigurationTests {
     }
 
     @Test
-    public void testUpdate_RetentionPolicy_TypeLevelReplacement() {
+    public void testUpdate_RetentionPolicy_FieldLevelMerge() {
         Map<MemoryType, RetentionRule> existingPolicy = new java.util.EnumMap<>(MemoryType.class);
         existingPolicy.put(MemoryType.SESSIONS, new RetentionRule(30, 100));
         existingPolicy.put(MemoryType.LONG_TERM, new RetentionRule(90, 500));
 
         MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").retentionPolicy(existingPolicy).build();
 
-        // Update sessions with only max_count — full replacement at type level
+        // Update sessions with only max_count — field-level merge preserves existing retention_days
+        // Use 4-arg constructor to simulate JSON parse: max_count explicitly set, retention_days absent
         Map<MemoryType, RetentionRule> updatePolicy = new java.util.EnumMap<>(MemoryType.class);
-        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200));
+        updatePolicy.put(MemoryType.SESSIONS, new RetentionRule(null, 200, false, true));
 
         MemoryConfiguration updateContent = MemoryConfiguration.builder().retentionPolicy(updatePolicy).build();
         config.update(updateContent);
 
-        // Sessions: fully replaced — retentionDays is now null (not preserved)
+        // Sessions: field-level merge — retention_days preserved (not explicitly set in update), max_count updated
         RetentionRule sessionsRule = config.getRetentionPolicy().get(MemoryType.SESSIONS);
-        assertNull(sessionsRule.getRetentionDays());
+        assertEquals(Integer.valueOf(30), sessionsRule.getRetentionDays());
         assertEquals(Integer.valueOf(200), sessionsRule.getMaxCount());
 
         // Long-term: untouched (type not in update)

--- a/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/memorycontainer/RetentionRuleTests.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -144,6 +145,61 @@ public class RetentionRuleTests {
         RetentionRule parsed = RetentionRule.parse(parser);
 
         assertEquals(original, parsed);
+    }
+
+    @Test
+    public void testToXContent_ExplicitNullMaxCountEmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(30, null, false, true);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":30,\"max_count\":null}", json);
+    }
+
+    @Test
+    public void testToXContent_ExplicitNullRetentionDaysEmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(null, 100, true, false);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":null,\"max_count\":100}", json);
+    }
+
+    @Test
+    public void testToXContent_AbsentFieldsOmitted() throws IOException {
+        RetentionRule rule = new RetentionRule(null, null, false, false);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        rule.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{}", json);
+    }
+
+    @Test
+    public void testXContentRoundTrip_ExplicitNulls_PreservesFlags() throws IOException {
+        RetentionRule original = new RetentionRule(null, null, true, true);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        original.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = TestHelper.xContentBuilderToString(builder);
+
+        assertEquals("{\"retention_days\":null,\"max_count\":null}", json);
+
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        RetentionRule parsed = RetentionRule.parse(parser);
+
+        assertNull(parsed.getRetentionDays());
+        assertNull(parsed.getMaxCount());
+        assertTrue(parsed.isRetentionDaysExplicitlySet());
+        assertTrue(parsed.isMaxCountExplicitlySet());
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
@@ -20,7 +20,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.search.SearchModule;

--- a/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
@@ -20,6 +20,7 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.common.TestHelper;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.search.SearchModule;

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -862,4 +862,57 @@ public class MLAddMemoriesInputTest {
         assertEquals("new-checkpoint-id", input.getCheckpointId());
     }
 
+    @Test
+    public void testPinnedField() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        assertEquals(Boolean.TRUE, input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldNull() {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .build();
+
+        assertNull(input.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldStreamSerialization() throws IOException {
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(testMessages)
+            .pinned(true)
+            .build();
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        input.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLAddMemoriesInput deserialized = new MLAddMemoriesInput(in);
+        assertEquals(Boolean.TRUE, deserialized.getPinned());
+    }
+
+    @Test
+    public void testPinnedFieldParsing() throws IOException {
+        String json = "{\"memory_container_id\":\"container-123\",\"payload_type\":\"conversational\","
+            + "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}],"
+            + "\"pinned\":true}";
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        parser.nextToken();
+        MLAddMemoriesInput parsed = MLAddMemoriesInput.parse(parser, "container-123", null);
+        assertEquals(Boolean.TRUE, parsed.getPinned());
+    }
+
 }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/memory/MLAddMemoriesInputTest.java
@@ -876,11 +876,7 @@ public class MLAddMemoriesInputTest {
 
     @Test
     public void testPinnedFieldNull() {
-        MLAddMemoriesInput input = MLAddMemoriesInput
-            .builder()
-            .memoryContainerId("container-123")
-            .messages(testMessages)
-            .build();
+        MLAddMemoriesInput input = MLAddMemoriesInput.builder().memoryContainerId("container-123").messages(testMessages).build();
 
         assertNull(input.getPinned());
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -9,6 +9,9 @@ import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
 
 import java.time.Instant;
+import java.util.Map;
+
+import org.opensearch.common.logging.HeaderWarning;
 
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
@@ -24,6 +27,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
@@ -100,6 +105,9 @@ public class TransportCreateMemoryContainerAction extends
 
         // Validate configuration before creating memory container
         validateConfiguration(input.getConfiguration(), ActionListener.wrap(isValid -> {
+            // Emit warning if sessions retention is set on a container with disableSession=true
+            emitDisableSessionRetentionWarning(input.getConfiguration());
+
             // Check if memory container index exists, create if not
             ActionListener<Boolean> indexCheckListener = ActionListener.wrap(created -> {
                 try {
@@ -285,6 +293,20 @@ public class TransportCreateMemoryContainerAction extends
         } catch (Exception e) {
             log.error("Failed to save memory container", e);
             listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,7 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
-import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 
 import java.time.Instant;
 import java.util.EnumMap;
@@ -162,29 +161,37 @@ public class TransportCreateMemoryContainerAction extends
             }
         }
 
-        // Auto-apply default retention policy when retention is enabled and user did not provide one
+        // Auto-apply admin-configured default retention policy when user did not provide one
         if (configuration != null && !configuration.isRetentionPolicyExplicitlyNull()) {
             Map<MemoryType, RetentionRule> existingPolicy = configuration.getRetentionPolicy();
-            if ((existingPolicy == null || existingPolicy.isEmpty())
-                && ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
-                Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
-                defaultPolicy.put(
-                    MemoryType.SESSIONS,
-                    new RetentionRule(
-                        ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings()),
-                        ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings())
-                    )
-                );
-                defaultPolicy.put(
-                    MemoryType.LONG_TERM,
-                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings()))
-                );
-                defaultPolicy.put(
-                    MemoryType.HISTORY,
-                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings()))
-                );
-                configuration.setRetentionPolicy(defaultPolicy);
-                log.info("Auto-applied default retention policy to new container '{}'", input.getName());
+            if (existingPolicy == null || existingPolicy.isEmpty()) {
+                int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
+                int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
+                int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
+                int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
+
+                boolean anyConfigured = sessionRetentionDays > 0 || sessionMaxCount > 0 || longTermMaxCount > 0 || historyMaxCount > 0;
+                if (anyConfigured) {
+                    Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+                    if (sessionRetentionDays > 0 || sessionMaxCount > 0) {
+                        defaultPolicy
+                            .put(
+                                MemoryType.SESSIONS,
+                                new RetentionRule(
+                                    sessionRetentionDays > 0 ? sessionRetentionDays : null,
+                                    sessionMaxCount > 0 ? sessionMaxCount : null
+                                )
+                            );
+                    }
+                    if (longTermMaxCount > 0) {
+                        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+                    }
+                    if (historyMaxCount > 0) {
+                        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+                    }
+                    configuration.setRetentionPolicy(defaultPolicy);
+                    log.info("Auto-applied default retention policy to new container '{}'", input.getName());
+                }
             }
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -11,8 +11,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.time.Instant;
 import java.util.Map;
 
-import org.opensearch.common.logging.HeaderWarning;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexResponse;
@@ -20,6 +18,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerAction.java
@@ -7,8 +7,14 @@ package org.opensearch.ml.action.memorycontainer;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 
 import java.time.Instant;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
@@ -17,6 +23,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -63,6 +70,7 @@ public class TransportCreateMemoryContainerAction extends
     private final ConnectorAccessControlHelper connectorAccessControlHelper;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private final MLModelManager mlModelManager;
+    private final ClusterService clusterService;
 
     @Inject
     public TransportCreateMemoryContainerAction(
@@ -73,7 +81,8 @@ public class TransportCreateMemoryContainerAction extends
         MLIndicesHandler mlIndicesHandler,
         ConnectorAccessControlHelper connectorAccessControlHelper,
         MLFeatureEnabledSetting mlFeatureEnabledSetting,
-        MLModelManager mlModelManager
+        MLModelManager mlModelManager,
+        ClusterService clusterService
     ) {
         super(MLCreateMemoryContainerAction.NAME, transportService, actionFilters, MLCreateMemoryContainerRequest::new);
         this.client = client;
@@ -82,6 +91,7 @@ public class TransportCreateMemoryContainerAction extends
         this.connectorAccessControlHelper = connectorAccessControlHelper;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
         this.mlModelManager = mlModelManager;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -149,6 +159,32 @@ public class TransportCreateMemoryContainerAction extends
                 if (strategy.getEnabled() == null) {
                     strategy.setEnabled(true);
                 }
+            }
+        }
+
+        // Auto-apply default retention policy when retention is enabled and user did not provide one
+        if (configuration != null && !configuration.isRetentionPolicyExplicitlyNull()) {
+            Map<MemoryType, RetentionRule> existingPolicy = configuration.getRetentionPolicy();
+            if ((existingPolicy == null || existingPolicy.isEmpty())
+                && ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+                Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+                defaultPolicy.put(
+                    MemoryType.SESSIONS,
+                    new RetentionRule(
+                        ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings()),
+                        ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings())
+                    )
+                );
+                defaultPolicy.put(
+                    MemoryType.LONG_TERM,
+                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings()))
+                );
+                defaultPolicy.put(
+                    MemoryType.HISTORY,
+                    new RetentionRule(null, ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings()))
+                );
+                configuration.setRetentionPolicy(defaultPolicy);
+                log.info("Auto-applied default retention policy to new container '{}'", input.getName());
             }
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -32,6 +33,8 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLUpdateMemoryContainerAction;
@@ -186,6 +189,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
 
                     // No transition - proceed with normal update
                     updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, currentConfig);
+
+                    // Emit warning if sessions retention is set on a container with disableSession=true
+                    emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
                     actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -251,6 +257,20 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                         + "Create a new memory container if you need different embedding configuration."
                 );
             }
+        }
+    }
+
+    private void emitDisableSessionRetentionWarning(MemoryConfiguration config) {
+        if (config == null) {
+            return;
+        }
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (config.isDisableSession() && retentionPolicy != null && retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            HeaderWarning
+                .addWarning(
+                    "sessions retention_policy has no effect when disableSession=true;"
+                        + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.OpenSearchStatusException;
-import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.HeaderWarning;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -267,10 +267,15 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                         UpdateRequest updateRequest = new UpdateRequest(sessionIndex, sessionId)
                             .doc(Map.of(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli()))
                             .retryOnConflict(3);
-                        client.update(updateRequest, ActionListener.wrap(
-                            resp -> log.debug("Bumped session {} last_updated_time", sessionId),
-                            e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
-                        ));
+                        client
+                            .update(
+                                updateRequest,
+                                ActionListener
+                                    .wrap(
+                                        resp -> log.debug("Bumped session {} last_updated_time", sessionId),
+                                        e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
+                                    )
+                            );
                     }
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -34,8 +34,11 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -306,7 +309,16 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             // Add memory content from input object
             mlAddMemoriesInput.toXContent(builder, ToXContent.EMPTY_PARAMS, true);
 
-            indexRequest.source(builder);
+            // Denormalize session_id to a top-level keyword field (namespace is flat_object and
+            // cannot be aggregated) so the retention job can enumerate sessions efficiently
+            String sessionId = mlAddMemoriesInput.getSessionId();
+            if (sessionId != null) {
+                Map<String, Object> source = XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+                source.put(SESSION_ID_FIELD, sessionId);
+                indexRequest.source(source);
+            } else {
+                indexRequest.source(builder);
+            }
             indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             return indexRequest;
         } catch (IOException e) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -123,8 +123,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
-                        "pinned field is not supported for working memory type."
-                            + " To preserve a conversation, pin the session instead.",
+                        "pinned field is not supported for working memory type." + " To preserve a conversation, pin the session instead.",
                         RestStatus.BAD_REQUEST
                     )
                 );

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -118,6 +118,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             return;
         }
 
+        // Reject pinned field — add-memories creates working memory which cannot be pinned
+        if (input.getPinned() != null) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "pinned field is not supported for working memory type."
+                            + " To preserve a conversation, pin the session instead.",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            return;
+        }
+
         String memoryContainerId = input.getMemoryContainerId();
 
         if (StringUtils.isBlank(memoryContainerId)) {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -31,6 +31,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.commons.authuser.User;
@@ -189,15 +190,15 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                                     NAMESPACE_FIELD,
                                     input.getNamespace(),
                                     CREATED_TIME_FIELD,
-                                    now.getEpochSecond(),
+                                    now.toEpochMilli(),
                                     LAST_UPDATED_TIME_FIELD,
-                                    now.getEpochSecond()
+                                    now.toEpochMilli()
                                 )
                         );
                     indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     ActionListener<IndexResponse> responseActionListener = ActionListener.<IndexResponse>wrap(r -> {
                         input.getNamespace().put(SESSION_ID_FIELD, r.getId());
-                        processAndIndexMemory(input, container, user, actionListener);
+                        processAndIndexMemory(input, container, user, actionListener, true);
                     }, e -> {
                         log.error("Failed to index session data", e);
                         actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -219,7 +220,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
 
                 memoryProcessingService.summarizeMessages(tenantId, container.getConfiguration(), messages, summaryListener);
             } else {
-                processAndIndexMemory(input, container, user, actionListener);
+                processAndIndexMemory(input, container, user, actionListener, false);
             }
         } catch (Exception e) {
             log.error("Failed to create session", e);
@@ -231,7 +232,8 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
         MLAddMemoriesInput input,
         MLMemoryContainer container,
         User user,
-        ActionListener<MLAddMemoriesResponse> actionListener
+        ActionListener<MLAddMemoriesResponse> actionListener,
+        boolean newlyCreatedSession
     ) {
         try {
             boolean infer = input.isInfer();
@@ -256,6 +258,21 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                     .workingMemoryId(r.getId())
                     .build();
                 actionListener.onResponse(response);
+
+                // Bump last_updated_time on existing sessions
+                if (!newlyCreatedSession && !memoryConfig.isDisableSession()) {
+                    String sessionId = input.getSessionId();
+                    String sessionIndex = memoryConfig.getSessionIndexName();
+                    if (sessionId != null && sessionIndex != null) {
+                        UpdateRequest updateRequest = new UpdateRequest(sessionIndex, sessionId)
+                            .doc(Map.of(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli()))
+                            .retryOnConflict(3);
+                        client.update(updateRequest, ActionListener.wrap(
+                            resp -> log.debug("Bumped session {} last_updated_time", sessionId),
+                            e -> log.debug("Failed to bump session {} last_updated_time", sessionId, e)
+                        ));
+                    }
+                }
 
                 if (infer) {
                     threadPool.executor(AGENTIC_MEMORY_THREAD_POOL).execute(() -> {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MESSAGES_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.METADATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.OWNER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_BLOB_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.STRUCTURED_DATA_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SUMMARY_FIELD;
@@ -136,6 +137,20 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     return;
                 }
 
+                // Reject pinned field for working memory type
+                Map<String, Object> updateContent = updateRequest.getMlUpdateMemoryInput().getUpdateContent();
+                if (memoryType == MemoryType.WORKING && updateContent.containsKey(PINNED_FIELD)) {
+                    actionListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "pinned field is not supported for working memory type."
+                                    + " To preserve a conversation, pin the session instead.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    return;
+                }
+
                 // Prepare the update
                 Map<String, Object> newDoc = constructNewDoc(updateRequest.getMlUpdateMemoryInput(), memoryType, originalDoc);
                 IndexRequest indexRequest = new IndexRequest(memoryIndexName).id(memoryId).source(newDoc);
@@ -186,6 +201,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         if (updateContent.containsKey(ADDITIONAL_INFO_FIELD)) {
             updateFields.put(ADDITIONAL_INFO_FIELD, updateContent.get(ADDITIONAL_INFO_FIELD));
         }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
+        }
         return updateFields;
     }
 
@@ -217,6 +235,9 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
         }
         if (updateContent.containsKey(TAGS_FIELD)) {
             updateFields.put(TAGS_FIELD, updateContent.get(TAGS_FIELD));
+        }
+        if (updateContent.containsKey(PINNED_FIELD)) {
+            updateFields.put(PINNED_FIELD, updateContent.get(PINNED_FIELD));
         }
         return updateFields;
     }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryAction.java
@@ -184,8 +184,34 @@ public class TransportUpdateMemoryAction extends HandledTransportAction<ActionRe
                     break;
             }
         }
-        updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
+        if (shouldBumpLastUpdatedTime(memoryType, updateContent)) {
+            updateFields.put(LAST_UPDATED_TIME_FIELD, Instant.now().toEpochMilli());
+        }
         return updateFields;
+    }
+
+    /**
+     * Determines whether last_updated_time should be bumped based on the memory type
+     * and the fields being updated. Only content field changes trigger a timestamp bump.
+     * Non-content fields (tags, pinned, metadata, additional_info, agents) do not.
+     */
+    private boolean shouldBumpLastUpdatedTime(MemoryType memoryType, Map<String, Object> updateContent) {
+        if (memoryType == null) {
+            return false;
+        }
+        switch (memoryType) {
+            case SESSIONS:
+                return updateContent.containsKey(SUMMARY_FIELD);
+            case LONG_TERM:
+                return updateContent.containsKey(MEMORY_FIELD);
+            case WORKING:
+                return updateContent.containsKey(MESSAGES_FIELD)
+                    || updateContent.containsKey(BINARY_DATA_FIELD)
+                    || updateContent.containsKey(STRUCTURED_DATA_FIELD)
+                    || updateContent.containsKey(STRUCTURED_DATA_BLOB_FIELD);
+            default:
+                return false;
+        }
     }
 
     public Map<String, Object> constructSessionMemUpdateFields(Map<String, Object> updateFields, Map<String, Object> updateContent) {

--- a/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/model_group/SearchModelGroupTransportAction.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.action.model_group;
 
 import static org.opensearch.ml.action.handler.MLSearchHandler.wrapRestActionListener;
+import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MODEL_GROUP_RESOURCE_TYPE;
 import static org.opensearch.ml.helper.ModelAccessControlHelper.shouldUseResourceAuthz;
 import static org.opensearch.ml.utils.RestActionUtils.wrapListenerToHandleSearchIndexNotFound;
@@ -128,9 +129,13 @@ public class SearchModelGroupTransportAction extends HandledTransportAction<MLSe
     }
 
     private void search(String tenantId, SearchRequest request, ActionListener<SearchResponse> listener) {
+        String[] indices = request.indices();
+        if (indices == null || indices.length == 0) {
+            indices = new String[] { ML_MODEL_GROUP_INDEX };
+        }
         SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest
             .builder()
-            .indices(request.indices())
+            .indices(indices)
             .searchSourceBuilder(request.source())
             .tenantId(tenantId)
             .build();

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -105,7 +105,8 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
-                    mlTaskManager.indexMemoryRetentionJob();
+                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    mlTaskManager.indexMemoryRetentionJob(intervalHours);
                     this.startedMemoryRetentionJob = true;
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -40,6 +41,7 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
     private final Client client;
     private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
     private boolean startedStatsJob;
+    private boolean startedMemoryRetentionJob;
 
     public MLCommonsClusterEventListener(
         ClusterService clusterService,
@@ -98,6 +100,13 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                     mlTaskManager.indexStatsCollectorJob(true);
                     // using this variable in case if same node has a cluster state change event and the state is not updated yet
                     this.startedStatsJob = true;
+                }
+
+                if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+                    && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
+                    && !this.startedMemoryRetentionJob) {
+                    mlTaskManager.indexMemoryRetentionJob();
+                    this.startedMemoryRetentionJob = true;
                 }
 
                 break;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -13,6 +13,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.jobs.processors.MLBatchTaskUpdateProcessor;
 import org.opensearch.ml.jobs.processors.MLStatsJobProcessor;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -105,6 +106,9 @@ public class MLJobRunner implements ScheduledJobRunner {
                 break;
             case BATCH_TASK_UPDATE:
                 MLBatchTaskUpdateProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
+                break;
+            case MEMORY_RETENTION:
+                MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool).process(jobParameter, jobExecutionContext);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported job type " + jobParameter.getJobType());

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobRunner.java
@@ -26,7 +26,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MLJobRunner implements ScheduledJobRunner {
 
-    private static MLJobRunner instance;
+    private static volatile MLJobRunner instance;
 
     public static MLJobRunner getInstance() {
         if (instance != null) {
@@ -59,7 +59,7 @@ public class MLJobRunner implements ScheduledJobRunner {
     @Setter
     private MLFeatureEnabledSetting mlFeatureEnabledSetting;
 
-    private boolean initialized;
+    private volatile boolean initialized;
 
     @VisibleForTesting
     MLJobRunner() {
@@ -79,8 +79,8 @@ public class MLJobRunner implements ScheduledJobRunner {
         this.client = client;
         this.sdkClient = sdkClient;
         this.connectorAccessControlHelper = connectorAccessControlHelper;
-        this.initialized = true;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.initialized = true;
     }
 
     @Override

--- a/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/MLJobType.java
@@ -7,7 +7,8 @@ package org.opensearch.ml.jobs;
 
 public enum MLJobType {
     STATS_COLLECTOR("Job to collect static metrics and push to Metrics Registry"),
-    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models");
+    BATCH_TASK_UPDATE("Job to poll and update status of running batch prediction tasks for remote models"),
+    MEMORY_RETENTION("Job to enforce retention policies on agentic memory containers");
 
     private final String description;
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -13,6 +13,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
@@ -98,6 +99,11 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     public void run() {
         if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
             log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        if (!ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+            log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;
         }
 
@@ -351,6 +357,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         int maxCount,
         ActionListener<Set<String>> listener
     ) {
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
+
         // Walk sessions sorted by last_updated_time DESC (newest first).
         // Skip the first maxCount sessions; collect the rest as expired.
         Set<String> expiredIds = new HashSet<>();
@@ -377,7 +386,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
             .query(query)
             .size(CONTAINER_PAGE_SIZE)
-            .sort(LAST_UPDATED_TIME_FIELD, SortOrder.DESC)
+            .sort(CREATED_TIME_FIELD, SortOrder.DESC)
             .sort("_id", SortOrder.ASC)
             .fetchSource(false);
 
@@ -566,6 +575,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void executeLongTermMaxCount(String longTermIndex, String containerId, int maxCount, ActionListener<Long> listener) {
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(longTermIndex, containerId, "long_term", maxCount);
+
         // Step 1: count non-pinned long-term docs
         SearchRequest countRequest = new SearchRequest(longTermIndex);
         countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -587,8 +599,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 }
 
                 int excess = (int) (totalCount - maxCount);
-                // Step 2: search for oldest excess docs by last_updated_time ASC
-                collectOldestDocIds(longTermIndex, containerId, LAST_UPDATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                // Step 2: search for oldest excess docs by created_time ASC
+                collectOldestDocIds(longTermIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
                     if (idsToDelete.isEmpty()) {
                         listener.onResponse(0L);
                         return;
@@ -722,6 +734,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         int maxCount = rule.getMaxCount();
 
+        // Check if pinned count alone exceeds max_count (fire-and-forget warning)
+        checkPinnedExceedsMaxCount(historyIndex, containerId, "history", maxCount);
+
         // Step 1: count non-pinned history docs
         SearchRequest countRequest = new SearchRequest(historyIndex);
         countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -792,6 +807,36 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
                 listener.onResponse(null);
             }, listener::onFailure));
+        }
+    }
+
+    private void checkPinnedExceedsMaxCount(String index, String containerId, String memoryType, int maxCount) {
+        SearchRequest pinnedCountRequest = new SearchRequest(index);
+        pinnedCountRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder pinnedQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder pinnedSource = new SearchSourceBuilder().query(pinnedQuery).size(0).trackTotalHits(true);
+        pinnedCountRequest.source(pinnedSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(pinnedCountRequest, ActionListener.wrap(pinnedResponse -> {
+                long pinnedCount = pinnedResponse.getHits().getTotalHits().value();
+                if (pinnedCount > maxCount) {
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] container={} type={} pinned_count={} exceeds max_count={}."
+                                + " Container will grow unbounded until pins are removed.",
+                            containerId,
+                            memoryType,
+                            pinnedCount,
+                            maxCount
+                        );
+                }
+            }, e -> { log.debug("Failed to check pinned count for container [{}] type [{}]", containerId, memoryType, e); }));
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -5,11 +5,56 @@
 
 package org.opensearch.ml.jobs.processors;
 
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_STORAGE_CONFIG_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -18,6 +63,10 @@ import com.google.common.annotations.VisibleForTesting;
 public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static final int CONTAINER_PAGE_SIZE = 100;
+    private static final int DELETE_BY_QUERY_BATCH_SIZE = 500;
+    private static final int BULK_DELETE_BATCH_SIZE = 1000;
 
     private static MemoryRetentionJobProcessor instance;
 
@@ -52,6 +101,713 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        log.info("Memory retention job triggered");
+        log.info("Memory retention job started");
+        resolveContainersWithPolicies(null);
+    }
+
+    private void resolveContainersWithPolicies(Object[] searchAfterValues) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHits hits = response.getHits();
+                SearchHit[] hitArray = hits.getHits();
+
+                if (hitArray.length == 0) {
+                    onJobComplete();
+                    return;
+                }
+
+                processContainerChain(
+                    hitArray,
+                    0,
+                    hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null
+                );
+            }, e -> {
+                log.error("Failed to search for containers with retention policies", e);
+                onJobComplete();
+            }));
+        }
+    }
+
+    private void processContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+        if (index >= hits.length) {
+            if (nextPageSortValues != null) {
+                resolveContainersWithPolicies(nextPageSortValues);
+            } else {
+                executeOrphanSweep();
+                onJobComplete();
+            }
+            return;
+        }
+
+        processContainer(hits[index], ActionListener.wrap(v -> scheduleNext(hits, index + 1, nextPageSortValues), e -> {
+            log.error("Failed processing container [{}]", hits[index].getId(), e);
+            scheduleNext(hits, index + 1, nextPageSortValues);
+        }));
+    }
+
+    private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
+        int throttleSeconds = ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS.get(clusterService.getSettings());
+        threadPool
+            .schedule(
+                () -> processContainerChain(hits, nextIndex, nextPageSortValues),
+                TimeValue.timeValueSeconds(throttleSeconds),
+                ThreadPool.Names.GENERIC
+            );
+    }
+
+    private void processContainer(SearchHit hit, ActionListener<Void> listener) {
+        String containerId = hit.getId();
+        try {
+            Map<String, Object> source = hit.getSourceAsMap();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) source.get(MEMORY_STORAGE_CONFIG_FIELD);
+
+            if (configMap == null) {
+                log.warn("Container [{}] has no configuration field, skipping", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
+            BytesReference bytes = BytesReference.bytes(xContentBuilder);
+            XContentParser parser = XContentHelper
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
+            parser.nextToken();
+            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+            executeSessionRetention(
+                config,
+                containerId,
+                ActionListener
+                    .wrap(
+                        v -> executeLongTermRetention(
+                            config,
+                            containerId,
+                            ActionListener
+                                .wrap(
+                                    v2 -> executeHistoryRetention(
+                                        config,
+                                        containerId,
+                                        ActionListener
+                                            .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ),
+                                    listener::onFailure
+                                )
+                        ),
+                        listener::onFailure
+                    )
+            );
+        } catch (Exception e) {
+            log.error("Error parsing configuration for container [{}]", containerId, e);
+            listener.onResponse(null);
+        }
+    }
+
+    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
+        if (sessionIndex == null) {
+            log.debug("Session index is null for container [{}], skipping session retention", containerId);
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.SESSIONS)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule sessionRule = retentionPolicy.get(MemoryType.SESSIONS);
+        if (sessionRule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        identifyExpiredSessions(config, containerId, sessionIndex, sessionRule, ActionListener.wrap(expiredSessionIds -> {
+            if (expiredSessionIds.isEmpty()) {
+                log.info("[MemoryRetentionJob] container={} sessions_expired=0", containerId);
+                listener.onResponse(null);
+                return;
+            }
+
+            log.info("[MemoryRetentionJob] container={} sessions_expired={}", containerId, expiredSessionIds.size());
+
+            cascadeDeleteWorkingMemory(
+                config,
+                containerId,
+                expiredSessionIds,
+                ActionListener
+                    .wrap(deletedCount -> deleteSessionDocuments(config, sessionIndex, expiredSessionIds, listener), listener::onFailure)
+            );
+        }, listener::onFailure));
+    }
+
+    private void identifyExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        RetentionRule rule,
+        ActionListener<Set<String>> listener
+    ) {
+        Set<String> expiredIds = new HashSet<>();
+
+        ActionListener<Set<String>> timeBasedDone = ActionListener.wrap(timeExpired -> {
+            expiredIds.addAll(timeExpired);
+            if (rule.getMaxCount() != null) {
+                identifyCountBasedExpiredSessions(
+                    config,
+                    containerId,
+                    sessionIndex,
+                    rule.getMaxCount(),
+                    ActionListener.wrap(countExpired -> {
+                        expiredIds.addAll(countExpired);
+                        listener.onResponse(expiredIds);
+                    }, listener::onFailure)
+                );
+            } else {
+                listener.onResponse(expiredIds);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            identifyTimeBasedExpiredSessions(config, containerId, sessionIndex, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(new HashSet<>());
+        }
+    }
+
+    private void identifyTimeBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int retentionDays,
+        ActionListener<Set<String>> listener
+    ) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        request.source(sourceBuilder);
+
+        Set<String> expiredIds = new HashSet<>();
+        searchAllPages(request, expiredIds, listener);
+    }
+
+    private void searchAllPages(SearchRequest request, Set<String> accumulator, ActionListener<Set<String>> listener) {
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    accumulator.add(hit.getId());
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] sortValues = hits[hits.length - 1].getSortValues();
+                    request.source().searchAfter(sortValues);
+                    searchAllPages(request, accumulator, listener);
+                } else {
+                    listener.onResponse(accumulator);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void identifyCountBasedExpiredSessions(
+        MemoryConfiguration config,
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        ActionListener<Set<String>> listener
+    ) {
+        // Walk sessions sorted by last_updated_time DESC (newest first).
+        // Skip the first maxCount sessions; collect the rest as expired.
+        Set<String> expiredIds = new HashSet<>();
+        identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
+    }
+
+    private void identifyCountBasedPage(
+        String containerId,
+        String sessionIndex,
+        int maxCount,
+        Set<String> expiredIds,
+        int seenSoFar,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(sessionIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort(LAST_UPDATED_TIME_FIELD, SortOrder.DESC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                int currentSeen = seenSoFar;
+
+                for (SearchHit hit : hits) {
+                    currentSeen++;
+                    if (currentSeen > maxCount) {
+                        expiredIds.add(hit.getId());
+                    }
+                }
+
+                if (hits.length == CONTAINER_PAGE_SIZE) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, currentSeen, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(expiredIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void cascadeDeleteWorkingMemory(
+        MemoryConfiguration config,
+        String containerId,
+        Set<String> expiredSessionIds,
+        ActionListener<Long> listener
+    ) {
+        String workingMemoryIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingMemoryIndex == null) {
+            listener.onResponse(0L);
+            return;
+        }
+
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), DELETE_BY_QUERY_BATCH_SIZE);
+        cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, 0, 0L, listener);
+    }
+
+    private void cascadeDeleteBatch(
+        MemoryConfiguration config,
+        String workingMemoryIndex,
+        String containerId,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            log.info("[MemoryRetentionJob] container={} cascade_working_memory_deleted={}", containerId, totalDeleted);
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingMemoryIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + ".session_id", batch))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse bulkResponse) -> {
+                long deleted = bulkResponse.getDeleted();
+                cascadeDeleteBatch(config, workingMemoryIndex, containerId, batches, batchIndex + 1, totalDeleted + deleted, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteSessionDocuments(
+        MemoryConfiguration config,
+        String sessionIndex,
+        Set<String> expiredSessionIds,
+        ActionListener<Void> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(expiredSessionIds), BULK_DELETE_BATCH_SIZE);
+        deleteSessionBatch(config, sessionIndex, batches, 0, listener);
+    }
+
+    private void deleteSessionBatch(
+        MemoryConfiguration config,
+        String sessionIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        ActionListener<Void> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String sessionId : batch) {
+            bulkRequest.add(new DeleteRequest(sessionIndex, sessionId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
+        if (longTermIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.LONG_TERM)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.LONG_TERM);
+        if (rule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        ActionListener<Long> timeBasedDone = ActionListener.wrap(timeDeleted -> {
+            if (rule.getMaxCount() != null) {
+                executeLongTermMaxCount(longTermIndex, containerId, rule.getMaxCount(), ActionListener.wrap(countDeleted -> {
+                    long total = (timeDeleted != null ? timeDeleted : 0L) + countDeleted;
+                    log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            } else {
+                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, timeDeleted != null ? timeDeleted : 0L);
+                listener.onResponse(null);
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            executeLongTermRetentionDays(longTermIndex, containerId, rule.getRetentionDays(), timeBasedDone);
+        } else {
+            timeBasedDone.onResponse(0L);
+        }
+    }
+
+    private void executeLongTermRetentionDays(String longTermIndex, String containerId, int retentionDays, ActionListener<Long> listener) {
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+                    .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                listener.onResponse(response.getDeleted());
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeLongTermMaxCount(String longTermIndex, String containerId, int maxCount, ActionListener<Long> listener) {
+        // Step 1: count non-pinned long-term docs
+        SearchRequest countRequest = new SearchRequest(longTermIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    listener.onResponse(0L);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search for oldest excess docs by last_updated_time ASC
+                collectOldestDocIds(longTermIndex, containerId, LAST_UPDATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        listener.onResponse(0L);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(longTermIndex, new ArrayList<>(idsToDelete), listener);
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void collectOldestDocIds(String index, String containerId, String timeField, int limit, ActionListener<Set<String>> listener) {
+        Set<String> collected = new HashSet<>();
+        collectOldestDocIdsPage(index, containerId, timeField, limit, collected, null, listener);
+    }
+
+    private void collectOldestDocIdsPage(
+        String index,
+        String containerId,
+        String timeField,
+        int limit,
+        Set<String> collected,
+        Object[] searchAfter,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(index);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        int pageSize = Math.min(CONTAINER_PAGE_SIZE, limit - collected.size());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(pageSize)
+            .sort(timeField, SortOrder.ASC)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(false);
+
+        if (searchAfter != null) {
+            sourceBuilder.searchAfter(searchAfter);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+                for (SearchHit hit : hits) {
+                    collected.add(hit.getId());
+                    if (collected.size() >= limit) {
+                        listener.onResponse(collected);
+                        return;
+                    }
+                }
+
+                if (hits.length == pageSize && collected.size() < limit) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    collectOldestDocIdsPage(index, containerId, timeField, limit, collected, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(collected);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteDocumentsBatch(String index, List<String> ids, ActionListener<Long> listener) {
+        List<List<String>> batches = partition(ids, BULK_DELETE_BATCH_SIZE);
+        deleteDocumentsBatchRecursive(index, batches, 0, 0L, listener);
+    }
+
+    private void deleteDocumentsBatchRecursive(
+        String index,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        for (String docId : batch) {
+            bulkRequest.add(new DeleteRequest(index, docId));
+        }
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .bulk(
+                    bulkRequest,
+                    ActionListener
+                        .wrap(
+                            bulkResponse -> deleteDocumentsBatchRecursive(
+                                index,
+                                batches,
+                                batchIndex + 1,
+                                totalDeleted + batch.size(),
+                                listener
+                            ),
+                            listener::onFailure
+                        )
+                );
+        }
+    }
+
+    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        String historyIndex = config.getIndexName(MemoryType.HISTORY);
+        if (historyIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+        if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.HISTORY)) {
+            listener.onResponse(null);
+            return;
+        }
+
+        RetentionRule rule = retentionPolicy.get(MemoryType.HISTORY);
+        if (rule == null || rule.getMaxCount() == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int maxCount = rule.getMaxCount();
+
+        // Step 1: count non-pinned history docs
+        SearchRequest countRequest = new SearchRequest(historyIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder countQuery = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                    listener.onResponse(null);
+                    return;
+                }
+
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search oldest excess docs by created_time ASC (history uses created_time)
+                collectOldestDocIds(historyIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
+                    if (idsToDelete.isEmpty()) {
+                        log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
+                        listener.onResponse(null);
+                        return;
+                    }
+                    // Step 3: bulk delete those IDs
+                    deleteDocumentsBatch(historyIndex, new ArrayList<>(idsToDelete), ActionListener.wrap(deleted -> {
+                        log.info("[MemoryRetentionJob] container={} history_deleted={}", containerId, deleted);
+                        listener.onResponse(null);
+                    }, listener::onFailure));
+                }, listener::onFailure));
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        if (!config.isDisableSession()) {
+            listener.onResponse(null);
+            return;
+        }
+
+        String workingIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        int ttlDays = ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS.get(clusterService.getSettings());
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
+                listener.onResponse(null);
+            }, listener::onFailure));
+        }
+    }
+
+    private void executeOrphanSweep() {
+        log.debug("Orphan sweep not yet implemented");
+    }
+
+    private void onJobComplete() {
+        log.info("Memory retention job completed");
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -7,12 +7,15 @@ package org.opensearch.ml.jobs.processors;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_SESSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_STORAGE_CONFIG_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.NAMESPACE_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
@@ -68,6 +71,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int CONTAINER_PAGE_SIZE = 100;
     private static final int DELETE_BY_QUERY_BATCH_SIZE = 500;
     private static final int BULK_DELETE_BATCH_SIZE = 1000;
+    private static final int ORPHAN_SESSION_ID_CAP = 50_000;
+    private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
+    private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
 
     private static MemoryRetentionJobProcessor instance;
 
@@ -159,7 +165,6 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 resolveContainersWithPolicies(nextPageSortValues);
             } else {
                 executeOrphanSweep();
-                onJobComplete();
             }
             return;
         }
@@ -841,7 +846,328 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void executeOrphanSweep() {
-        log.debug("Orphan sweep not yet implemented");
+        resolveOrphanSweepContainers(null);
+    }
+
+    private void resolveOrphanSweepContainers(Object[] searchAfterValues) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD))
+            .mustNot(QueryBuilders.termQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + DISABLE_SESSION_FIELD, true));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHits hits = response.getHits();
+                SearchHit[] hitArray = hits.getHits();
+
+                if (hitArray.length == 0) {
+                    onJobComplete();
+                    return;
+                }
+
+                Object[] nextPageSort = hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null;
+                processOrphanSweepContainerChain(hitArray, 0, nextPageSort);
+            }, e -> {
+                log.error("Failed to search containers for orphan sweep", e);
+                onJobComplete();
+            }));
+        }
+    }
+
+    private void processOrphanSweepContainerChain(SearchHit[] hits, int index, Object[] nextPageSortValues) {
+        if (index >= hits.length) {
+            if (nextPageSortValues != null) {
+                resolveOrphanSweepContainers(nextPageSortValues);
+            } else {
+                onJobComplete();
+            }
+            return;
+        }
+
+        SearchHit hit = hits[index];
+        String containerId = hit.getId();
+
+        try {
+            Map<String, Object> source = hit.getSourceAsMap();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> configMap = (Map<String, Object>) source.get(MEMORY_STORAGE_CONFIG_FIELD);
+
+            if (configMap == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
+            BytesReference bytes = BytesReference.bytes(xContentBuilder);
+            XContentParser parser = XContentHelper
+                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
+            parser.nextToken();
+            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+
+            String workingIndex = config.getIndexName(MemoryType.WORKING);
+            String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
+
+            if (workingIndex == null || sessionsIndex == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            sweepOrphansForContainer(
+                config,
+                containerId,
+                workingIndex,
+                sessionsIndex,
+                ActionListener.wrap(v -> processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues), e -> {
+                    log.error("[MemoryRetentionJob] Orphan sweep failed for container [{}]", containerId, e);
+                    processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                })
+            );
+        } catch (Exception e) {
+            log.error("[MemoryRetentionJob] Error parsing config for orphan sweep container [{}]", containerId, e);
+            processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+        }
+    }
+
+    private void sweepOrphansForContainer(
+        MemoryConfiguration config,
+        String containerId,
+        String workingIndex,
+        String sessionsIndex,
+        ActionListener<Void> listener
+    ) {
+        Set<String> sessionIds = new HashSet<>();
+        enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
+            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
+                deleteNullSessionWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                    log
+                        .info(
+                            "[MemoryRetentionJob] container={} orphans_deleted={} null_session_deleted={}",
+                            containerId,
+                            orphansDeleted,
+                            nullDeleted
+                        );
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            }, listener::onFailure);
+
+            if (collectedIds.isEmpty()) {
+                afterOrphans.onResponse(0L);
+            } else {
+                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
+            }
+        }, listener::onFailure));
+    }
+
+    private void enumerateSessionIdsFromWorkingMemory(
+        String workingIndex,
+        String containerId,
+        Set<String> sessionIds,
+        Object[] searchAfterValues,
+        ActionListener<Set<String>> listener
+    ) {
+        SearchRequest request = new SearchRequest(workingIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+            .query(query)
+            .size(ORPHAN_ENUMERATION_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(new String[] { NAMESPACE_FIELD }, null);
+
+        if (searchAfterValues != null) {
+            sourceBuilder.searchAfter(searchAfterValues);
+        }
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                SearchHit[] hits = response.getHits().getHits();
+
+                for (SearchHit hit : hits) {
+                    Map<String, Object> source = hit.getSourceAsMap();
+                    if (source != null) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> namespace = (Map<String, Object>) source.get(NAMESPACE_FIELD);
+                        if (namespace != null) {
+                            String sessionId = (String) namespace.get(SESSION_ID_FIELD);
+                            if (sessionId != null) {
+                                sessionIds.add(sessionId);
+                            }
+                        }
+                    }
+
+                    if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+                        log
+                            .warn(
+                                "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
+                                    + " Remaining orphans will be caught on next run.",
+                                containerId,
+                                ORPHAN_SESSION_ID_CAP
+                            );
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+                }
+
+                if (hits.length == ORPHAN_ENUMERATION_PAGE_SIZE) {
+                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextSearchAfter, listener);
+                } else {
+                    listener.onResponse(sessionIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    private void checkAndDeleteOrphans(
+        String containerId,
+        String workingIndex,
+        String sessionsIndex,
+        Set<String> sessionIds,
+        ActionListener<Long> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(sessionIds), ORPHAN_SESSION_BATCH_SIZE);
+        Set<String> allOrphanIds = new HashSet<>();
+        checkOrphanBatch(containerId, sessionsIndex, batches, 0, allOrphanIds, ActionListener.wrap(orphanIds -> {
+            if (orphanIds.isEmpty()) {
+                listener.onResponse(0L);
+                return;
+            }
+            deleteOrphanedWorkingMemory(containerId, workingIndex, orphanIds, listener);
+        }, listener::onFailure));
+    }
+
+    private void checkOrphanBatch(
+        String containerId,
+        String sessionsIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        Set<String> allOrphanIds,
+        ActionListener<Set<String>> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(allOrphanIds);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        SearchRequest request = new SearchRequest(sessionsIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termsQuery("_id", batch))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(batch.size()).fetchSource(false);
+
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                Set<String> existingIds = new HashSet<>();
+                for (SearchHit hit : response.getHits().getHits()) {
+                    existingIds.add(hit.getId());
+                }
+
+                for (String sessionId : batch) {
+                    if (!existingIds.contains(sessionId)) {
+                        allOrphanIds.add(sessionId);
+                    }
+                }
+
+                checkOrphanBatch(containerId, sessionsIndex, batches, batchIndex + 1, allOrphanIds, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteOrphanedWorkingMemory(
+        String containerId,
+        String workingIndex,
+        Set<String> orphanSessionIds,
+        ActionListener<Long> listener
+    ) {
+        List<List<String>> batches = partition(new ArrayList<>(orphanSessionIds), DELETE_BY_QUERY_BATCH_SIZE);
+        deleteOrphanBatch(containerId, workingIndex, batches, 0, 0L, listener);
+    }
+
+    private void deleteOrphanBatch(
+        String containerId,
+        String workingIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        long totalDeleted,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(totalDeleted);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, batch))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse bulkResponse) -> {
+                long deleted = bulkResponse.getDeleted();
+                deleteOrphanBatch(containerId, workingIndex, batches, batchIndex + 1, totalDeleted + deleted, listener);
+            }, listener::onFailure));
+        }
+    }
+
+    private void deleteNullSessionWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
+        int orphanTtlDays = ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS.get(clusterService.getSettings());
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+
+        DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
+        dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        dbq
+            .setQuery(
+                QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+            );
+        dbq.setRefresh(true);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
+                listener.onResponse(response.getDeleted());
+            }, listener::onFailure));
+        }
     }
 
     private void onJobComplete() {

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class MemoryRetentionJobProcessor extends MLJobProcessor {
+
+    private static final Logger log = LogManager.getLogger(MemoryRetentionJobProcessor.class);
+
+    private static MemoryRetentionJobProcessor instance;
+
+    public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (MemoryRetentionJobProcessor.class) {
+            if (instance != null) {
+                return instance;
+            }
+
+            instance = new MemoryRetentionJobProcessor(clusterService, client, threadPool);
+            return instance;
+        }
+    }
+
+    @VisibleForTesting
+    public static synchronized void reset() {
+        instance = null;
+    }
+
+    public MemoryRetentionJobProcessor(ClusterService clusterService, Client client, ThreadPool threadPool) {
+        super(clusterService, client, threadPool);
+    }
+
+    @Override
+    public void run() {
+        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+            log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
+            return;
+        }
+
+        log.info("Memory retention job triggered");
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.DISABLE_SESSION_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.LAST_UPDATED_TIME_FIELD;
@@ -15,6 +16,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.USER_ID_FIELD;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
@@ -26,21 +28,25 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.IndicesOptions;
-import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -53,6 +59,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
@@ -61,6 +68,8 @@ import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -81,7 +90,21 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
     private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
 
-    private static MemoryRetentionJobProcessor instance;
+    /**
+     * Threshold for detecting legacy epoch-SECOND timestamps. Documents written before
+     * TransportCreateMemorySessionAction switched to toEpochMilli() stored created_time /
+     * last_updated_time as epoch seconds (e.g. 1752400000), which compared against
+     * System.currentTimeMillis() looks like January 1970 and would be evicted immediately.
+     *
+     * Any value below 10 billion is assumed to be epoch seconds:
+     * - 10 billion SECONDS is ~year 2286, so no real epoch-second timestamp exceeds it for centuries.
+     * - 10 billion MILLIS is ~1970-04-26, so no real epoch-millis timestamp for actual data is this small.
+     */
+    private static final long EPOCH_SECOND_DETECTION_THRESHOLD = 10_000_000_000L;
+
+    private static volatile MemoryRetentionJobProcessor instance;
+
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
         if (instance != null) {
@@ -109,18 +132,28 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     @Override
     public void run() {
-        if (ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())) {
+        if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
             log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
             return;
         }
 
-        if (!ML_COMMONS_MEMORY_RETENTION_ENABLED.get(clusterService.getSettings())) {
+        if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;
         }
 
-        log.info("Memory retention job started");
-        resolveContainersWithPolicies(null);
+        if (!isRunning.compareAndSet(false, true)) {
+            log.warn("Memory retention job already in progress, skipping this invocation");
+            return;
+        }
+
+        try {
+            log.info("Memory retention job started");
+            resolveContainersWithPolicies(null);
+        } catch (Exception e) {
+            log.error("Unexpected error starting memory retention job", e);
+            isRunning.set(false);
+        }
     }
 
     private void resolveContainersWithPolicies(Object[] searchAfterValues) {
@@ -178,13 +211,18 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
-        int throttleSeconds = ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS.get(clusterService.getSettings());
-        threadPool
-            .schedule(
-                () -> processContainerChain(hits, nextIndex, nextPageSortValues),
-                TimeValue.timeValueSeconds(throttleSeconds),
-                ThreadPool.Names.GENERIC
-            );
+        int throttleSeconds = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS);
+        try {
+            threadPool
+                .schedule(
+                    () -> processContainerChain(hits, nextIndex, nextPageSortValues),
+                    TimeValue.timeValueSeconds(throttleSeconds),
+                    ThreadPool.Names.GENERIC
+                );
+        } catch (Exception e) {
+            log.error("Failed to schedule next container processing", e);
+            isRunning.set(false);
+        }
     }
 
     private void processContainer(SearchHit hit, ActionListener<Void> listener) {
@@ -202,10 +240,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
             BytesReference bytes = BytesReference.bytes(xContentBuilder);
-            XContentParser parser = XContentHelper
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
-            parser.nextToken();
-            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+            MemoryConfiguration config;
+            try (
+                XContentParser parser = XContentHelper
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON)
+            ) {
+                parser.nextToken();
+                config = MemoryConfiguration.parse(parser);
+            }
 
             Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
             if (retentionPolicy == null || retentionPolicy.isEmpty()) {
@@ -214,8 +256,12 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     listener.onResponse(null);
                     return;
                 }
-                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(v -> {
-                    executeRetentionPipeline(config, containerId, listener);
+                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(persisted -> {
+                    if (persisted) {
+                        executeRetentionPipeline(config, containerId, listener);
+                    } else {
+                        listener.onResponse(null);
+                    }
                 }, listener::onFailure));
             } else {
                 executeRetentionPipeline(config, containerId, listener);
@@ -240,8 +286,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                                 v2 -> executeHistoryRetention(
                                     config,
                                     containerId,
-                                    ActionListener
-                                        .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ActionListener.wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
                                 ),
                                 listener::onFailure
                             )
@@ -251,54 +296,112 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         );
     }
 
-    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
-        int sessionRetentionDays = ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings());
-        int sessionMaxCount = ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings());
-        int longTermMaxCount = ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings());
-        int historyMaxCount = ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings());
+    /**
+     * Backfills the cluster-default retention policy onto a container that has none, using a
+     * conditional ("if-absent") script update so a concurrently user-set policy or opt-out is
+     * never clobbered. Responds {@code true} only if the default policy was actually persisted;
+     * {@code false} means this container must be skipped for this run (no admin default retention
+     * settings are configured, a concurrent user write won, or the persist failed) so deletions
+     * never happen under a policy the user cannot see. Only settings explicitly configured by the
+     * admin (value &gt; 0; the settings default to -1, an unset sentinel) contribute to the policy.
+     */
+    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
+        int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
+        int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
+        int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
+        int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
+
+        boolean anyConfigured = sessionRetentionDays > 0 || sessionMaxCount > 0 || longTermMaxCount > 0 || historyMaxCount > 0;
+        if (!anyConfigured) {
+            log
+                .debug(
+                    "Container [{}] has no retention policy and no admin default retention settings are configured; skipping",
+                    containerId
+                );
+            listener.onResponse(false);
+            return;
+        }
 
         Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
-        defaultPolicy.put(MemoryType.SESSIONS, new RetentionRule(sessionRetentionDays, sessionMaxCount));
-        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
-        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+        if (sessionRetentionDays > 0 || sessionMaxCount > 0) {
+            defaultPolicy
+                .put(
+                    MemoryType.SESSIONS,
+                    new RetentionRule(sessionRetentionDays > 0 ? sessionRetentionDays : null, sessionMaxCount > 0 ? sessionMaxCount : null)
+                );
+        }
+        if (longTermMaxCount > 0) {
+            defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+        }
+        if (historyMaxCount > 0) {
+            defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+        }
 
         config.setRetentionPolicy(defaultPolicy);
 
-        log.info(
-            "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
-            containerId,
-            sessionMaxCount,
-            sessionRetentionDays,
-            longTermMaxCount,
-            historyMaxCount
-        );
+        log
+            .info(
+                "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
+                containerId,
+                sessionMaxCount,
+                sessionRetentionDays,
+                longTermMaxCount,
+                historyMaxCount
+            );
 
         try {
             XContentBuilder policyBuilder = XContentFactory.jsonBuilder().startObject();
-            policyBuilder.startObject(RETENTION_POLICY_FIELD);
             for (Map.Entry<MemoryType, RetentionRule> entry : defaultPolicy.entrySet()) {
                 policyBuilder.field(entry.getKey().getValue());
                 entry.getValue().toXContent(policyBuilder, null);
             }
             policyBuilder.endObject();
-            policyBuilder.endObject();
+            Map<String, Object> policyMap = XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2();
+
+            // Conditional write: only backfill if the container still has no retention_policy key.
+            // A present key (even with a null value, i.e. an explicit opt-out) means a user write
+            // happened concurrently and takes precedence, so the update becomes a noop.
+            String scriptSource = "Map cfg = (Map) ctx._source.get(params.configField);"
+                + " if (cfg == null || cfg.containsKey(params.policyField)) { ctx.op = 'noop'; }"
+                + " else { cfg.put(params.policyField, params.policy); }";
+            Map<String, Object> scriptParams = Map
+                .of("configField", MEMORY_STORAGE_CONFIG_FIELD, "policyField", RETENTION_POLICY_FIELD, "policy", policyMap);
 
             UpdateRequest updateRequest = new UpdateRequest(ML_MEMORY_CONTAINER_INDEX, containerId)
-                .doc(Map.of(MEMORY_STORAGE_CONFIG_FIELD, XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2()))
+                .script(new Script(ScriptType.INLINE, "painless", scriptSource, scriptParams))
                 .retryOnConflict(3);
 
             try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
                 client.update(updateRequest, ActionListener.wrap(response -> {
+                    if (response.getResult() == DocWriteResponse.Result.NOOP) {
+                        log.debug("Container [{}] retention policy was set concurrently by a user; skipping default backfill", containerId);
+                        listener.onResponse(false);
+                        return;
+                    }
                     log.debug("Successfully persisted default retention policy on container [{}]", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(true);
                 }, e -> {
-                    log.warn("Failed to persist default retention policy on container [{}], proceeding with in-memory defaults", containerId, e);
-                    listener.onResponse(null);
+                    if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
+                        log
+                            .debug(
+                                "Conflict persisting default retention policy on container [{}]; user's policy takes precedence",
+                                containerId,
+                                e
+                            );
+                    } else {
+                        log
+                            .warn(
+                                "Failed to persist default retention policy on container [{}], skipping retention for this run",
+                                containerId,
+                                e
+                            );
+                    }
+                    listener.onResponse(false);
                 }));
             }
         } catch (Exception e) {
-            log.warn("Failed to build default retention policy for container [{}], proceeding with in-memory defaults", containerId, e);
-            listener.onResponse(null);
+            log.warn("Failed to build default retention policy for container [{}], skipping retention for this run", containerId, e);
+            listener.onResponse(false);
         }
     }
 
@@ -387,6 +490,10 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchRequest request = new SearchRequest(sessionIndex);
         request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
+        // NOTE: legacy sessions written before the epoch-millis fix stored last_updated_time as epoch
+        // SECONDS, which always satisfies lt(cutoffMillis) and would make every pre-upgrade session look
+        // expired. The query therefore only pre-filters candidates; each hit's timestamp is fetched and
+        // re-verified client-side via normalizeTimestamp() before the session is marked expired.
         BoolQueryBuilder query = QueryBuilders
             .boolQuery()
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
@@ -397,31 +504,134 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             .query(query)
             .size(CONTAINER_PAGE_SIZE)
             .sort("_id", SortOrder.ASC)
-            .fetchSource(false);
+            .fetchSource(new String[] { LAST_UPDATED_TIME_FIELD }, null);
 
         request.source(sourceBuilder);
 
         Set<String> expiredIds = new HashSet<>();
-        searchAllPages(request, expiredIds, listener);
+        searchAllPages(request, containerId, cutoffMillis, new AtomicBoolean(false), expiredIds, listener);
     }
 
-    private void searchAllPages(SearchRequest request, Set<String> accumulator, ActionListener<Set<String>> listener) {
+    private void searchAllPages(
+        SearchRequest request,
+        String containerId,
+        long cutoffMillis,
+        AtomicBoolean epochSecondWarned,
+        Set<String> accumulator,
+        ActionListener<Set<String>> listener
+    ) {
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.search(request, ActionListener.wrap(response -> {
                 SearchHit[] hits = response.getHits().getHits();
                 for (SearchHit hit : hits) {
-                    accumulator.add(hit.getId());
+                    if (isSessionExpired(hit, containerId, cutoffMillis, epochSecondWarned)) {
+                        accumulator.add(hit.getId());
+                    }
                 }
 
                 if (hits.length == CONTAINER_PAGE_SIZE) {
                     Object[] sortValues = hits[hits.length - 1].getSortValues();
                     request.source().searchAfter(sortValues);
-                    searchAllPages(request, accumulator, listener);
+                    searchAllPages(request, containerId, cutoffMillis, epochSecondWarned, accumulator, listener);
                 } else {
                     listener.onResponse(accumulator);
                 }
             }, listener::onFailure));
         }
+    }
+
+    /**
+     * Re-verifies a session hit against the retention cutoff using a normalized (epoch-millis)
+     * timestamp. Legacy documents that stored last_updated_time in epoch seconds match the range
+     * query unconditionally, so this client-side check is what prevents pre-upgrade sessions from
+     * being mass-evicted. If the timestamp cannot be read from the hit source, the session is
+     * SKIPPED (not deleted) to avoid data loss from unparseable metadata.
+     */
+    private boolean isSessionExpired(SearchHit hit, String containerId, long cutoffMillis, AtomicBoolean epochSecondWarned) {
+        Long lastUpdated = extractTimestamp(hit, LAST_UPDATED_TIME_FIELD);
+        if (lastUpdated == null) {
+            log
+                .warn(
+                    "[MemoryRetentionJob] container={} session={} has unparseable/missing last_updated_time; skipping",
+                    containerId,
+                    hit.getId()
+                );
+            return false;
+        }
+
+        long normalized = normalizeTimestamp(lastUpdated);
+        if (normalized != lastUpdated && epochSecondWarned.compareAndSet(false, true)) {
+            log
+                .warn(
+                    "[MemoryRetentionJob] container={} detected epoch-second timestamp on session {},"
+                        + " converting to millis for comparison. Consider running timestamp migration.",
+                    containerId,
+                    hit.getId()
+                );
+        }
+        return normalized < cutoffMillis;
+    }
+
+    /**
+     * Extracts a timestamp field from a hit's source, tolerating the numeric types the source map
+     * may deserialize to (Integer, Long, Double) as well as numeric strings. Returns {@code null}
+     * when the source or field is unavailable.
+     */
+    private static Long extractTimestamp(SearchHit hit, String field) {
+        Map<String, Object> source = hit.getSourceAsMap();
+        if (source == null) {
+            return null;
+        }
+        Object value = source.get(field);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalizes a stored timestamp to epoch milliseconds. Legacy documents (written before
+     * TransportCreateMemorySessionAction switched to toEpochMilli()) stored timestamps in epoch
+     * SECONDS; comparing those against System.currentTimeMillis() makes them look like January 1970
+     * and would evict all pre-upgrade data on the first job run. Any value below
+     * {@link #EPOCH_SECOND_DETECTION_THRESHOLD} is assumed to be epoch seconds and converted.
+     *
+     * @param timestamp a stored created_time / last_updated_time value (epoch seconds or millis)
+     * @return the timestamp in epoch milliseconds
+     */
+    private static long normalizeTimestamp(long timestamp) {
+        if (timestamp > 0 && timestamp < EPOCH_SECOND_DETECTION_THRESHOLD) {
+            return timestamp * 1000;
+        }
+        return timestamp;
+    }
+
+    /**
+     * Builds an "expired before cutoff" query that applies the {@link #normalizeTimestamp(long)}
+     * heuristic at the query level, for delete-by-query paths where per-document client-side
+     * normalization is not possible. A document is expired when either:
+     * <ul>
+     *   <li>epoch-millis scale ({@code >= EPOCH_SECOND_DETECTION_THRESHOLD}) and {@code < cutoffMillis}, or</li>
+     *   <li>legacy epoch-seconds scale ({@code < EPOCH_SECOND_DETECTION_THRESHOLD}) and
+     *       {@code value * 1000 < cutoffMillis}, i.e. {@code value < cutoffMillis / 1000}.</li>
+     * </ul>
+     * A plain {@code lt(cutoffMillis)} range would match every legacy epoch-second document and
+     * mass-delete pre-upgrade data.
+     */
+    private static BoolQueryBuilder buildEpochAwareCutoffQuery(String timeField, long cutoffMillis) {
+        long secondsScaleCutoff = Math.min(cutoffMillis / 1000, EPOCH_SECOND_DETECTION_THRESHOLD);
+        return QueryBuilders
+            .boolQuery()
+            .should(QueryBuilders.rangeQuery(timeField).gte(EPOCH_SECOND_DETECTION_THRESHOLD).lt(cutoffMillis))
+            .should(QueryBuilders.rangeQuery(timeField).lt(secondsScaleCutoff))
+            .minimumShouldMatch(1);
     }
 
     private void identifyCountBasedExpiredSessions(
@@ -434,8 +644,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // Check if pinned count alone exceeds max_count (fire-and-forget warning)
         checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
 
-        // Walk sessions sorted by last_updated_time DESC (newest first).
-        // Skip the first maxCount sessions; collect the rest as expired.
+        // Walk sessions sorted by created_time DESC (newest first). max_count is a cap on total
+        // sessions by creation order; retention_days handles activity-based eviction separately.
         Set<String> expiredIds = new HashSet<>();
         identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
     }
@@ -575,15 +785,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client
-                .bulk(
-                    bulkRequest,
-                    ActionListener
-                        .wrap(
-                            bulkResponse -> deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener),
-                            listener::onFailure
-                        )
-                );
+            client.bulk(bulkRequest, ActionListener.wrap(bulkResponse -> {
+                if (bulkResponse.hasFailures()) {
+                    String failureMsg = bulkResponse.buildFailureMessage();
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] Partial session delete failures: {}",
+                            failureMsg.length() > 500 ? failureMsg.substring(0, 500) + "..." : failureMsg
+                        );
+                }
+                deleteSessionBatch(config, sessionIndex, batches, batchIndex + 1, listener);
+            }, listener::onFailure));
         }
     }
 
@@ -631,12 +843,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store last_updated_time in epoch seconds and would all
+        // match a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.rangeQuery(LAST_UPDATED_TIME_FIELD).lt(cutoffMillis))
+                    .must(buildEpochAwareCutoffQuery(LAST_UPDATED_TIME_FIELD, cutoffMillis))
                     .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true))
             );
         dbq.setRefresh(true);
@@ -769,21 +983,18 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client
-                .bulk(
-                    bulkRequest,
-                    ActionListener
-                        .wrap(
-                            bulkResponse -> deleteDocumentsBatchRecursive(
-                                index,
-                                batches,
-                                batchIndex + 1,
-                                totalDeleted + batch.size(),
-                                listener
-                            ),
-                            listener::onFailure
-                        )
-                );
+            client.bulk(bulkRequest, ActionListener.wrap(bulkResponse -> {
+                long batchDeleted = Arrays.stream(bulkResponse.getItems()).filter(i -> !i.isFailed()).count();
+                if (bulkResponse.hasFailures()) {
+                    String failureMsg = bulkResponse.buildFailureMessage();
+                    log
+                        .warn(
+                            "[MemoryRetentionJob] Partial bulk delete failures: {}",
+                            failureMsg.length() > 500 ? failureMsg.substring(0, 500) + "..." : failureMsg
+                        );
+                }
+                deleteDocumentsBatchRecursive(index, batches, batchIndex + 1, totalDeleted + batchDeleted, listener);
+            }, listener::onFailure));
         }
     }
 
@@ -862,17 +1073,19 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        int ttlDays = ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS.get(clusterService.getSettings());
+        int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store created_time in epoch seconds and would all match
+        // a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 
@@ -983,15 +1196,44 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(configMap);
             BytesReference bytes = BytesReference.bytes(xContentBuilder);
-            XContentParser parser = XContentHelper
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON);
-            parser.nextToken();
-            MemoryConfiguration config = MemoryConfiguration.parse(parser);
+            MemoryConfiguration config;
+            try (
+                XContentParser parser = XContentHelper
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, bytes, XContentType.JSON)
+            ) {
+                parser.nextToken();
+                config = MemoryConfiguration.parse(parser);
+            }
 
             String workingIndex = config.getIndexName(MemoryType.WORKING);
             String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
 
             if (workingIndex == null || sessionsIndex == null) {
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            // Safety check: if the working memory index doesn't exist there is nothing to sweep,
+            // and if the sessions index doesn't exist the sweep would classify ALL working memory
+            // as orphaned and delete it. Skip the sweep in either case.
+            if (!clusterService.state().metadata().hasIndex(workingIndex)) {
+                log
+                    .debug(
+                        "[MemoryRetentionJob] Skipping orphan sweep for container={}: working memory index {} does not exist",
+                        containerId,
+                        workingIndex
+                    );
+                processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
+                return;
+            }
+
+            if (!clusterService.state().metadata().hasIndex(sessionsIndex)) {
+                log
+                    .debug(
+                        "[MemoryRetentionJob] Skipping orphan sweep for container={}: sessions index {} does not exist",
+                        containerId,
+                        sessionsIndex
+                    );
                 processOrphanSweepContainerChain(hits, index + 1, nextPageSortValues);
                 return;
             }
@@ -1022,10 +1264,10 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         Set<String> sessionIds = new HashSet<>();
         enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
             ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
-                deleteNullSessionWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
                     log
                         .info(
-                            "[MemoryRetentionJob] container={} orphans_deleted={} null_session_deleted={}",
+                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
                             containerId,
                             orphansDeleted,
                             nullDeleted
@@ -1153,9 +1395,24 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(batch.size()).fetchSource(false);
 
         request.source(sourceBuilder);
+        request.allowPartialSearchResults(false);
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.search(request, ActionListener.wrap(response -> {
+                if (response.getFailedShards() > 0 || response.isTimedOut()) {
+                    listener
+                        .onFailure(
+                            new IllegalStateException(
+                                "Orphan check for container ["
+                                    + containerId
+                                    + "] had "
+                                    + response.getFailedShards()
+                                    + " failed shards or timed out; skipping to avoid incorrect deletions"
+                            )
+                        );
+                    return;
+                }
+
                 Set<String> existingIds = new HashSet<>();
                 for (SearchHit hit : response.getHits().getHits()) {
                     existingIds.add(hit.getId());
@@ -1216,19 +1473,23 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void deleteNullSessionWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
-        int orphanTtlDays = ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS.get(clusterService.getSettings());
+    private void deleteEmptyNamespaceWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
+        int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Epoch-aware cutoff: legacy docs store created_time in epoch seconds and would all match
+        // a plain lt(cutoffMillis) range. See normalizeTimestamp().
         dbq
             .setQuery(
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
-                    .must(QueryBuilders.rangeQuery(CREATED_TIME_FIELD).lt(cutoffMillis))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + USER_ID_FIELD))
+                    .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + AGENT_ID_FIELD))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 
@@ -1240,6 +1501,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void onJobComplete() {
+        isRunning.set(false);
         log.info("Memory retention job completed");
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -1650,6 +1650,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             log.debug("[MemoryRetentionJob] container={} deleting orphaned working memory for session ids={}", containerId, batch);
         }
 
+        int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
         dbq
@@ -1658,6 +1661,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
                     .must(buildSessionIdMatchQuery(batch))
+                    .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis))
             );
         dbq.setRefresh(true);
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -33,6 +33,7 @@ import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -72,6 +73,9 @@ import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.threadpool.ThreadPool;
@@ -89,6 +93,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private static final int ORPHAN_SESSION_ID_CAP = 50_000;
     private static final int ORPHAN_SESSION_BATCH_SIZE = 1000;
     private static final int ORPHAN_ENUMERATION_PAGE_SIZE = 1000;
+    private static final String SESSION_IDS_AGG_NAME = "session_ids";
+    private static final String ORPHAN_KEYSPACE_ALPHABET = "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz";
+    private static final int ORPHAN_START_KEY_LENGTH = 4;
 
     /**
      * Threshold for detecting legacy epoch-SECOND timestamps. Documents written before
@@ -204,9 +211,15 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        processContainer(hits[index], ActionListener.wrap(v -> scheduleNext(hits, index + 1, nextPageSortValues), e -> {
+        processContainer(hits[index], ActionListener.wrap(hadDeletions -> {
+            if (hadDeletions) {
+                scheduleNext(hits, index + 1, nextPageSortValues);
+            } else {
+                processContainerChain(hits, index + 1, nextPageSortValues);
+            }
+        }, e -> {
             log.error("Failed processing container [{}]", hits[index].getId(), e);
-            scheduleNext(hits, index + 1, nextPageSortValues);
+            processContainerChain(hits, index + 1, nextPageSortValues);
         }));
     }
 
@@ -225,7 +238,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void processContainer(SearchHit hit, ActionListener<Void> listener) {
+    private void processContainer(SearchHit hit, ActionListener<Boolean> listener) {
         String containerId = hit.getId();
         try {
             Map<String, Object> source = hit.getSourceAsMap();
@@ -234,7 +247,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
             if (configMap == null) {
                 log.warn("Container [{}] has no configuration field, skipping", containerId);
-                listener.onResponse(null);
+                listener.onResponse(false);
                 return;
             }
 
@@ -253,14 +266,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             if (retentionPolicy == null || retentionPolicy.isEmpty()) {
                 if (config.isRetentionPolicyExplicitlyNull()) {
                     log.debug("Container [{}] explicitly opted out of retention, skipping", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(false);
                     return;
                 }
                 applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(persisted -> {
                     if (persisted) {
                         executeRetentionPipeline(config, containerId, listener);
                     } else {
-                        listener.onResponse(null);
+                        listener.onResponse(false);
                     }
                 }, listener::onFailure));
             } else {
@@ -268,25 +281,40 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             }
         } catch (Exception e) {
             log.error("Error parsing configuration for container [{}]", containerId, e);
-            listener.onResponse(null);
+            listener.onResponse(false);
         }
     }
 
-    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         executeSessionRetention(
             config,
             containerId,
             ActionListener
                 .wrap(
-                    v -> executeLongTermRetention(
+                    sessionsDeleted -> executeLongTermRetention(
                         config,
                         containerId,
                         ActionListener
                             .wrap(
-                                v2 -> executeHistoryRetention(
+                                longTermDeleted -> executeHistoryRetention(
                                     config,
                                     containerId,
-                                    ActionListener.wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                    ActionListener
+                                        .wrap(
+                                            historyDeleted -> executeWorkingMemoryTTL(
+                                                config,
+                                                containerId,
+                                                ActionListener
+                                                    .wrap(
+                                                        workingDeleted -> listener
+                                                            .onResponse(
+                                                                sessionsDeleted || longTermDeleted || historyDeleted || workingDeleted
+                                                            ),
+                                                        listener::onFailure
+                                                    )
+                                            ),
+                                            listener::onFailure
+                                        )
                                 ),
                                 listener::onFailure
                             )
@@ -405,30 +433,30 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeSessionRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
         if (sessionIndex == null) {
             log.debug("Session index is null for container [{}], skipping session retention", containerId);
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.SESSIONS)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule sessionRule = retentionPolicy.get(MemoryType.SESSIONS);
         if (sessionRule == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         identifyExpiredSessions(config, containerId, sessionIndex, sessionRule, ActionListener.wrap(expiredSessionIds -> {
             if (expiredSessionIds.isEmpty()) {
                 log.info("[MemoryRetentionJob] container={} sessions_expired=0", containerId);
-                listener.onResponse(null);
+                listener.onResponse(false);
                 return;
             }
 
@@ -439,7 +467,15 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 containerId,
                 expiredSessionIds,
                 ActionListener
-                    .wrap(deletedCount -> deleteSessionDocuments(config, sessionIndex, expiredSessionIds, listener), listener::onFailure)
+                    .wrap(
+                        deletedCount -> deleteSessionDocuments(
+                            config,
+                            sessionIndex,
+                            expiredSessionIds,
+                            ActionListener.wrap(v -> listener.onResponse(true), listener::onFailure)
+                        ),
+                        listener::onFailure
+                    )
             );
         }, listener::onFailure));
     }
@@ -634,6 +670,20 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             .minimumShouldMatch(1);
     }
 
+    /**
+     * Matches working-memory documents belonging to any of the given session IDs. Prefers the
+     * top-level {@code session_id} keyword field but also matches on the legacy
+     * {@code namespace.session_id} flat_object subpath for pre-upgrade documents that lack the
+     * top-level field.
+     */
+    private static BoolQueryBuilder buildSessionIdMatchQuery(List<String> sessionIds) {
+        return QueryBuilders
+            .boolQuery()
+            .should(QueryBuilders.termsQuery(SESSION_ID_FIELD, sessionIds))
+            .should(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, sessionIds))
+            .minimumShouldMatch(1);
+    }
+
     private void identifyCountBasedExpiredSessions(
         MemoryConfiguration config,
         String containerId,
@@ -644,60 +694,29 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // Check if pinned count alone exceeds max_count (fire-and-forget warning)
         checkPinnedExceedsMaxCount(sessionIndex, containerId, "sessions", maxCount);
 
-        // Walk sessions sorted by created_time DESC (newest first). max_count is a cap on total
-        // sessions by creation order; retention_days handles activity-based eviction separately.
-        Set<String> expiredIds = new HashSet<>();
-        identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, 0, null, listener);
-    }
+        // Step 1: count non-pinned sessions
+        SearchRequest countRequest = new SearchRequest(sessionIndex);
+        countRequest.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-    private void identifyCountBasedPage(
-        String containerId,
-        String sessionIndex,
-        int maxCount,
-        Set<String> expiredIds,
-        int seenSoFar,
-        Object[] searchAfter,
-        ActionListener<Set<String>> listener
-    ) {
-        SearchRequest request = new SearchRequest(sessionIndex);
-        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-
-        BoolQueryBuilder query = QueryBuilders
+        BoolQueryBuilder countQuery = QueryBuilders
             .boolQuery()
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
             .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(query)
-            .size(CONTAINER_PAGE_SIZE)
-            .sort(CREATED_TIME_FIELD, SortOrder.DESC)
-            .sort("_id", SortOrder.ASC)
-            .fetchSource(false);
-
-        if (searchAfter != null) {
-            sourceBuilder.searchAfter(searchAfter);
-        }
-
-        request.source(sourceBuilder);
+        SearchSourceBuilder countSource = new SearchSourceBuilder().query(countQuery).size(0).trackTotalHits(true);
+        countRequest.source(countSource);
 
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.wrap(response -> {
-                SearchHit[] hits = response.getHits().getHits();
-                int currentSeen = seenSoFar;
-
-                for (SearchHit hit : hits) {
-                    currentSeen++;
-                    if (currentSeen > maxCount) {
-                        expiredIds.add(hit.getId());
-                    }
+            client.search(countRequest, ActionListener.wrap(countResponse -> {
+                long totalCount = countResponse.getHits().getTotalHits().value();
+                if (totalCount <= maxCount) {
+                    listener.onResponse(new HashSet<>());
+                    return;
                 }
 
-                if (hits.length == CONTAINER_PAGE_SIZE) {
-                    Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
-                    identifyCountBasedPage(containerId, sessionIndex, maxCount, expiredIds, currentSeen, nextSearchAfter, listener);
-                } else {
-                    listener.onResponse(expiredIds);
-                }
+                int excess = (int) (totalCount - maxCount);
+                // Step 2: search for oldest excess sessions by created_time ASC
+                collectOldestDocIds(sessionIndex, containerId, CREATED_TIME_FIELD, excess, listener);
             }, listener::onFailure));
         }
     }
@@ -734,6 +753,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] container={} cascade deleting working memory for session ids={}", containerId, batch);
+        }
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingMemoryIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -742,7 +764,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + ".session_id", batch))
+                    .must(buildSessionIdMatchQuery(batch))
             );
         dbq.setRefresh(true);
 
@@ -777,6 +799,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] index={} deleting session ids={}", sessionIndex, batch);
+        }
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
@@ -799,22 +824,22 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeLongTermRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
         if (longTermIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.LONG_TERM)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule rule = retentionPolicy.get(MemoryType.LONG_TERM);
         if (rule == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
@@ -823,11 +848,12 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 executeLongTermMaxCount(longTermIndex, containerId, rule.getMaxCount(), ActionListener.wrap(countDeleted -> {
                     long total = (timeDeleted != null ? timeDeleted : 0L) + countDeleted;
                     log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
-                    listener.onResponse(null);
+                    listener.onResponse(total > 0);
                 }, listener::onFailure));
             } else {
-                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, timeDeleted != null ? timeDeleted : 0L);
-                listener.onResponse(null);
+                long total = timeDeleted != null ? timeDeleted : 0L;
+                log.info("[MemoryRetentionJob] container={} long_term_deleted={}", containerId, total);
+                listener.onResponse(total > 0);
             }
         }, listener::onFailure);
 
@@ -840,6 +866,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private void executeLongTermRetentionDays(String longTermIndex, String containerId, int retentionDays, ActionListener<Long> listener) {
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} long_term retention_days DBQ index={} cutoffMillis={}",
+                containerId,
+                longTermIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(longTermIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -975,6 +1008,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] index={} deleting doc ids={}", index, batch);
+        }
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
@@ -998,22 +1034,22 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
     }
 
-    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeHistoryRetention(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         String historyIndex = config.getIndexName(MemoryType.HISTORY);
         if (historyIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
         if (retentionPolicy == null || !retentionPolicy.containsKey(MemoryType.HISTORY)) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         RetentionRule rule = retentionPolicy.get(MemoryType.HISTORY);
         if (rule == null || rule.getMaxCount() == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
@@ -1039,7 +1075,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 long totalCount = countResponse.getHits().getTotalHits().value();
                 if (totalCount <= maxCount) {
                     log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
-                    listener.onResponse(null);
+                    listener.onResponse(false);
                     return;
                 }
 
@@ -1048,33 +1084,40 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 collectOldestDocIds(historyIndex, containerId, CREATED_TIME_FIELD, excess, ActionListener.wrap(idsToDelete -> {
                     if (idsToDelete.isEmpty()) {
                         log.info("[MemoryRetentionJob] container={} history_deleted=0", containerId);
-                        listener.onResponse(null);
+                        listener.onResponse(false);
                         return;
                     }
                     // Step 3: bulk delete those IDs
                     deleteDocumentsBatch(historyIndex, new ArrayList<>(idsToDelete), ActionListener.wrap(deleted -> {
                         log.info("[MemoryRetentionJob] container={} history_deleted={}", containerId, deleted);
-                        listener.onResponse(null);
+                        listener.onResponse(deleted > 0);
                     }, listener::onFailure));
                 }, listener::onFailure));
             }, listener::onFailure));
         }
     }
 
-    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+    private void executeWorkingMemoryTTL(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
         if (!config.isDisableSession()) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         String workingIndex = config.getIndexName(MemoryType.WORKING);
         if (workingIndex == null) {
-            listener.onResponse(null);
+            listener.onResponse(false);
             return;
         }
 
         int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} working_memory TTL DBQ index={} cutoffMillis={}",
+                containerId,
+                workingIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1092,7 +1135,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
             client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
                 log.info("[MemoryRetentionJob] container={} working_memory_ttl_deleted={}", containerId, response.getDeleted());
-                listener.onResponse(null);
+                listener.onResponse(response.getDeleted() > 0);
             }, listener::onFailure));
         }
     }
@@ -1262,33 +1305,80 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         ActionListener<Void> listener
     ) {
         Set<String> sessionIds = new HashSet<>();
-        enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, ActionListener.wrap(collectedIds -> {
-            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
-                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
-                    log
-                        .info(
-                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
-                            containerId,
-                            orphansDeleted,
-                            nullDeleted
-                        );
-                    listener.onResponse(null);
-                }, listener::onFailure));
-            }, listener::onFailure);
+        String startKey = randomEnumerationStartKey();
+        enumerateSessionIdsFromWorkingMemory(
+            workingIndex,
+            containerId,
+            sessionIds,
+            Map.of(SESSION_ID_FIELD, startKey),
+            startKey,
+            false,
+            ActionListener
+                .wrap(
+                    aggregatedIds -> enumerateLegacySessionIdsFromWorkingMemory(
+                        workingIndex,
+                        containerId,
+                        aggregatedIds,
+                        new Object[] { startKey },
+                        startKey,
+                        false,
+                        ActionListener.wrap(collectedIds -> {
+                            ActionListener<Long> afterOrphans = ActionListener.wrap(orphansDeleted -> {
+                                deleteEmptyNamespaceWorkingMemory(containerId, workingIndex, ActionListener.wrap(nullDeleted -> {
+                                    log
+                                        .info(
+                                            "[MemoryRetentionJob] container={} orphans_deleted={} empty_namespace_deleted={}",
+                                            containerId,
+                                            orphansDeleted,
+                                            nullDeleted
+                                        );
+                                    listener.onResponse(null);
+                                }, listener::onFailure));
+                            }, listener::onFailure);
 
-            if (collectedIds.isEmpty()) {
-                afterOrphans.onResponse(0L);
-            } else {
-                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
-            }
-        }, listener::onFailure));
+                            if (collectedIds.isEmpty()) {
+                                afterOrphans.onResponse(0L);
+                            } else {
+                                checkAndDeleteOrphans(containerId, workingIndex, sessionsIndex, collectedIds, afterOrphans);
+                            }
+                        }, listener::onFailure)
+                    ),
+                    listener::onFailure
+                )
+        );
     }
 
+    /**
+     * Generates a random keyspace position to start orphan enumeration from. Enumeration begins at
+     * this key, wraps around to the start of the keyspace once exhausted, and stops when it reaches
+     * the start key again. A single run still achieves full coverage when under the cap, but when
+     * ORPHAN_SESSION_ID_CAP truncates enumeration, each run truncates a different keyspace slice so
+     * all regions are probabilistically covered across runs.
+     */
+    private String randomEnumerationStartKey() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder(ORPHAN_START_KEY_LENGTH);
+        for (int i = 0; i < ORPHAN_START_KEY_LENGTH; i++) {
+            key.append(ORPHAN_KEYSPACE_ALPHABET.charAt(random.nextInt(ORPHAN_KEYSPACE_ALPHABET.length())));
+        }
+        return key.toString();
+    }
+
+    /**
+     * Enumerates distinct session IDs from working memory via a paged composite aggregation on the
+     * top-level {@code session_id} keyword field. Cost is proportional to the number of unique
+     * sessions rather than total documents. Pre-upgrade documents lack the top-level field (the
+     * {@code namespace} field is flat_object and cannot be aggregated) and are picked up separately
+     * by {@link #enumerateLegacySessionIdsFromWorkingMemory}. Enumeration starts at a per-run random
+     * key and wraps around so the ORPHAN_SESSION_ID_CAP truncates a different slice each run.
+     */
     private void enumerateSessionIdsFromWorkingMemory(
         String workingIndex,
         String containerId,
         Set<String> sessionIds,
-        Object[] searchAfterValues,
+        Map<String, Object> afterKey,
+        String startKey,
+        boolean wrapped,
         ActionListener<Set<String>> listener
     ) {
         SearchRequest request = new SearchRequest(workingIndex);
@@ -1296,7 +1386,95 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         BoolQueryBuilder query = QueryBuilders
             .boolQuery()
+            .must(QueryBuilders.existsQuery(SESSION_ID_FIELD))
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
+
+        CompositeAggregationBuilder aggregation = new CompositeAggregationBuilder(
+            SESSION_IDS_AGG_NAME,
+            List.of(new TermsValuesSourceBuilder(SESSION_ID_FIELD).field(SESSION_ID_FIELD))
+        ).size(ORPHAN_SESSION_BATCH_SIZE);
+
+        if (afterKey != null) {
+            aggregation.aggregateAfter(afterKey);
+        }
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(query).size(0).aggregation(aggregation);
+        request.source(sourceBuilder);
+
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client.search(request, ActionListener.wrap(response -> {
+                CompositeAggregation composite = response.getAggregations() != null
+                    ? response.getAggregations().get(SESSION_IDS_AGG_NAME)
+                    : null;
+                if (composite == null) {
+                    listener.onResponse(sessionIds);
+                    return;
+                }
+
+                for (CompositeAggregation.Bucket bucket : composite.getBuckets()) {
+                    Object sessionId = bucket.getKey().get(SESSION_ID_FIELD);
+                    if (sessionId != null) {
+                        if (wrapped && sessionId.toString().compareTo(startKey) > 0) {
+                            listener.onResponse(sessionIds);
+                            return;
+                        }
+                        sessionIds.add(sessionId.toString());
+                    }
+
+                    if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+                        log
+                            .warn(
+                                "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
+                                    + " Remaining orphans will be covered in future runs.",
+                                containerId,
+                                ORPHAN_SESSION_ID_CAP
+                            );
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+                }
+
+                Map<String, Object> nextAfterKey = composite.afterKey();
+                if (composite.getBuckets().size() == ORPHAN_SESSION_BATCH_SIZE && nextAfterKey != null) {
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextAfterKey, startKey, wrapped, listener);
+                } else if (!wrapped) {
+                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, startKey, true, listener);
+                } else {
+                    listener.onResponse(sessionIds);
+                }
+            }, listener::onFailure));
+        }
+    }
+
+    /**
+     * Backward-compatibility enumeration for pre-upgrade working-memory documents that were indexed
+     * before the top-level {@code session_id} field existed. Scans only documents that have
+     * {@code namespace.session_id} but lack the top-level field, so its cost shrinks to zero as
+     * legacy documents are cleaned up. Like the aggregation path, scanning starts at the per-run
+     * random key in {@code _id} order and wraps around so cap truncation covers a different slice
+     * each run.
+     */
+    private void enumerateLegacySessionIdsFromWorkingMemory(
+        String workingIndex,
+        String containerId,
+        Set<String> sessionIds,
+        Object[] searchAfterValues,
+        String startKey,
+        boolean wrapped,
+        ActionListener<Set<String>> listener
+    ) {
+        if (sessionIds.size() >= ORPHAN_SESSION_ID_CAP) {
+            listener.onResponse(sessionIds);
+            return;
+        }
+
+        SearchRequest request = new SearchRequest(workingIndex);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
             .must(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+            .mustNot(QueryBuilders.existsQuery(SESSION_ID_FIELD))
             .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId));
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
@@ -1316,6 +1494,11 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 SearchHit[] hits = response.getHits().getHits();
 
                 for (SearchHit hit : hits) {
+                    if (wrapped && hit.getId().compareTo(startKey) > 0) {
+                        listener.onResponse(sessionIds);
+                        return;
+                    }
+
                     Map<String, Object> source = hit.getSourceAsMap();
                     if (source != null) {
                         @SuppressWarnings("unchecked")
@@ -1332,7 +1515,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                         log
                             .warn(
                                 "[MemoryRetentionJob] container={} session_id cap ({}) reached during orphan enumeration."
-                                    + " Remaining orphans will be caught on next run.",
+                                    + " Remaining orphans will be covered in future runs.",
                                 containerId,
                                 ORPHAN_SESSION_ID_CAP
                             );
@@ -1343,7 +1526,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
                 if (hits.length == ORPHAN_ENUMERATION_PAGE_SIZE) {
                     Object[] nextSearchAfter = hits[hits.length - 1].getSortValues();
-                    enumerateSessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, nextSearchAfter, listener);
+                    enumerateLegacySessionIdsFromWorkingMemory(
+                        workingIndex,
+                        containerId,
+                        sessionIds,
+                        nextSearchAfter,
+                        startKey,
+                        wrapped,
+                        listener
+                    );
+                } else if (!wrapped) {
+                    enumerateLegacySessionIdsFromWorkingMemory(workingIndex, containerId, sessionIds, null, startKey, true, listener);
                 } else {
                     listener.onResponse(sessionIds);
                 }
@@ -1453,6 +1646,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
 
         List<String> batch = batches.get(batchIndex);
+        if (log.isDebugEnabled()) {
+            log.debug("[MemoryRetentionJob] container={} deleting orphaned working memory for session ids={}", containerId, batch);
+        }
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1461,7 +1657,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
-                    .must(QueryBuilders.termsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD, batch))
+                    .must(buildSessionIdMatchQuery(batch))
             );
         dbq.setRefresh(true);
 
@@ -1476,6 +1672,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private void deleteEmptyNamespaceWorkingMemory(String containerId, String workingIndex, ActionListener<Long> listener) {
         int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
         long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(orphanTtlDays);
+        log
+            .debug(
+                "[MemoryRetentionJob] container={} empty_namespace DBQ index={} cutoffMillis={}",
+                containerId,
+                workingIndex,
+                cutoffMillis
+            );
 
         DeleteByQueryRequest dbq = new DeleteByQueryRequest(workingIndex);
         dbq.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -1486,6 +1689,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 QueryBuilders
                     .boolQuery()
                     .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+                    .mustNot(QueryBuilders.existsQuery(SESSION_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + USER_ID_FIELD))
                     .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + AGENT_ID_FIELD))

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -15,6 +15,10 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PINNED_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_POLICY_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.SESSION_ID_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
@@ -24,6 +28,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MUL
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +39,7 @@ import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.unit.TimeValue;
@@ -121,12 +127,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
         request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-        BoolQueryBuilder query = QueryBuilders
-            .boolQuery()
-            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD));
-
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(query)
+            .query(QueryBuilders.matchAllQuery())
             .size(CONTAINER_PAGE_SIZE)
             .sort("_id", SortOrder.ASC)
             .fetchSource(true);
@@ -205,30 +207,97 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             parser.nextToken();
             MemoryConfiguration config = MemoryConfiguration.parse(parser);
 
-            executeSessionRetention(
-                config,
-                containerId,
-                ActionListener
-                    .wrap(
-                        v -> executeLongTermRetention(
-                            config,
-                            containerId,
-                            ActionListener
-                                .wrap(
-                                    v2 -> executeHistoryRetention(
-                                        config,
-                                        containerId,
-                                        ActionListener
-                                            .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
-                                    ),
-                                    listener::onFailure
-                                )
-                        ),
-                        listener::onFailure
-                    )
-            );
+            Map<MemoryType, RetentionRule> retentionPolicy = config.getRetentionPolicy();
+            if (retentionPolicy == null || retentionPolicy.isEmpty()) {
+                if (config.isRetentionPolicyExplicitlyNull()) {
+                    log.debug("Container [{}] explicitly opted out of retention, skipping", containerId);
+                    listener.onResponse(null);
+                    return;
+                }
+                applyDefaultRetentionPolicy(config, containerId, ActionListener.wrap(v -> {
+                    executeRetentionPipeline(config, containerId, listener);
+                }, listener::onFailure));
+            } else {
+                executeRetentionPipeline(config, containerId, listener);
+            }
         } catch (Exception e) {
             log.error("Error parsing configuration for container [{}]", containerId, e);
+            listener.onResponse(null);
+        }
+    }
+
+    private void executeRetentionPipeline(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        executeSessionRetention(
+            config,
+            containerId,
+            ActionListener
+                .wrap(
+                    v -> executeLongTermRetention(
+                        config,
+                        containerId,
+                        ActionListener
+                            .wrap(
+                                v2 -> executeHistoryRetention(
+                                    config,
+                                    containerId,
+                                    ActionListener
+                                        .wrap(v3 -> executeWorkingMemoryTTL(config, containerId, listener), listener::onFailure)
+                                ),
+                                listener::onFailure
+                            )
+                    ),
+                    listener::onFailure
+                )
+        );
+    }
+
+    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Void> listener) {
+        int sessionRetentionDays = ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS.get(clusterService.getSettings());
+        int sessionMaxCount = ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT.get(clusterService.getSettings());
+        int longTermMaxCount = ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT.get(clusterService.getSettings());
+        int historyMaxCount = ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT.get(clusterService.getSettings());
+
+        Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
+        defaultPolicy.put(MemoryType.SESSIONS, new RetentionRule(sessionRetentionDays, sessionMaxCount));
+        defaultPolicy.put(MemoryType.LONG_TERM, new RetentionRule(null, longTermMaxCount));
+        defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+
+        config.setRetentionPolicy(defaultPolicy);
+
+        log.info(
+            "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
+            containerId,
+            sessionMaxCount,
+            sessionRetentionDays,
+            longTermMaxCount,
+            historyMaxCount
+        );
+
+        try {
+            XContentBuilder policyBuilder = XContentFactory.jsonBuilder().startObject();
+            policyBuilder.startObject(RETENTION_POLICY_FIELD);
+            for (Map.Entry<MemoryType, RetentionRule> entry : defaultPolicy.entrySet()) {
+                policyBuilder.field(entry.getKey().getValue());
+                entry.getValue().toXContent(policyBuilder, null);
+            }
+            policyBuilder.endObject();
+            policyBuilder.endObject();
+
+            UpdateRequest updateRequest = new UpdateRequest(ML_MEMORY_CONTAINER_INDEX, containerId)
+                .doc(Map.of(MEMORY_STORAGE_CONFIG_FIELD, XContentHelper.convertToMap(BytesReference.bytes(policyBuilder), false, XContentType.JSON).v2()))
+                .retryOnConflict(3);
+
+            try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+                client.update(updateRequest, ActionListener.wrap(response -> {
+                    log.debug("Successfully persisted default retention policy on container [{}]", containerId);
+                    listener.onResponse(null);
+                }, e -> {
+                    log.warn("Failed to persist default retention policy on container [{}], proceeding with in-memory defaults", containerId, e);
+                    listener.onResponse(null);
+                }));
+            }
+        } catch (Exception e) {
+            log.warn("Failed to build default retention policy for container [{}], proceeding with in-memory defaults", containerId, e);
             listener.onResponse(null);
         }
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1436,7 +1436,11 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_MAX_JSON_SIZE,
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
-                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED
+                MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1437,10 +1437,15 @@ public class MachineLearningPlugin extends Plugin
                 MLCommonsSettings.ML_COMMONS_UNIFIED_AGENT_API_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MCP_HEADER_PASSTHROUGH_ENABLED,
                 MLCommonsSettings.ML_COMMONS_AG_UI_ENABLED,
+                MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                 MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                 MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
                 MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
-                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
             );
         return settings;
     }

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.MINUTES), // DEMO: changed from HOURS to MINUTES
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
@@ -41,6 +43,7 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
@@ -591,6 +594,7 @@ public class MLTaskManager implements SettingsChangeListener {
                 .index(CommonValue.ML_JOBS_INDEX)
                 .id(MLJobType.MEMORY_RETENTION.name())
                 .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .opType(DocWriteRequest.OpType.CREATE)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
             indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
@@ -655,7 +659,17 @@ public class MLTaskManager implements SettingsChangeListener {
                         if (successCallback != null) {
                             successCallback.run();
                         }
-                    }, e -> log.error("Failed to index {} job", jobType.name(), e)), context::restore));
+                    }, e -> {
+                        if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
+                            // The job document already exists (created by this or another node); treat as success
+                            log.debug("{} job already exists, skipping creation", jobType.name());
+                            if (successCallback != null) {
+                                successCallback.run();
+                            }
+                        } else {
+                            log.error("Failed to index {} job", jobType.name(), e);
+                        }
+                    }), context::restore));
                 }
             }
         }, e -> log.error("Failed to initialize ML jobs index", e)));

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -571,7 +571,7 @@ public class MLTaskManager implements SettingsChangeListener {
         }
     }
 
-    public void indexMemoryRetentionJob() {
+    public void indexMemoryRetentionJob(int intervalHours) {
         if (this.memoryRetentionJobStarted) {
             log.debug("Memory retention job already started");
             return;
@@ -580,7 +580,7 @@ public class MLTaskManager implements SettingsChangeListener {
         try {
             MLJobParameter jobParameter = new MLJobParameter(
                 MLJobType.MEMORY_RETENTION.name(),
-                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
                 120L,
                 null,
                 MLJobType.MEMORY_RETENTION,

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -84,6 +84,7 @@ public class MLTaskManager implements SettingsChangeListener {
     private final Map<MLTaskType, AtomicInteger> runningTasksCount;
     private boolean taskPollingJobStarted;
     private boolean statsCollectorJobStarted;
+    private boolean memoryRetentionJobStarted;
     public static final ImmutableSet<MLTaskState> TASK_DONE_STATES = ImmutableSet
         .of(MLTaskState.COMPLETED, MLTaskState.COMPLETED_WITH_ERROR, MLTaskState.FAILED, MLTaskState.CANCELLED);
 
@@ -567,6 +568,37 @@ public class MLTaskManager implements SettingsChangeListener {
             indexJob(indexRequest, MLJobType.BATCH_TASK_UPDATE, () -> this.taskPollingJobStarted = true);
         } catch (IOException e) {
             log.error("Failed to index task polling job", e);
+        }
+    }
+
+    public void indexMemoryRetentionJob() {
+        if (this.memoryRetentionJobStarted) {
+            log.debug("Memory retention job already started");
+            return;
+        }
+
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), 24, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.debug("Memory retention job started successfully");
+            });
+        } catch (IOException e) {
+            log.error("Failed to index memory retention job", e);
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -1939,7 +1939,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(captor.getValue().getMessage().contains("Internal server error"));
     }
 
-    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    @Test
     public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
         // Create config with retention_policy to verify it passes through
         Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
@@ -1992,6 +1992,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -21,6 +21,7 @@ import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,8 @@ import org.opensearch.ml.common.MLModel;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -1937,6 +1940,58 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
     }
 
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
+    public void testDoExecuteSuccess_WithRetentionPolicy() throws InterruptedException {
+        // Create config with retention_policy to verify it passes through
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).maxCount(100).build());
+        retentionPolicy.put(MemoryType.LONG_TERM, RetentionRule.builder().maxCount(500).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration configWithRetention = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput retentionInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("retention-container")
+            .description("Container with retention policy")
+            .configuration(configWithRetention)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest retentionRequest = new MLCreateMemoryContainerRequest(retentionInput);
+
+        mockSuccessfulCreatePipeline();
+        mockAndRunExecuteMethod(retentionRequest);
+
+        // Verify the configuration retains the retention policy
+        assertNotNull(configWithRetention.getRetentionPolicy());
+        assertEquals(2, configWithRetention.getRetentionPolicy().size());
+        assertEquals(Integer.valueOf(30), configWithRetention.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+    }
+
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model
         MLModel llmModel = mock(MLModel.class);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -2009,6 +2009,472 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         assertEquals(Integer.valueOf(500), configWithRetention.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
     }
 
+    @Test
+    public void testBuildMemoryContainer_StrategyWithNullIdAndEnabled() throws InterruptedException {
+        // Test that strategies without an ID get one generated, and null enabled defaults to true
+        MemoryStrategy strategyNoId = MemoryStrategy
+            .builder()
+            .namespace(List.of(SESSION_ID_FIELD))
+            .type(MemoryStrategyType.SEMANTIC)
+            .build(); // No id, no enabled
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies.add(strategyNoId);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("auto-id-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        // Verify the strategy now has an auto-generated ID and enabled=true
+        assertNotNull(strategyNoId.getId());
+        assertFalse(strategyNoId.getId().isBlank());
+        assertEquals(Boolean.TRUE, strategyNoId.getEnabled());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_StrategyWithBlankId() throws InterruptedException {
+        // Test that strategies with blank ID also get one generated
+        MemoryStrategy strategyBlankId = MemoryStrategy
+            .builder()
+            .namespace(List.of(SESSION_ID_FIELD))
+            .id("   ") // blank
+            .enabled(true)
+            .type(MemoryStrategyType.SEMANTIC)
+            .build();
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies.add(strategyBlankId);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("blank-id-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        // Verify the blank ID was replaced
+        assertNotNull(strategyBlankId.getId());
+        assertFalse(strategyBlankId.getId().isBlank());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_AutoApplyRetentionFromClusterSettings() throws InterruptedException {
+        // Test that default retention policy is auto-applied from cluster settings
+        // when user doesn't specify one
+        Settings settingsWithRetention = Settings
+            .builder()
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", 1000)
+            .build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Configuration WITHOUT retention policy
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .maxInferSize(5)
+            .strategies(strategies)
+            .build(); // No retentionPolicy set
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("auto-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify retention policy was auto-applied
+        assertNotNull(config.getRetentionPolicy());
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.SESSIONS));
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.LONG_TERM));
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.HISTORY));
+        assertEquals(Integer.valueOf(30), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(100), config.getRetentionPolicy().get(MemoryType.SESSIONS).getMaxCount());
+        assertEquals(Integer.valueOf(500), config.getRetentionPolicy().get(MemoryType.LONG_TERM).getMaxCount());
+        assertEquals(Integer.valueOf(1000), config.getRetentionPolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_AutoApplyRetention_OnlySessionDays() throws InterruptedException {
+        // Test partial cluster settings: only session_retention_days is set
+        Settings settingsWithRetention = Settings.builder().put("plugins.ml_commons.memory.default_session_retention_days", 14).build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .build(); // No retentionPolicy, no strategies
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("partial-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify only SESSIONS rule was created (with retentionDays only, no maxCount)
+        assertNotNull(config.getRetentionPolicy());
+        assertTrue(config.getRetentionPolicy().containsKey(MemoryType.SESSIONS));
+        assertFalse(config.getRetentionPolicy().containsKey(MemoryType.LONG_TERM));
+        assertFalse(config.getRetentionPolicy().containsKey(MemoryType.HISTORY));
+        assertEquals(Integer.valueOf(14), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertNull(config.getRetentionPolicy().get(MemoryType.SESSIONS).getMaxCount());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NoAutoApplyRetention_WhenExplicitlyNull() throws InterruptedException {
+        // Test that retention policy is NOT auto-applied when user explicitly set it to null
+        Settings settingsWithRetention = Settings
+            .builder()
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .build()
+        );
+        // Simulate user explicitly passing "retention_policy": null
+        when(config.isRetentionPolicyExplicitlyNull()).thenReturn(true);
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("no-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify retention policy was NOT applied
+        assertNull(config.getRetentionPolicy());
+    }
+
+    @Test
+    public void testEmitDisableSessionRetentionWarning_WithDisableSessionAndSessionsRetention() throws InterruptedException {
+        // Test that warning is emitted when disableSession=true and SESSIONS retention is set
+        Map<MemoryType, RetentionRule> retentionPolicy = new EnumMap<>(MemoryType.class);
+        retentionPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(30).build());
+
+        List<MemoryStrategy> strategies = new ArrayList<>();
+        strategies
+            .add(
+                MemoryStrategy
+                    .builder()
+                    .namespace(List.of(SESSION_ID_FIELD))
+                    .id("strategy-id1")
+                    .enabled(true)
+                    .type(MemoryStrategyType.SEMANTIC)
+                    .build()
+            );
+
+        MemoryConfiguration config = spy(
+            MemoryConfiguration
+                .builder()
+                .indexPrefix("test-memory-index")
+                .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+                .embeddingModelId("test-embedding-model")
+                .llmId("test-llm-model")
+                .dimension(768)
+                .maxInferSize(5)
+                .strategies(strategies)
+                .retentionPolicy(retentionPolicy)
+                .disableSession(true)
+                .build()
+        );
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("disable-session-with-retention")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulCreatePipeline();
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        // Test passes if no exception is thrown - warning is emitted via HeaderWarning
+        verify(actionListener).onResponse(responseCaptor.capture());
+        assertNotNull(responseCaptor.getValue());
+
+        // Acknowledge the expected warning to satisfy OpenSearchTestCase's ensureNoWarnings check
+        assertWarnings(
+            "sessions retention_policy has no effect when disableSession=true;"
+                + " working memory TTL is governed by cluster setting plugins.ml_commons.memory.working_memory_ttl_days"
+        );
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NullConfiguration() throws InterruptedException {
+        // Test when configuration is null (edge case)
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("null-config-container")
+            .configuration(null)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        // When config is null, validation should still work (no strategies, no models to validate)
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        // Depending on implementation, may fail or succeed. The goal is to hit the null config branch.
+        // Either onResponse or onFailure is fine as long as we exercise the code path
+    }
+
+    @Test
+    public void testBuildMemoryContainer_NullStrategies() throws InterruptedException {
+        // Test when configuration has null strategies (different from empty list)
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .strategies(null)
+            .build();
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("null-strategies-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+        assertNotNull(responseCaptor.getValue());
+    }
+
+    @Test
+    public void testBuildMemoryContainer_ExistingRetentionNotOverwritten() throws InterruptedException {
+        // Test that auto-apply does NOT overwrite an already-set retention policy
+        Settings settingsWithRetention = Settings.builder().put("plugins.ml_commons.memory.default_session_retention_days", 30).build();
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithRetention, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Config with EXISTING retention policy
+        Map<MemoryType, RetentionRule> existingPolicy = new EnumMap<>(MemoryType.class);
+        existingPolicy.put(MemoryType.SESSIONS, RetentionRule.builder().retentionDays(7).build());
+
+        MemoryConfiguration config = MemoryConfiguration
+            .builder()
+            .indexPrefix("test-memory-index")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("test-embedding-model")
+            .llmId("test-llm-model")
+            .dimension(768)
+            .retentionPolicy(existingPolicy)
+            .build();
+
+        MLCreateMemoryContainerInput testInput = MLCreateMemoryContainerInput
+            .builder()
+            .name("existing-retention-container")
+            .configuration(config)
+            .tenantId(TENANT_ID)
+            .build();
+
+        MLCreateMemoryContainerRequest testRequest = new MLCreateMemoryContainerRequest(testInput);
+
+        mockSuccessfulModelValidation();
+        mockSuccessfulIndexCreation();
+
+        CompletableFuture<PutDataObjectResponse> future = CompletableFuture.completedFuture(putDataObjectResponse);
+        when(sdkClient.putDataObjectAsync(any(PutDataObjectRequest.class))).thenReturn(future);
+
+        action.doExecute(task, testRequest, actionListener);
+
+        verify(actionListener).onResponse(responseCaptor.capture());
+
+        // Verify existing policy was NOT overwritten - still 7 days, not 30
+        assertEquals(Integer.valueOf(7), config.getRetentionPolicy().get(MemoryType.SESSIONS).getRetentionDays());
+    }
+
     // Helper method to mock successful LLM validation (without embedding validation which will be tested)
     private void mockSuccessfulLLMValidation() {
         // Mock valid LLM model

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -51,6 +51,8 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.ConfigConstants;
@@ -68,6 +70,7 @@ import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
 import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerInput;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerRequest;
@@ -153,6 +156,18 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         when(clusterService.getSettings()).thenReturn(settings);
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet);
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         // Setup admin client chain
         when(client.admin()).thenReturn(adminClient);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportCreateMemoryContainerActionTests.java
@@ -152,6 +152,7 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
         threadContext = new ThreadContext(settings);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(clusterService.getSettings()).thenReturn(settings);
 
         // Setup admin client chain
         when(client.admin()).thenReturn(adminClient);
@@ -228,7 +229,8 @@ public class TransportCreateMemoryContainerActionTests extends OpenSearchTestCas
             mlIndicesHandler,
             connectorAccessControlHelper,
             mlFeatureEnabledSetting,
-            mlModelManager
+            mlModelManager,
+            clusterService
         );
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -166,17 +166,36 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
-    public void testDoExecute_BlankMemoryContainerId() {
+    public void testDoExecute_PinnedFieldRejected() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
-        
+
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
-        when(input.getMemoryContainerId()).thenReturn("");
-        
+        when(input.getPinned()).thenReturn(true);
+
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
         when(request.getMlAddMemoryInput()).thenReturn(input);
-        
+
         transportAddMemoriesAction.doExecute(task, request, actionListener);
-        
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(captor.capture());
+        assert captor.getValue() instanceof OpenSearchStatusException;
+        assert captor.getValue().getMessage().contains("pinned field is not supported for working memory type");
+    }
+
+    @Test
+    public void testDoExecute_BlankMemoryContainerId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("");
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
         verify(actionListener).onFailure(any(IllegalArgumentException.class));
     }
 
@@ -185,6 +204,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -213,6 +233,7 @@ public class TransportAddMemoriesActionTests {
         List<MessageInput> messages = Arrays.asList(message);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -248,6 +269,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -300,6 +322,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -348,6 +371,7 @@ public class TransportAddMemoriesActionTests {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         
         MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
@@ -382,6 +406,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "session-123");
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -431,6 +456,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id in namespace
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -485,6 +511,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -556,6 +583,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - should trigger session creation
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -613,6 +641,7 @@ public class TransportAddMemoriesActionTests {
         namespace.put("session_id", "existing-session-123"); // User provided session_id
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -664,6 +693,7 @@ public class TransportAddMemoriesActionTests {
         // No session_id - would normally trigger session creation, but getLlmId() is null
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -715,6 +745,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);
@@ -773,6 +804,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -831,6 +863,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -890,6 +923,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -949,6 +983,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1014,6 +1049,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy2);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1071,6 +1107,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(disabledStrategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1128,6 +1165,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1184,6 +1222,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1250,6 +1289,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1335,6 +1375,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1430,6 +1471,7 @@ public class TransportAddMemoriesActionTests {
         strategies.add(strategy);
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(true);
@@ -1498,6 +1540,7 @@ public class TransportAddMemoriesActionTests {
         Map<String, String> namespace = new HashMap<>();
 
         MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
         when(input.getMemoryContainerId()).thenReturn("container-123");
         when(input.getMessages()).thenReturn(messages);
         when(input.isInfer()).thenReturn(false);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.ml.action.memorycontainer.memory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -308,6 +310,112 @@ public class TransportAddMemoriesActionTests {
         // Verify the full flow
         verify(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
         verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testDoExecute_WorkingMemoryIndexedWithTopLevelSessionId() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-123");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-123");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), requestCaptor.capture(), any());
+
+        Map<String, Object> source = requestCaptor.getValue().sourceAsMap();
+        assertEquals("session-123", source.get("session_id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> indexedNamespace = (Map<String, Object>) source.get("namespace");
+        assertEquals("session-123", indexedNamespace.get("session_id"));
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testDoExecute_WorkingMemoryIndexedWithoutSessionIdOmitsTopLevelField() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("agent_id", "agent-1");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.isDisableSession()).thenReturn(true);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-123");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(memoryContainerHelper).indexData(any(MemoryConfiguration.class), requestCaptor.capture(), any());
+
+        Map<String, Object> source = requestCaptor.getValue().sourceAsMap();
+        assertFalse(source.containsKey("session_id"));
         verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
     }
 
@@ -1587,5 +1695,185 @@ public class TransportAddMemoriesActionTests {
         verify(actionListener).onFailure(argThat(exception -> exception instanceof OpenSearchStatusException
             && ((OpenSearchStatusException)exception).status() == RestStatus.BAD_REQUEST
             && exception.getMessage().contains("LLM predict result cannot be extracted")));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_ExistingSession() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-existing");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-456");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        org.opensearch.action.update.UpdateResponse updateResponse = mock(org.opensearch.action.update.UpdateResponse.class);
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(client).update(argThat(req -> {
+            org.opensearch.action.update.UpdateRequest updateReq = (org.opensearch.action.update.UpdateRequest) req;
+            return "session-index".equals(updateReq.index()) && "session-existing".equals(updateReq.id());
+        }), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_NewlyCreatedSession_NoBump() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("container-123");
+        when(input.getMessages()).thenReturn(Arrays.asList(message));
+        when(input.isInfer()).thenReturn(false);
+        when(input.getNamespace()).thenReturn(namespace);
+        when(input.getOwnerId()).thenReturn("user-123");
+        when(input.getPayloadType()).thenReturn(PayloadType.CONVERSATIONAL);
+        when(input.getParameters()).thenReturn(new HashMap<>());
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+        when(config.getLlmId()).thenReturn("llm-model");
+        when(config.getStrategies()).thenReturn(
+            Arrays.asList(MemoryStrategy.builder().type(MemoryStrategyType.SUMMARY).build())
+        );
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onResponse("Summary text");
+            return null;
+        }).when(memoryProcessingService).summarizeMessages(any(), eq(config), any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("new-session-id");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(client, org.mockito.Mockito.never()).update(
+            any(org.opensearch.action.update.UpdateRequest.class), any()
+        );
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+    }
+
+    @Test
+    public void testSessionLastUpdatedTimeBump_FailureDoesNotFailResponse() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello world")).role("user").build();
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("session_id", "session-bump-fail");
+
+        MLAddMemoriesInput input = MLAddMemoriesInput
+            .builder()
+            .memoryContainerId("container-123")
+            .messages(Arrays.asList(message))
+            .namespace(namespace)
+            .build();
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            when(indexResponse.getId()).thenReturn("working-mem-789");
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("Simulated bump failure"));
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+        verify(actionListener, org.mockito.Mockito.never()).onFailure(any());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -738,14 +738,38 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
 
     @Test
     public void testConstructUpdateFields_UnknownType() {
-        // Test unknown memory type returns empty map
         Map<String, Object> updateContent = new HashMap<>();
         updateContent.put("field", "value");
         MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
 
         Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, null, new HashMap<>());
 
-        assertEquals(1, result.size()); // only last_updated_time is added for unknown types
+        assertEquals(0, result.size());
+        assertNull(result.get("last_updated_time"));
+    }
+
+    @Test
+    public void testNonContentUpdateDoesNotBumpLastUpdatedTime_Session() {
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put("tags", Map.of("tag1", "value1"));
+        updateContent.put("metadata", Map.of("key", "val"));
+        updateContent.put("additional_info", Map.of("extra", "data"));
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+
+        Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, MemoryType.SESSIONS, new HashMap<>());
+
+        assertNull(result.get("last_updated_time"));
+    }
+
+    @Test
+    public void testContentUpdateDoesBumpLastUpdatedTime_Session() {
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("summary", "New summary");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+
+        Map<String, Object> result = transportUpdateMemoryAction.constructNewDoc(input, MemoryType.SESSIONS, new HashMap<>());
+
         assertNotNull(result.get("last_updated_time"));
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportUpdateMemoryActionTests.java
@@ -795,4 +795,163 @@ public class TransportUpdateMemoryActionTests extends OpenSearchTestCase {
         verify(memoryContainerHelper, never()).indexData(any(), any(), any());
     }
 
+    @Test
+    public void testDoExecute_PinnedRejectedForWorkingMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.WORKING)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.WORKING)).thenReturn("test-working-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener, times(1)).onFailure(errorCaptor.capture());
+        Exception capturedError = errorCaptor.getValue();
+        assertTrue(capturedError instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) capturedError).status());
+        assertTrue(capturedError.getMessage().contains("pinned field is not supported for working memory type"));
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForSessionMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.SESSIONS)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.SESSIONS)).thenReturn("test-session-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            // Verify pinned field is included in the indexed document
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void testDoExecute_PinnedAcceptedForLongTermMemory() {
+        String memoryContainerId = "container-123";
+        String memoryId = "memory-456";
+        Map<String, Object> updateContent = new HashMap<>();
+        updateContent.put("pinned", true);
+        updateContent.put(MEMORY_FIELD, "some memory text");
+        MLUpdateMemoryInput input = MLUpdateMemoryInput.builder().updateContent(updateContent).build();
+        MLUpdateMemoryRequest updateRequest = MLUpdateMemoryRequest
+            .builder()
+            .memoryContainerId(memoryContainerId)
+            .memoryType(MemoryType.LONG_TERM)
+            .memoryId(memoryId)
+            .mlUpdateMemoryInput(input)
+            .build();
+
+        IndexResponse mockIndexResponse = mock(IndexResponse.class);
+        GetResponse mockGetResponse = mock(GetResponse.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("owner_id", "user-123");
+        sourceMap.put(MEMORY_FIELD, "old memory");
+        when(mockGetResponse.isExists()).thenReturn(true);
+        when(mockGetResponse.getSourceAsMap()).thenReturn(sourceMap);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(mockContainer);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq(memoryContainerId), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), eq(mockContainer))).thenReturn(true);
+        when(memoryContainerHelper.getMemoryIndexName(mockContainer, MemoryType.LONG_TERM)).thenReturn("test-lt-index");
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(mockGetResponse);
+            return null;
+        }).when(memoryContainerHelper).getData(any(), any(GetRequest.class), any());
+
+        doAnswer(invocation -> {
+            IndexRequest request = invocation.getArgument(1);
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            assertTrue(request.sourceAsMap().containsKey("pinned"));
+            assertEquals(true, request.sourceAsMap().get("pinned"));
+            listener.onResponse(mockIndexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(), any(IndexRequest.class), any());
+
+        doReturn(true).when(memoryContainerHelper).checkMemoryAccess(any(), any());
+
+        transportUpdateMemoryAction.doExecute(task, updateRequest, actionListener);
+
+        verify(actionListener, times(1)).onResponse(mockIndexResponse);
+        verify(actionListener, never()).onFailure(any());
+    }
+
 }

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.cluster;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -129,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob();
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
@@ -142,7 +143,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
@@ -154,7 +155,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
     private DiscoveryNode createDataNode(Version version) {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -130,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager).indexMemoryRetentionJob(2); // DEMO: interval is 2 minutes for local testing
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -120,6 +120,43 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexStatsCollectorJob(anyBoolean());
     }
 
+    public void testClusterChanged_MemoryRetentionJobStarted() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings())
+            .thenReturn(org.opensearch.common.settings.Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob();
+    }
+
     private DiscoveryNode createDataNode(Version version) {
         return new DiscoveryNode(
             "dataNode",

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -130,7 +130,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager).indexMemoryRetentionJob(2); // DEMO: interval is 2 minutes for local testing
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {

--- a/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/MLJobRunnerTests.java
@@ -6,16 +6,22 @@
 package org.opensearch.ml.jobs;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.helper.ConnectorAccessControlHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -78,6 +84,22 @@ public class MLJobRunnerTests {
     public void testRunJobWithDisabledJob() {
         when(jobParameter.isEnabled()).thenReturn(false);
         when(jobParameter.getJobType()).thenReturn(MLJobType.STATS_COLLECTOR);
+        jobRunner.runJob(jobParameter, jobExecutionContext);
+    }
+
+    @Test
+    public void testRunJobWithMemoryRetentionType() {
+        MemoryRetentionJobProcessor.reset();
+        when(jobParameter.isEnabled()).thenReturn(true);
+        when(jobParameter.getJobType()).thenReturn(MLJobType.MEMORY_RETENTION);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        LockService lockService = mock(LockService.class);
+        when(jobExecutionContext.getLockService()).thenReturn(lockService);
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+
         jobRunner.runJob(jobParameter, jobExecutionContext);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -6,18 +6,57 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
+@RunWith(MockitoJUnitRunner.class)
 public class MemoryRetentionJobProcessorTests {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     @Mock
     private ClusterService clusterService;
@@ -28,12 +67,34 @@ public class MemoryRetentionJobProcessorTests {
     @Mock
     private Client client;
 
+    private ThreadContext threadContext;
+
     private MemoryRetentionJobProcessor processor;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         MemoryRetentionJobProcessor.reset();
+
+        // Default settings: multi-tenancy disabled, throttle = 1 second
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        // Use real ThreadContext (it's a final class and cannot be mocked)
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        // Mock threadPool.schedule to execute immediately
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(threadPool).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+
         processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
     }
 
@@ -51,25 +112,1236 @@ public class MemoryRetentionJobProcessorTests {
 
         processor.run();
 
-        // No exception thrown, method returns early with warning log
+        // Should not search for containers when multi-tenancy is enabled
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWhenMultiTenancyDisabled() {
-        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
-        when(clusterService.getSettings()).thenReturn(settings);
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
         processor.run();
 
-        // No exception thrown, logs "Memory retention job triggered"
+        // Verify container search is initiated
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
     }
 
     @Test
     public void testRunExecutesWithDefaultSettings() {
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
 
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
         processor.run();
 
         // Default multi_tenancy_enabled is false, so job should execute
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNoContainersWithPolicy() {
+        // Container search returns empty hits -> job completes
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionTimeBased() {
+        // 1 container with retention_days=7, mock 3 expired sessions -> verify cascade + bulk delete
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-time",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns 3 expired sessions
+                SearchHit hit1 = new SearchHit(0, "expired-session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "expired-session-2", null, null);
+                SearchHit hit3 = new SearchHit(2, "expired-session-3", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2, hit3 },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory (Phase 2)
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(10L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete was called on working memory
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called on sessions
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerWithSessionRetentionCountBased() {
+        // max_count=5, 10 sessions -> verify 5 oldest deleted
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-count",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", null, 5)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = sessionSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
+                    // First 5 are kept, last 5 are expired
+                    SearchHit[] hits = new SearchHit[10];
+                    for (int i = 0; i < 10; i++) {
+                        hits[i] = new SearchHit(i, "session-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) (10 - i), "session-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify cascade delete + bulk delete both called
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testCascadeOrdering() {
+        // Verify delete_by_query (working memory) is called BEFORE bulk delete (sessions)
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-cascade",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns expired sessions
+                SearchHit hit1 = new SearchHit(0, "session-1", null, null);
+                SearchHit hit2 = new SearchHit(1, "session-2", null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2 },
+                    new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track the ordering of operations
+        AtomicInteger orderCounter = new AtomicInteger(0);
+        AtomicInteger cascadeDeleteOrder = new AtomicInteger(-1);
+        AtomicInteger bulkDeleteOrder = new AtomicInteger(-1);
+
+        // Mock cascade delete-by-query for working memory (Phase 2)
+        BulkByScrollResponse workingDeleteResponse = mock(BulkByScrollResponse.class);
+        when(workingDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(workingDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions (Phase 3)
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            bulkDeleteOrder.set(orderCounter.getAndIncrement());
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Working memory delete (cascade) must happen BEFORE session delete (bulk)
+        assertTrue(
+            "Working memory cascade delete should execute before session bulk delete",
+            cascadeDeleteOrder.get() < bulkDeleteOrder.get()
+        );
+        assertTrue("Cascade delete should have been called", cascadeDeleteOrder.get() >= 0);
+        assertTrue("Bulk delete should have been called", bulkDeleteOrder.get() >= 0);
+    }
+
+    @Test
+    public void testPinnedSessionsExcluded() {
+        // Pinned sessions older than retention_days -> not deleted
+        // The processor's query uses mustNot(pinned=true), so we verify the query contains pinned filter
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-pinned",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Verify the query excludes pinned=true
+                String queryString = request.source().query().toString();
+                assertTrue("Query should exclude pinned documents (must_not pinned:true)", queryString.contains("pinned"));
+
+                // Return empty result - all sessions are pinned and excluded
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify session search was made (with pinned exclusion)
+        verify(client, atLeast(2)).search(any(SearchRequest.class), isA(ActionListener.class));
+        // No deletions should occur since all sessions are pinned (excluded by query)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testBatching() {
+        // 600 expired sessions -> verify 2 delete_by_query calls (500 + 100) for working memory cascade
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-batch",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionPageCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Return 600 expired sessions across 6 full pages of 100, then an empty page
+                int pageNum = sessionPageCount.getAndIncrement();
+                if (pageNum < 6) {
+                    // Full page of 100 hits (triggers pagination)
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        int globalIdx = pageNum * 100 + i;
+                        hits[i] = new SearchHit(globalIdx, "session-" + globalIdx, null, null);
+                        hits[i].sortValues(new Object[] { "session-" + globalIdx }, new DocValueFormat[] { DocValueFormat.RAW });
+                    }
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                } else {
+                    // Final page: empty (terminates pagination)
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Track cascade delete calls
+        AtomicInteger cascadeDeleteCount = new AtomicInteger(0);
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(100L);
+
+        doAnswer(invocation -> {
+            cascadeDeleteCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // With 600 sessions and DELETE_BY_QUERY_BATCH_SIZE=500, expect 2 cascade delete calls
+        assertTrue("Should have at least 2 cascade delete-by-query calls for 600 sessions (batch size 500)", cascadeDeleteCount.get() >= 2);
+    }
+
+    @Test
+    public void testEmptyExpiredSet() {
+        // No sessions match retention criteria -> phases 2-3 skipped
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-empty",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions found
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify no cascade delete or bulk delete was called
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testContainerProcessingError() {
+        // One container fails -> next container still processed
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-fail", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-fail" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-success", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-success" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        // Less than page size (100) so no pagination
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                int count = sessionSearchCount.getAndIncrement();
+                if (count == 0) {
+                    // First container's session search fails
+                    listener.onFailure(new RuntimeException("Simulated search failure"));
+                } else {
+                    // Second container's session search succeeds with empty results
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify that we searched at least twice (once for each container's sessions)
+        assertTrue("Both containers should be processed, second container search made", sessionSearchCount.get() >= 2);
+    }
+
+    @Test
+    public void testNullSessionIndex() {
+        // Container with disableSession=true -> session retention skipped, but working memory TTL fires (Phase 6)
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-session", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for Phase 6 working memory TTL (disableSession=true triggers it)
+        BulkByScrollResponse ttlResponse = mock(BulkByScrollResponse.class);
+        when(ttlResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Session retention is skipped (session index is null), but Phase 6 working memory TTL fires
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // No bulk deletes (no sessions to delete, no count-based eviction)
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testMultipleContainersProcessed() {
+        // 2 containers -> both processed sequentially
+        String sourceJson1 = "{\"configuration\":{\"index_prefix\":\"prefix1\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        String sourceJson2 = "{\"configuration\":{\"index_prefix\":\"prefix2\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":30}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-1", null, null);
+        hit1.sourceRef(new BytesArray(sourceJson1));
+        hit1.sortValues(new Object[] { "container-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-2", null, null);
+        hit2.sourceRef(new BytesArray(sourceJson2));
+        hit2.sortValues(new Object[] { "container-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse containerSearchResponse = mock(SearchResponse.class);
+        SearchHits containerHits = new SearchHits(new SearchHit[] { hit1, hit2 }, new TotalHits(2, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(containerSearchResponse.getHits()).thenReturn(containerHits);
+
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                listener.onResponse(containerSearchResponse);
+            } else {
+                sessionSearchCount.incrementAndGet();
+                // Return 1 expired session for each container
+                SearchHit expiredHit = new SearchHit(0, "expired-session-" + sessionSearchCount.get(), null, null);
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { expiredHit },
+                    new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both containers should have been processed: at least 2 session searches
+        assertTrue("Both containers should be processed with session searches", sessionSearchCount.get() >= 2);
+        // Verify cascade delete was called for both containers
+        verify(client, atLeast(2)).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        // Verify bulk delete was called for both containers
+        verify(client, atLeast(2)).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 4: Long-Term Retention Tests ---
+
+    @Test
+    public void testLongTermRetentionDays() {
+        // Container with LTM policy retention_days=30 -> verify _delete_by_query on long-term index
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-days", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions (no session retention rule)
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for long-term retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(5L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            // Verify the query targets long-term index and uses last_updated_time
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Should use last_updated_time for long-term", queryString.contains("last_updated_time"));
+            assertTrue("Should exclude pinned docs", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermMaxCount() {
+        // Container with LTM policy max_count=100, 150 docs -> verify search for oldest 50 IDs + bulk delete
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=150
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(150, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 50 IDs: return 50 hits
+                    SearchHit[] hits = new SearchHit[50];
+                    for (int i = 0; i < 50; i++) {
+                        hits[i] = new SearchHit(i, "ltm-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(50, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Verify bulk delete called for the 50 excess docs
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermPinnedExclusion() {
+        // Verify mustNot(pinned=true) in long-term retention_days delete query
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-pinned", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Capture the DeleteByQueryRequest to verify pinned exclusion
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Long-term delete query should exclude pinned=true", queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNullLtmIndex() {
+        // Container without LLM/strategies -> getIndexName(LONG_TERM) returns null -> LTM phase skipped
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-llm", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query or bulk delete should fire (LTM phase skipped due to null index)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testLongTermBothRetentionDaysAndMaxCount() {
+        // Both retention_days AND max_count set -> verify both operations fire sequentially
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"retention_days\":30,\"max_count\":100}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ltm-both", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query for max_count: return 120
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(120, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 20 IDs
+                    SearchHit[] hits = new SearchHit[20];
+                    for (int i = 0; i < 20; i++) {
+                        hits[i] = new SearchHit(i, "ltm-excess-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "ltm-excess-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(20, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for retention_days
+        BulkByScrollResponse ltmDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ltmDeleteResponse.getDeleted()).thenReturn(3L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ltmDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for max_count
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Both operations should have fired
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- Phase 5: History Retention Tests ---
+
+    @Test
+    public void testHistoryMaxCount() {
+        // Container with history policy max_count=500, 600 docs -> verify search sorted by created_time ASC
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-count", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return totalHits=600
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Search for oldest 100 IDs — verify sort field is created_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History search should sort by created_time", sourceStr.contains("created_time"));
+
+                    SearchHit[] hits = new SearchHit[100];
+                    for (int i = 0; i < 100; i++) {
+                        hits[i] = new SearchHit(i, "history-doc-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "history-doc-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(100, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testHistoryUsesCreatedTime() {
+        // Verify the sort field in history search is created_time, not last_updated_time
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"history\":{\"max_count\":10}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-history-time", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+        AtomicInteger verifiedCreatedTime = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Count query: return 15 docs (exceeds max_count=10)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    // Verify sort uses created_time, NOT last_updated_time
+                    String sourceStr = request.source().toString();
+                    assertTrue("History must use created_time for sorting", sourceStr.contains("created_time"));
+                    assertTrue("History must NOT use last_updated_time", !sourceStr.contains("last_updated_time"));
+                    verifiedCreatedTime.incrementAndGet();
+
+                    SearchHit[] hits = new SearchHit[5];
+                    for (int i = 0; i < 5; i++) {
+                        hits[i] = new SearchHit(i, "hist-" + i, null, null);
+                        hits[i]
+                            .sortValues(
+                                new Object[] { (long) i, "hist-" + i },
+                                new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
+                            );
+                    }
+                    SearchHits searchHits = new SearchHits(hits, new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchResponse searchResp = mock(SearchResponse.class);
+                    when(searchResp.getHits()).thenReturn(searchHits);
+                    listener.onResponse(searchResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Should have verified created_time sort field", verifiedCreatedTime.get() > 0);
+    }
+
+    // --- Phase 6: Working Memory TTL Tests ---
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionTrue() {
+        // Container with disableSession=true -> verify _delete_by_query on working index with created_time range
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-enabled", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query for working memory TTL
+        BulkByScrollResponse ttlDeleteResponse = mock(BulkByScrollResponse.class);
+        when(ttlDeleteResponse.getDeleted()).thenReturn(8L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Working memory TTL should filter by memory_container_id", queryString.contains("memory_container_id"));
+            assertTrue("Working memory TTL should use created_time", queryString.contains("created_time"));
+            // Working memory does NOT support pinning, so no pinned filter
+            assertTrue("Working memory TTL should NOT exclude pinned (no pinning support)", !queryString.contains("pinned"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testWorkingMemoryTTLDisableSessionFalse() {
+        // Container with disableSession=false -> Phase 6 skipped entirely
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":false,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-ttl-skipped", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Session search returns no expired sessions
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // No delete-by-query should be called (session expired=0, and working memory TTL is skipped)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    // --- All phases chain test ---
+
+    @Test
+    public void testAllPhasesChainCorrectly() {
+        // Container with session, long-term, and history policies -> verify all three phases run
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{"
+            + "\"sessions\":{\"retention_days\":7},"
+            + "\"long-term\":{\"retention_days\":30},"
+            + "\"history\":{\"max_count\":500}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-all-phases", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // For count queries return 0 (under threshold), for other searches return empty
+                SearchResponse countResp = mock(SearchResponse.class);
+                SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                when(countResp.getHits()).thenReturn(countHits);
+                listener.onResponse(countResp);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock delete_by_query — should be called for session phase and long-term retention_days
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Long-term retention_days should trigger a delete_by_query
+        assertTrue("At least one delete_by_query should have been called for long-term retention_days", deleteByQueryCount.get() >= 1);
+    }
+
+    // --- Helper methods ---
+
+    private SearchResponse createContainerSearchResponseFromJson(String containerId, String sourceJson) {
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        SearchHit hit = new SearchHit(0, containerId, null, null);
+        hit.sourceRef(new BytesArray(sourceJson));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(searchResponse.getHits()).thenReturn(hits);
+        return searchResponse;
+    }
+
+    private SearchResponse createContainerSearchResponse(
+        String containerId,
+        String indexPrefix,
+        boolean useSystemIndex,
+        Map<String, Object> retentionPolicy
+    ) {
+        // Build the JSON source for the container hit
+        StringBuilder retentionJson = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : retentionPolicy.entrySet()) {
+            if (!first)
+                retentionJson.append(",");
+            first = false;
+            @SuppressWarnings("unchecked")
+            Map<String, Object> rule = (Map<String, Object>) entry.getValue();
+            retentionJson.append("\"").append(entry.getKey()).append("\":{");
+            boolean ruleFirst = true;
+            if (rule.containsKey("retention_days")) {
+                retentionJson.append("\"retention_days\":").append(rule.get("retention_days"));
+                ruleFirst = false;
+            }
+            if (rule.containsKey("max_count")) {
+                if (!ruleFirst)
+                    retentionJson.append(",");
+                retentionJson.append("\"max_count\":").append(rule.get("max_count"));
+            }
+            retentionJson.append("}");
+        }
+        retentionJson.append("}");
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\""
+            + indexPrefix
+            + "\","
+            + "\"use_system_index\":"
+            + useSystemIndex
+            + ","
+            + "\"retention_policy\":"
+            + retentionJson.toString()
+            + "}}";
+
+        return createContainerSearchResponseFromJson(containerId, sourceJson);
+    }
+
+    private Map<String, Object> createRetentionPolicyMap(String memoryType, Integer retentionDays, Integer maxCount) {
+        Map<String, Object> retentionPolicy = new HashMap<>();
+        Map<String, Object> rule = new HashMap<>();
+        if (retentionDays != null) {
+            rule.put("retention_days", retentionDays);
+        }
+        if (maxCount != null) {
+            rule.put("max_count", maxCount);
+        }
+        retentionPolicy.put(memoryType, rule);
+        return retentionPolicy;
+    }
+
+    private SearchResponse emptySearchResponse() {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(response.getHits()).thenReturn(hits);
+        return response;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+public class MemoryRetentionJobProcessorTests {
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private Client client;
+
+    private MemoryRetentionJobProcessor processor;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        MemoryRetentionJobProcessor.reset();
+        processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    @Test
+    public void testGetInstance() {
+        MemoryRetentionJobProcessor instance1 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        MemoryRetentionJobProcessor instance2 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testRunSkipsWhenMultiTenancyEnabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, method returns early with warning log
+    }
+
+    @Test
+    public void testRunExecutesWhenMultiTenancyDisabled() {
+        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", false).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // No exception thrown, logs "Memory retention job triggered"
+    }
+
+    @Test
+    public void testRunExecutesWithDefaultSettings() {
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+
+        processor.run();
+
+        // Default multi_tenancy_enabled is false, so job should execute
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,11 +34,16 @@ import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -46,6 +52,7 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -79,9 +86,40 @@ public class MemoryRetentionJobProcessorTests {
         Settings settings = Settings
             .builder()
             .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
             .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", -1)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
             .build();
         when(clusterService.getSettings()).thenReturn(settings);
+
+        java.util.Set<Setting<?>> clusterSettingsSet = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        ClusterSettings clusterSettings = new ClusterSettings(settings, clusterSettingsSet);
+        lenient().when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        // Default cluster state: all memory indices exist (orphan sweep runs)
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        lenient().when(clusterService.state()).thenReturn(clusterState);
+        lenient().when(clusterState.metadata()).thenReturn(metadata);
+        lenient().when(metadata.hasIndex(anyString())).thenReturn(true);
 
         // Use real ThreadContext (it's a final class and cannot be mocked)
         threadContext = new ThreadContext(Settings.EMPTY);
@@ -109,6 +147,21 @@ public class MemoryRetentionJobProcessorTests {
     public void testRunSkipsWhenMultiTenancyEnabled() {
         Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
         when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
 
         processor.run();
 
@@ -124,6 +177,21 @@ public class MemoryRetentionJobProcessorTests {
             .put("plugins.ml_commons.memory.retention_enabled", false)
             .build();
         when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
 
         processor.run();
 
@@ -148,7 +216,23 @@ public class MemoryRetentionJobProcessorTests {
 
     @Test
     public void testRunExecutesWithDefaultSettings() {
-        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        Settings defaultSettings = Settings.EMPTY;
+        when(clusterService.getSettings()).thenReturn(defaultSettings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(defaultSettings, s));
 
         // Return empty containers
         doAnswer(invocation -> {
@@ -202,10 +286,11 @@ public class MemoryRetentionJobProcessorTests {
                     listener.onResponse(emptySearchResponse());
                 }
             } else {
-                // Session search returns 3 expired sessions
-                SearchHit hit1 = new SearchHit(0, "expired-session-1", null, null);
-                SearchHit hit2 = new SearchHit(1, "expired-session-2", null, null);
-                SearchHit hit3 = new SearchHit(2, "expired-session-3", null, null);
+                // Session search returns 3 expired sessions with old last_updated_time
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit2 = createHitWithSource("expired-session-2", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit3 = createHitWithSource("expired-session-3", Map.of("last_updated_time", oldTimestamp));
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { hit1, hit2, hit3 },
                     new TotalHits(3, TotalHits.Relation.EQUAL_TO),
@@ -230,6 +315,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions (Phase 3)
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -311,6 +398,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -348,9 +437,10 @@ public class MemoryRetentionJobProcessorTests {
                     listener.onResponse(emptySearchResponse());
                 }
             } else {
-                // Session search returns expired sessions
-                SearchHit hit1 = new SearchHit(0, "session-1", null, null);
-                SearchHit hit2 = new SearchHit(1, "session-2", null, null);
+                // Session search returns expired sessions with old timestamps
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit2 = createHitWithSource("session-2", Map.of("last_updated_time", oldTimestamp));
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { hit1, hit2 },
                     new TotalHits(2, TotalHits.Relation.EQUAL_TO),
@@ -381,6 +471,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for sessions (Phase 3)
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             bulkDeleteOrder.set(orderCounter.getAndIncrement());
@@ -468,13 +560,14 @@ public class MemoryRetentionJobProcessorTests {
                 }
             } else {
                 // Return 600 expired sessions across 6 full pages of 100, then an empty page
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
                 int pageNum = sessionPageCount.getAndIncrement();
                 if (pageNum < 6) {
                     // Full page of 100 hits (triggers pagination)
                     SearchHit[] hits = new SearchHit[100];
                     for (int i = 0; i < 100; i++) {
                         int globalIdx = pageNum * 100 + i;
-                        hits[i] = new SearchHit(globalIdx, "session-" + globalIdx, null, null);
+                        hits[i] = createHitWithSource("session-" + globalIdx, Map.of("last_updated_time", oldTimestamp));
                         hits[i].sortValues(new Object[] { "session-" + globalIdx }, new DocValueFormat[] { DocValueFormat.RAW });
                     }
                     SearchHits sessionHits = new SearchHits(hits, new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -504,6 +597,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -681,8 +776,12 @@ public class MemoryRetentionJobProcessorTests {
                 listener.onResponse(containerSearchResponse);
             } else {
                 sessionSearchCount.incrementAndGet();
-                // Return 1 expired session for each container
-                SearchHit expiredHit = new SearchHit(0, "expired-session-" + sessionSearchCount.get(), null, null);
+                // Return 1 expired session for each container with old timestamp
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+                SearchHit expiredHit = createHitWithSource(
+                    "expired-session-" + sessionSearchCount.get(),
+                    Map.of("last_updated_time", oldTimestamp)
+                );
                 SearchHits sessionHits = new SearchHits(
                     new SearchHit[] { expiredHit },
                     new TotalHits(1, TotalHits.Relation.EQUAL_TO),
@@ -707,6 +806,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -838,6 +939,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1003,6 +1106,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete for max_count
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1137,6 +1242,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1215,6 +1322,8 @@ public class MemoryRetentionJobProcessorTests {
 
         // Mock bulk delete
         BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
 
         doAnswer(invocation -> {
             ActionListener<BulkResponse> listener = invocation.getArgument(1);
@@ -1681,6 +1790,146 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testOrphanSweepSkippedWhenSessionsIndexDoesNotExist() {
+        // Sessions index does not exist in cluster state: sweep must be skipped entirely,
+        // otherwise all working memory would be classified as orphaned and deleted.
+        lenient().when(clusterService.state().metadata().hasIndex(anyString())).thenAnswer(invocation -> {
+            String indexName = invocation.getArgument(0);
+            return !indexName.contains("sessions");
+        });
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-idx-missing", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger workingMemorySearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (inOrphanPhase[0] && request.indices()[0].contains("working")) {
+                    workingMemorySearchCount.incrementAndGet();
+                }
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        lenient().when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            if (inOrphanPhase[0]) {
+                orphanDbqCount.incrementAndGet();
+            }
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan sweep must not enumerate working memory when sessions index is missing", workingMemorySearchCount.get() == 0);
+        assertTrue("Orphan sweep must not delete anything when sessions index is missing", orphanDbqCount.get() == 0);
+    }
+
+    @Test
+    public void testOrphanSweepSkippedWhenWorkingMemoryIndexDoesNotExist() {
+        // Working memory index does not exist: nothing to sweep, skip.
+        lenient().when(clusterService.state().metadata().hasIndex(anyString())).thenAnswer(invocation -> {
+            String indexName = invocation.getArgument(0);
+            return !indexName.contains("working");
+        });
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-wm-missing", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger workingMemorySearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (inOrphanPhase[0] && request.indices()[0].contains("working")) {
+                    workingMemorySearchCount.incrementAndGet();
+                }
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        lenient().when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            if (inOrphanPhase[0]) {
+                orphanDbqCount.incrementAndGet();
+            }
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue(
+            "Orphan sweep must not enumerate working memory when working memory index is missing",
+            workingMemorySearchCount.get() == 0
+        );
+        assertTrue("Orphan sweep must not delete anything when working memory index is missing", orphanDbqCount.get() == 0);
+    }
+
+    @Test
     public void testSessionsIndexMissing() {
         String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
             + "\"use_system_index\":true,"
@@ -1867,5 +2116,26 @@ public class MemoryRetentionJobProcessorTests {
         SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
         when(response.getHits()).thenReturn(hits);
         return response;
+    }
+
+    private SearchHit createHitWithSource(String id, Map<String, Object> sourceMap) {
+        SearchHit hit = new SearchHit(id.hashCode(), id, null, null);
+        StringBuilder json = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, Object> entry : sourceMap.entrySet()) {
+            if (!first)
+                json.append(",");
+            json.append("\"").append(entry.getKey()).append("\":");
+            Object val = entry.getValue();
+            if (val instanceof String) {
+                json.append("\"").append(val).append("\"");
+            } else {
+                json.append(val);
+            }
+            first = false;
+        }
+        json.append("}");
+        hit.sourceRef(new BytesArray(json.toString()));
+        return hit;
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -56,6 +57,8 @@ import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
+import org.opensearch.search.aggregations.Aggregations;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -364,18 +367,23 @@ public class MemoryRetentionJobProcessorTests {
                     when(pinnedResp.getHits()).thenReturn(pinnedHits);
                     listener.onResponse(pinnedResp);
                 } else if (searchNum == 1) {
-                    // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
-                    // First 5 are kept, last 5 are expired
-                    SearchHit[] hits = new SearchHit[10];
-                    for (int i = 0; i < 10; i++) {
+                    // Count query: return totalHits=10 (exceeds max_count=5)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else if (searchNum == 2) {
+                    // Search for oldest 5 excess sessions by created_time ASC
+                    SearchHit[] hits = new SearchHit[5];
+                    for (int i = 0; i < 5; i++) {
                         hits[i] = new SearchHit(i, "session-" + i, null, null);
                         hits[i]
                             .sortValues(
-                                new Object[] { (long) (10 - i), "session-" + i },
+                                new Object[] { (long) i, "session-" + i },
                                 new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }
                             );
                     }
-                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    SearchHits sessionHits = new SearchHits(hits, new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
                     SearchResponse sessionResponse = mock(SearchResponse.class);
                     when(sessionResponse.getHits()).thenReturn(sessionHits);
                     listener.onResponse(sessionResponse);
@@ -412,6 +420,57 @@ public class MemoryRetentionJobProcessorTests {
         // Verify cascade delete + bulk delete both called
         verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
         verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testSessionMaxCountShortCircuitsWhenUnderLimit() {
+        // max_count=5, only 3 non-pinned sessions -> count query short-circuits: no ID search, no deletes
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-count-under",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", null, 5)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger sessionSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = sessionSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else {
+                    // Count query: return totalHits=3 (under max_count=5)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(3, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Only the pinned check and the count query should have hit the session index
+        assertTrue("Only pinned check + count query should fire when under max_count", sessionSearchCount.get() == 2);
+        // No deletions since totalCount (3) <= max_count (5)
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
     @Test
@@ -696,6 +755,108 @@ public class MemoryRetentionJobProcessorTests {
 
         // Verify that we searched at least twice (once for each container's sessions)
         assertTrue("Both containers should be processed, second container search made", sessionSearchCount.get() >= 2);
+        // Neither container deleted anything (first failed, second had no expired data) -> no throttle
+        verify(threadPool, never()).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+    }
+
+    @Test
+    public void testNoOpContainerSkipsThrottle() {
+        // Container with a policy but no expired data -> no deletions -> no inter-container throttle
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-noop",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // No expired sessions found
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Job still advances to the next step (orphan sweep container search) without any throttle
+        assertTrue("Job should proceed past the no-op container", containerSearchCount.get() >= 2);
+        verify(threadPool, never()).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+    }
+
+    @Test
+    public void testContainerWithDeletionsSchedulesThrottle() {
+        // Container with expired sessions -> deletions occur -> throttle scheduled before next container
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-throttled",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit expiredHit = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { expiredHit },
+                    new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Mock cascade delete for working memory
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(2L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        // Mock bulk delete for sessions
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Throttle (retention_job_throttle_seconds=1) is scheduled after the container with deletions
+        verify(threadPool, atLeastOnce()).schedule(any(Runnable.class), eq(TimeValue.timeValueSeconds(1)), anyString());
     }
 
     @Test
@@ -1576,6 +1737,167 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testOrphanEnumerationUsesCompositeAggregation() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-agg", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger compositeAggSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        when(bucket.getKey()).thenReturn(Map.of("session_id", "session-gone"));
+        CompositeAggregation composite = mock(CompositeAggregation.class);
+        when(composite.getName()).thenReturn("session_ids");
+        doReturn(java.util.List.of(bucket)).when(composite).getBuckets();
+        when(composite.afterKey()).thenReturn(null);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else if (targetIndex.contains("working") && request.source() != null && request.source().aggregations() != null) {
+                    compositeAggSearchCount.incrementAndGet();
+                    SearchResponse aggResponse = mock(SearchResponse.class);
+                    when(aggResponse.getAggregations()).thenReturn(new Aggregations(java.util.List.of(composite)));
+                    listener.onResponse(aggResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(1L);
+
+        AtomicInteger dbqCount = new AtomicInteger(0);
+        java.util.List<String> dbqQueries = new java.util.ArrayList<>();
+
+        doAnswer(invocation -> {
+            dbqCount.incrementAndGet();
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            dbqQueries.add(dbq.getSearchRequest().source().query().toString());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan enumeration should use a composite aggregation search", compositeAggSearchCount.get() >= 1);
+        assertTrue("Orphan delete and empty-namespace DBQ should fire", dbqCount.get() >= 2);
+        assertTrue(
+            "Orphan DBQ should match the aggregated session id on the top-level session_id field",
+            dbqQueries.stream().anyMatch(q -> q.contains("session-gone") && q.contains("\"session_id\""))
+        );
+    }
+
+    @Test
+    public void testOrphanEnumerationStartsAtRandomKeyAndWrapsAround() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-random-start", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+        java.util.List<String> compositeAggSources = new java.util.ArrayList<>();
+
+        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        when(bucket.getKey()).thenReturn(Map.of("session_id", "session-gone"));
+        CompositeAggregation composite = mock(CompositeAggregation.class);
+        when(composite.getName()).thenReturn("session_ids");
+        doReturn(java.util.List.of(bucket)).when(composite).getBuckets();
+        when(composite.afterKey()).thenReturn(null);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else if (targetIndex.contains("working") && request.source() != null && request.source().aggregations() != null) {
+                    compositeAggSources.add(request.source().toString());
+                    SearchResponse aggResponse = mock(SearchResponse.class);
+                    when(aggResponse.getAggregations()).thenReturn(new Aggregations(java.util.List.of(composite)));
+                    listener.onResponse(aggResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan enumeration should issue at least the initial composite search", compositeAggSources.size() >= 1);
+        assertTrue(
+            "First composite search must start from a randomized after key so cap truncation covers a different slice each run",
+            compositeAggSources.get(0).contains("\"after\"")
+        );
+        assertTrue(
+            "Enumeration must wrap around to the start of the keyspace after exhausting the first slice",
+            compositeAggSources.size() >= 2 && !compositeAggSources.get(compositeAggSources.size() - 1).contains("\"after\"")
+        );
+    }
+
+    @Test
     public void testNullSessionIdDeletedAfterGracePeriod() {
         Settings settings = Settings
             .builder()
@@ -2042,6 +2364,435 @@ public class MemoryRetentionJobProcessorTests {
         processor.run();
 
         assertTrue("Both retention and orphan sweep container searches should fire", containerSearchCount.get() >= 2);
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_IssuesUpdateWhenDefaultsConfigured() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-policy", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicBoolean updateCalled = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            updateCalled.set(true);
+            org.opensearch.action.update.UpdateRequest req = invocation.getArgument(0);
+            assertTrue("Update should use a script", req.script() != null);
+            assertTrue("Script should contain noop logic", req.script().getIdOrCode().contains("noop"));
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.update.UpdateResponse resp = mock(org.opensearch.action.update.UpdateResponse.class);
+            when(resp.getResult()).thenReturn(org.opensearch.action.DocWriteResponse.Result.UPDATED);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("client.update should be called to backfill default policy", updateCalled.get());
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_NoopSkipsContainer() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-policy-noop", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.update.UpdateResponse> listener = invocation.getArgument(1);
+            org.opensearch.action.update.UpdateResponse resp = mock(org.opensearch.action.update.UpdateResponse.class);
+            when(resp.getResult()).thenReturn(org.opensearch.action.DocWriteResponse.Result.NOOP);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testApplyDefaultRetentionPolicy_AllDefaultsMinusOne_NoUpdate() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-all-minus-one", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testEpochSecondNormalization_NewerTimestampNotDeleted() {
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-epoch",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.List<String> deletedIds = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        long nowMillis = System.currentTimeMillis();
+        long cutoffMillis = nowMillis - java.util.concurrent.TimeUnit.DAYS.toMillis(7);
+        long epochSecNewSession = (nowMillis - java.util.concurrent.TimeUnit.DAYS.toMillis(3)) / 1000;
+        long epochMillisOldSession = cutoffMillis - 10_000;
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                SearchHit hitNew = createHitWithSource("session-epoch-new", Map.of("last_updated_time", epochSecNewSession));
+                SearchHit hitOld = createHitWithSource("session-epoch-old", Map.of("last_updated_time", epochMillisOldSession));
+                SearchHit hitMissing = createHitWithSource("session-missing-ts", Map.of("other_field", "value"));
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hitNew, hitOld, hitMissing },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        when(cascadeResponse.getDeleted()).thenReturn(1L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            BulkRequest bulkReq = invocation.getArgument(0);
+            bulkReq.requests().forEach(r -> deletedIds.add(((org.opensearch.action.delete.DeleteRequest) r).id()));
+            BulkResponse bulkResponse = mock(BulkResponse.class);
+            lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+            lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Epoch-second session newer than cutoff should NOT be deleted", !deletedIds.contains("session-epoch-new"));
+        assertTrue("Epoch-millis session older than cutoff SHOULD be deleted", deletedIds.contains("session-epoch-old"));
+        assertTrue("Session with missing timestamp should NOT be deleted", !deletedIds.contains("session-missing-ts"));
+    }
+
+    @Test
+    public void testBuildEpochAwareCutoffQuery_Structure() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-dbq-cutoff", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicReference<String> capturedQuery = new java.util.concurrent.atomic.AtomicReference<>();
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            capturedQuery.set(dbq.getSearchRequest().source().query().toString());
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            BulkByScrollResponse resp = mock(BulkByScrollResponse.class);
+            when(resp.getDeleted()).thenReturn(0L);
+            listener.onResponse(resp);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        String query = capturedQuery.get();
+        assertTrue("Query must contain gte threshold clause", query != null && query.contains("10000000000"));
+        assertTrue("Query must contain minimum_should_match=1", query.contains("minimum_should_match") && query.contains("1"));
+        assertTrue("Query must have two should clauses for epoch-aware cutoff", query.contains("should"));
+    }
+
+    @Test
+    public void testDebugLogsSessionDeletionIds() {
+        org.apache.logging.log4j.core.LoggerContext context =
+            (org.apache.logging.log4j.core.LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        org.apache.logging.log4j.core.config.LoggerConfig loggerConfig = context
+            .getConfiguration()
+            .getLoggerConfig(MemoryRetentionJobProcessor.class.getName());
+        org.apache.logging.log4j.Level originalLevel = loggerConfig.getLevel();
+        loggerConfig.setLevel(org.apache.logging.log4j.Level.DEBUG);
+        context.updateLoggers();
+
+        java.util.List<String> capturedMessages = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        org.apache.logging.log4j.core.appender.AbstractAppender appender = new org.apache.logging.log4j.core.appender.AbstractAppender(
+            "test-debug-appender",
+            null,
+            org.apache.logging.log4j.core.layout.PatternLayout.createDefaultLayout(),
+            false
+        ) {
+            @Override
+            public void append(org.apache.logging.log4j.core.LogEvent event) {
+                capturedMessages.add(event.getLevel() + ": " + event.getMessage().getFormattedMessage());
+            }
+        };
+        appender.start();
+        loggerConfig.addAppender(appender, org.apache.logging.log4j.Level.DEBUG, null);
+        context.updateLoggers();
+
+        try {
+            SearchResponse containerSearchResponse = createContainerSearchResponse(
+                "container-debug",
+                "test-prefix",
+                true,
+                createRetentionPolicyMap("sessions", 7, null)
+            );
+
+            AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+            doAnswer(invocation -> {
+                SearchRequest request = invocation.getArgument(0);
+                ActionListener<SearchResponse> listener = invocation.getArgument(1);
+                if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                    if (containerSearchCount.getAndIncrement() == 0) {
+                        listener.onResponse(containerSearchResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                    SearchHit hit1 = createHitWithSource("debug-session-1", Map.of("last_updated_time", oldTimestamp));
+                    SearchHit hit2 = createHitWithSource("debug-session-2", Map.of("last_updated_time", oldTimestamp));
+                    SearchHits sessionHits = new SearchHits(
+                        new SearchHit[] { hit1, hit2 },
+                        new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                        Float.NaN
+                    );
+                    SearchResponse sessionResponse = mock(SearchResponse.class);
+                    when(sessionResponse.getHits()).thenReturn(sessionHits);
+                    listener.onResponse(sessionResponse);
+                }
+                return null;
+            }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+            BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+            when(cascadeResponse.getDeleted()).thenReturn(2L);
+            doAnswer(invocation -> {
+                ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+                listener.onResponse(cascadeResponse);
+                return null;
+            }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+            BulkResponse bulkResponse = mock(BulkResponse.class);
+            when(bulkResponse.hasFailures()).thenReturn(false);
+            when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+            doAnswer(invocation -> {
+                ActionListener<BulkResponse> listener = invocation.getArgument(1);
+                listener.onResponse(bulkResponse);
+                return null;
+            }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+            processor.run();
+
+            boolean foundDebugIds = capturedMessages
+                .stream()
+                .anyMatch(m -> m.startsWith("DEBUG:") && m.contains("deleting session ids=") && m.contains("debug-session-1"));
+            assertTrue("DEBUG log should contain session IDs being deleted", foundDebugIds);
+
+            boolean foundInfoAggregate = capturedMessages.stream().anyMatch(m -> m.startsWith("INFO:") && m.contains("sessions_expired=2"));
+            assertTrue("INFO aggregate log should be unchanged", foundInfoAggregate);
+        } finally {
+            loggerConfig.removeAppender(appender.getName());
+            appender.stop();
+            loggerConfig.setLevel(originalLevel);
+            context.updateLoggers();
+        }
+    }
+
+    @Test
+    public void testRetentionPolicyNullOptOut_SkipsEverything() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 100)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", 500)
+            .put("plugins.ml_commons.memory.default_history_max_count", 200)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<org.opensearch.common.settings.Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\",\"use_system_index\":true,\"retention_policy\":null}}";
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-opt-out", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, never()).update(any(org.opensearch.action.update.UpdateRequest.class), isA(ActionListener.class));
+        verify(client, never()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
     // --- Helper methods ---

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -1371,6 +1371,430 @@ public class MemoryRetentionJobProcessorTests {
         assertTrue("At least one delete_by_query should have been called for long-term retention_days", deleteByQueryCount.get() >= 1);
     }
 
+    // --- Phase 7: Orphan Sweep Tests ---
+
+    @Test
+    public void testOrphanDetectedAndDeleted() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-orphan", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger orphanPhaseSearchCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    orphanPhaseSearchCount.incrementAndGet();
+                    if (targetIndex.contains("working")) {
+                        SearchHit hit1 = new SearchHit(0, "working-1", null, null);
+                        hit1.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"session-exists\"}}"));
+                        hit1.sortValues(new Object[] { "working-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHit hit2 = new SearchHit(1, "working-2", null, null);
+                        hit2.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"session-gone\"}}"));
+                        hit2.sortValues(new Object[] { "working-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHits workingHits = new SearchHits(
+                            new SearchHit[] { hit1, hit2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse workingResponse = mock(SearchResponse.class);
+                        when(workingResponse.getHits()).thenReturn(workingHits);
+                        listener.onResponse(workingResponse);
+                    } else if (targetIndex.contains("sessions")) {
+                        SearchHit existsHit = new SearchHit(0, "session-exists", null, null);
+                        SearchHits sessionHits = new SearchHits(
+                            new SearchHit[] { existsHit },
+                            new TotalHits(1, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse sessionResponse = mock(SearchResponse.class);
+                        when(sessionResponse.getHits()).thenReturn(sessionHits);
+                        listener.onResponse(sessionResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse orphanDeleteResponse = mock(BulkByScrollResponse.class);
+        when(orphanDeleteResponse.getDeleted()).thenReturn(3L);
+
+        AtomicInteger dbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            dbqCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(orphanDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Orphan sweep should have searched working memory", orphanPhaseSearchCount.get() >= 1);
+        assertTrue("Delete-by-query should fire for orphans and null sessions", dbqCount.get() >= 2);
+    }
+
+    @Test
+    public void testNullSessionIdDeletedAfterGracePeriod() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-null-session", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0 || count == 1) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse nullDeleteResponse = mock(BulkByScrollResponse.class);
+        when(nullDeleteResponse.getDeleted()).thenReturn(5L);
+
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Null session delete should use created_time range", queryString.contains("created_time"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(nullDeleteResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Null session delete_by_query should fire", deleteByQueryCount.get() >= 1);
+    }
+
+    @Test
+    public void testNullSessionIdWithinGracePeriodNotDeleted() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-grace", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0 || count == 1) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse graceResponse = mock(BulkByScrollResponse.class);
+        when(graceResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            DeleteByQueryRequest dbq = invocation.getArgument(1);
+            String queryString = dbq.getSearchRequest().source().query().toString();
+            assertTrue("Null session delete should use created_time range for grace period", queryString.contains("created_time"));
+            assertTrue("Should filter docs without session_id", queryString.contains("session_id"));
+
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(graceResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        verify(client, atLeastOnce()).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testNoOrphansFound() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-orphans", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger deleteByQueryCount = new AtomicInteger(0);
+        boolean[] inOrphanPhase = { false };
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else if (count == 1) {
+                    inOrphanPhase[0] = true;
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                String targetIndex = request.indices()[0];
+
+                if (!inOrphanPhase[0]) {
+                    if (request.source() != null && request.source().size() == 0) {
+                        SearchResponse countResp = mock(SearchResponse.class);
+                        SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                        when(countResp.getHits()).thenReturn(countHits);
+                        listener.onResponse(countResp);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                } else {
+                    if (targetIndex.contains("working")) {
+                        SearchHit hit1 = new SearchHit(0, "w-1", null, null);
+                        hit1.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"s-1\"}}"));
+                        hit1.sortValues(new Object[] { "w-1" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHit hit2 = new SearchHit(1, "w-2", null, null);
+                        hit2.sourceRef(new BytesArray("{\"namespace\":{\"session_id\":\"s-2\"}}"));
+                        hit2.sortValues(new Object[] { "w-2" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+                        SearchHits workingHits = new SearchHits(
+                            new SearchHit[] { hit1, hit2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse workingResponse = mock(SearchResponse.class);
+                        when(workingResponse.getHits()).thenReturn(workingHits);
+                        listener.onResponse(workingResponse);
+                    } else if (targetIndex.contains("sessions")) {
+                        SearchHit exist1 = new SearchHit(0, "s-1", null, null);
+                        SearchHit exist2 = new SearchHit(1, "s-2", null, null);
+                        SearchHits sessionHits = new SearchHits(
+                            new SearchHit[] { exist1, exist2 },
+                            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+                            Float.NaN
+                        );
+                        SearchResponse sessionResponse = mock(SearchResponse.class);
+                        when(sessionResponse.getHits()).thenReturn(sessionHits);
+                        listener.onResponse(sessionResponse);
+                    } else {
+                        listener.onResponse(emptySearchResponse());
+                    }
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse nullResponse = mock(BulkByScrollResponse.class);
+        when(nullResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            deleteByQueryCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(nullResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Only null session cleanup DBQ should fire (no orphans)", deleteByQueryCount.get() == 1);
+    }
+
+    @Test
+    public void testSessionsIndexMissing() {
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-no-sessions-idx", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger orphanDbqCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                listener.onResponse(emptySearchResponse());
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse ttlResponse = mock(BulkByScrollResponse.class);
+        when(ttlResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            orphanDbqCount.incrementAndGet();
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(ttlResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Only Phase 6 TTL DBQ should fire, not orphan sweep", orphanDbqCount.get() == 1);
+    }
+
+    @Test
+    public void testDisableSessionTrueContainerSkippedInOrphanSweep() {
+        String sourceJsonSessionEnabled = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"max_count\":1000}}}}";
+
+        String sourceJsonSessionDisabled = "{\"configuration\":{\"index_prefix\":\"other-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"disable_session\":true,"
+            + "\"retention_policy\":{\"sessions\":{\"retention_days\":7}}}}";
+
+        SearchHit hit1 = new SearchHit(0, "container-with-session", null, null);
+        hit1.sourceRef(new BytesArray(sourceJsonSessionEnabled));
+        hit1.sortValues(new Object[] { "container-with-session" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchHit hit2 = new SearchHit(1, "container-no-session", null, null);
+        hit2.sourceRef(new BytesArray(sourceJsonSessionDisabled));
+        hit2.sortValues(new Object[] { "container-no-session" }, new DocValueFormat[] { DocValueFormat.RAW });
+
+        SearchResponse retentionContainerResponse = mock(SearchResponse.class);
+        SearchHits retentionContainerHits = new SearchHits(
+            new SearchHit[] { hit1, hit2 },
+            new TotalHits(2, TotalHits.Relation.EQUAL_TO),
+            Float.NaN
+        );
+        when(retentionContainerResponse.getHits()).thenReturn(retentionContainerHits);
+
+        SearchResponse orphanContainerResponse = createContainerSearchResponseFromJson("container-with-session", sourceJsonSessionEnabled);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                int count = containerSearchCount.getAndIncrement();
+                if (count == 0) {
+                    listener.onResponse(retentionContainerResponse);
+                } else if (count == 1) {
+                    listener.onResponse(orphanContainerResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                if (request.source() != null && request.source().size() == 0) {
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse dbqResponse = mock(BulkByScrollResponse.class);
+        when(dbqResponse.getDeleted()).thenReturn(0L);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(dbqResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertTrue("Both retention and orphan sweep container searches should fire", containerSearchCount.get() >= 2);
+    }
+
     // --- Helper methods ---
 
     private SearchResponse createContainerSearchResponseFromJson(String containerId, String sourceJson) {

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -117,6 +117,21 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testRunSkipsWhenRetentionDisabled() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", false)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+
+        processor.run();
+
+        // Should not search for containers when retention is disabled
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
     public void testRunExecutesWhenMultiTenancyDisabled() {
         // Return empty containers
         doAnswer(invocation -> {
@@ -256,6 +271,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = sessionSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count-based identification: returns 10 sessions sorted by last_updated_time DESC
                     // First 5 are kept, last 5 are expired
                     SearchHit[] hits = new SearchHit[10];
@@ -784,6 +805,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return totalHits=150
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(150, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -933,6 +960,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query for max_count: return 120
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(120, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -984,6 +1017,61 @@ public class MemoryRetentionJobProcessorTests {
         verify(client, atLeastOnce()).bulk(any(BulkRequest.class), isA(ActionListener.class));
     }
 
+    // --- Pinned Exceeds max_count Warning Tests ---
+
+    @Test
+    public void testPinnedExceedsMaxCountWarningFires() {
+        // Container with long-term max_count=10, pinned count returns 15 -> verify warning fires (no exception)
+        String sourceJson = "{\"configuration\":{\"index_prefix\":\"test-prefix\","
+            + "\"use_system_index\":true,"
+            + "\"llm_id\":\"test-llm\","
+            + "\"strategies\":[{\"type\":\"semantic\"}],"
+            + "\"retention_policy\":{\"long-term\":{\"max_count\":10}}}}";
+
+        SearchResponse containerSearchResponse = createContainerSearchResponseFromJson("container-pin-warn", sourceJson);
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        AtomicInteger nonContainerSearchCount = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                int searchNum = nonContainerSearchCount.getAndIncrement();
+                if (searchNum == 0) {
+                    // Pinned count check: return 15 pinned docs (exceeds max_count=10)
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
+                    // Count query for max_count: return 5 non-pinned (under limit, no eviction)
+                    SearchResponse countResp = mock(SearchResponse.class);
+                    SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(5, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(countResp.getHits()).thenReturn(countHits);
+                    listener.onResponse(countResp);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Pinned count check and normal count query both fired (at least 2 non-container searches)
+        assertTrue("Pinned count check and count query should both fire", nonContainerSearchCount.get() >= 2);
+        // No bulk delete since non-pinned count (5) is under max_count (10)
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+    }
+
     // --- Phase 5: History Retention Tests ---
 
     @Test
@@ -1013,6 +1101,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return totalHits=600
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(600, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -1083,6 +1177,12 @@ public class MemoryRetentionJobProcessorTests {
             } else {
                 int searchNum = nonContainerSearchCount.getAndIncrement();
                 if (searchNum == 0) {
+                    // Pinned count check (fire-and-forget): return 0 pinned docs
+                    SearchResponse pinnedResp = mock(SearchResponse.class);
+                    SearchHits pinnedHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                    when(pinnedResp.getHits()).thenReturn(pinnedHits);
+                    listener.onResponse(pinnedResp);
+                } else if (searchNum == 1) {
                     // Count query: return 15 docs (exceeds max_count=10)
                     SearchResponse countResp = mock(SearchResponse.class);
                     SearchHits countHits = new SearchHits(new SearchHit[0], new TotalHits(15, TotalHits.Relation.EQUAL_TO), Float.NaN);


### PR DESCRIPTION

  ### Description

  This PR adds **admin-owned default retention policies, opt-out behavior, and hardening** for the memory retention lifecycle feature (RFC #4859). It is the second of two stacked PRs and builds directly on the API + retention-job PR ("[Feature] Wire memory
  retention API and background job").

  > ** Depends on #4912 ("Wire memory retention API and background job").** This branch is stacked on that PR. Review/merge it after PR-B. Until PR-B merges into the feature branch, the diff here also includes PR-B's commits.

  **Defaults & opt-out**
  - Cluster-level admin-owned default retention policy, applied automatically to containers unless opted out (`retention_enabled=false` by default; defaults act as templates, no backfill).
  - Auto-apply default retention policy logic wired through the Create MemoryContainer path.
  - Field-level merge of retention config, `created_time` sort ordering, and session-liveness handling per team design review.

  **Hardening**
  - Orphan sweep (Phase 7) in the retention job, with an age guard to prevent deletion of live working memory.
  - Processor hardening and expanded unit tests across the container/memory transport actions and the retention job processor.
  - Working-memory index mapping update supporting the new behavior.

  ### Related Issues
  RFC #4859

  ### Check List
  - [x] New functionality includes unit tests.
  - [x] `./gradlew spotlessCheck` passes.
  - [x] `./gradlew build -x spotlessJava -x integTest` passes on Java 21.
  - [x] Commits are signed per the DCO using `--signoff`.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).