### PR TITLE
Bump bc-fips to 2.1.3 in plugin test classpath to fix CVE-2026-8149

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -205,7 +205,7 @@ test {
     // Unit tests don't run inside OpenSearch, so we add bc-fips directly to the test classpath.
     if (FipsBuildParams.isInFipsMode()) {
         classpath += configurations.detachedConfiguration(
-            dependencies.create("org.bouncycastle:bc-fips:2.1.2")
+            dependencies.create("org.bouncycastle:bc-fips:2.1.3")
         )
     }
 }


### PR DESCRIPTION
### Description
The FIPS-mode unit test classpath in plugin/build.gradle pinned org.bouncycastle:bc-fips to 2.1.2, which is affected by CVE-2026-8149(GHSA-mx76-r943-rf8g): the AES/GCM native path can intermittently produce a bad authentication tag on decryption. Bump to 2.1.3, the patched release

### Related Issues
Resolves #4922 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
