### PR TITLE
Validate model archives to block arbitrary code execution

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/ModelHelper.java
@@ -13,6 +13,8 @@ import static org.opensearch.ml.engine.utils.FileUtils.splitFileIntoChunks;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -22,6 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -52,6 +57,12 @@ public class ModelHelper {
     public static final String TOKENIZER_FILE_NAME = "tokenizer.json";
     public static final String PYTORCH_ENGINE = "PyTorch";
     public static final String ONNX_ENGINE = "OnnxRuntime";
+    private static final Set<String> DISALLOWED_MODEL_FILE_EXTENSIONS = Set.of(".jar", ".class", ".so", ".dylib", ".dll");
+    private static final Set<String> CLASS_LOADING_SERVING_PROPERTIES = Set.of("blockfactory", "translatorfactory", "translator");
+    private static final Set<String> NON_CLASS_SERVING_PROPERTIES = Set.of("application");
+    private static final Pattern FULLY_QUALIFIED_CLASS_NAME = Pattern.compile("^([a-zA-Z_$][\\w$]*\\.)+[A-Z][\\w$]*$");
+    private static final String ALLOWED_CLASS_PREFIX = "ai.djl.";
+    private static final String SERVING_PROPERTIES_FILE_NAME = "serving.properties";
     private final MLEngine mlEngine;
 
     public ModelHelper(MLEngine mlEngine) {
@@ -311,7 +322,15 @@ public class ModelHelper {
         try (ZipFile zipFile = new ZipFile(modelZipFilePath)) {
             Enumeration zipEntries = zipFile.entries();
             while (zipEntries.hasMoreElements()) {
-                String fileName = ((ZipEntry) zipEntries.nextElement()).getName();
+                ZipEntry zipEntry = (ZipEntry) zipEntries.nextElement();
+                String fileName = zipEntry.getName();
+                verifyNoExecutableFile(fileName);
+                String baseName = fileName.replace('\\', '/');
+                if (baseName.substring(baseName.lastIndexOf('/') + 1).equalsIgnoreCase(SERVING_PROPERTIES_FILE_NAME)) {
+                    try (InputStream in = zipFile.getInputStream(zipEntry)) {
+                        verifyServingProperties(in);
+                    }
+                }
                 hasPtFile = hasModelFile(modelFormat, MLModelFormat.TORCH_SCRIPT, PYTORCH_FILE_EXTENSION, hasPtFile, fileName);
                 hasOnnxFile = hasModelFile(modelFormat, MLModelFormat.ONNX, ONNX_FILE_EXTENSION, hasOnnxFile, fileName);
                 if (fileName.equals(TOKENIZER_FILE_NAME)) {
@@ -346,6 +365,60 @@ public class ModelHelper {
             return true;
         }
         return hasModelFile;
+    }
+
+    private static void verifyNoExecutableFile(String fileName) {
+        String lowerName = fileName.toLowerCase(Locale.ROOT);
+        for (String extension : DISALLOWED_MODEL_FILE_EXTENSIONS) {
+            if (lowerName.endsWith(extension)) {
+                throw new IllegalArgumentException("Model archive contains a disallowed executable file: " + fileName);
+            }
+        }
+    }
+
+    private static void verifyServingProperties(InputStream servingProperties) throws IOException {
+        Properties properties = new Properties();
+        properties.load(servingProperties);
+        for (String key : properties.stringPropertyNames()) {
+            String normalizedKey = key.trim().toLowerCase(Locale.ROOT);
+            if (NON_CLASS_SERVING_PROPERTIES.contains(normalizedKey)) {
+                continue;
+            }
+            String value = properties.getProperty(key).trim();
+            boolean isClassLoadingKey = CLASS_LOADING_SERVING_PROPERTIES.contains(normalizedKey);
+            boolean looksLikeClassName = FULLY_QUALIFIED_CLASS_NAME.matcher(value).matches();
+            if (!isClassLoadingKey && !looksLikeClassName) {
+                continue;
+            }
+            if (!value.isEmpty() && !value.startsWith(ALLOWED_CLASS_PREFIX)) {
+                throw new IllegalArgumentException(
+                    "serving.properties key '" + key + "' references a non-DJL class '" + value + "', which is not allowed"
+                );
+            }
+        }
+    }
+
+    /**
+     * Validate an unzipped model directory before DJL loads it. Rejects archives that
+     * carry executable files or a serving.properties that points DJL at a non-DJL class.
+     */
+    public static void verifyModelDirSafety(Path modelDir) throws IOException {
+        File[] files = modelDir.toFile().listFiles();
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            if (file.isDirectory()) {
+                verifyModelDirSafety(file.toPath());
+                continue;
+            }
+            verifyNoExecutableFile(file.getName());
+            if (file.getName().equalsIgnoreCase(SERVING_PROPERTIES_FILE_NAME)) {
+                try (InputStream in = Files.newInputStream(file.toPath())) {
+                    verifyServingProperties(in);
+                }
+            }
+        }
     }
 
     public void deleteFileCache(String modelId) {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModel.java
@@ -267,6 +267,7 @@ public abstract class DLModel implements Predictable {
                         FileUtils.deleteDirectory(pathFile);
                     }
                     ZipUtils.unzip(modelZipFile, modelPath);
+                    ModelHelper.verifyModelDirSafety(modelPath);
                     boolean findModelFile = false;
                     for (File file : pathFile.listFiles()) {
                         String name = file.getName();

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
@@ -145,6 +145,7 @@ public abstract class DLModelExecute implements MLExecutable {
                         FileUtils.deleteDirectory(pathFile);
                     }
                     ZipUtils.unzip(modelZipFile, modelPath);
+                    ModelHelper.verifyModelDirSafety(modelPath);
                     boolean findModelFile = false;
                     for (File file : Objects.requireNonNull(pathFile.listFiles())) {
                         String name = file.getName();

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_embedding/ModelHelperTest.java
@@ -12,17 +12,24 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.PrivilegedActionException;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -39,6 +46,9 @@ import org.opensearch.ml.engine.encryptor.EncryptorImpl;
 public class ModelHelperTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private ModelHelper modelHelper;
     private MLModelFormat modelFormat;
@@ -160,6 +170,170 @@ public class ModelHelperTest {
         exceptionRule.expectMessage("No tokenizer file");
         String modelUrl = getClass().getResource("traced_small_model_missing_tokenizer.zip").toString().substring(5);
         modelHelper.verifyModelZipFile(modelFormat, modelUrl, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesUnknownClassShapedKey_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("references a non-DJL class");
+        String zip = buildZip(
+            "serving.properties",
+            "someFutureFactory=com.attacker.Gadget\n".getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesUnknownDjlClassShapedKey_Allowed() throws IOException {
+        String zip = buildZip(
+            "serving.properties",
+            "someFutureFactory=ai.djl.foo.Bar\n".getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesNonClassShapedValue_Allowed() throws IOException {
+        String zip = buildZip(
+            "serving.properties",
+            ("engine=PyTorch\noption.maxLength=256\nmodelVersion=1.2.3\nmodelPath=models/my_model\n").getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ExecutableJar_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("disallowed executable file");
+        String zip = buildZip("evil.jar", "PK".getBytes(StandardCharsets.UTF_8), "model.pt", new byte[] { 1 }, "tokenizer.json", "{}");
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ExecutableClass_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("disallowed executable file");
+        String zip = buildZip("Evil.class", new byte[] { (byte) 0xCA, (byte) 0xFE }, "model.pt", new byte[] { 1 }, "tokenizer.json", "{}");
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_NativeLibrary_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("disallowed executable file");
+        String zip = buildZip("libx.so", new byte[] { 1 }, "model.pt", new byte[] { 1 }, "tokenizer.json", "{}");
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesNonDjlClass_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("references a non-DJL class");
+        String zip = buildZip(
+            "serving.properties",
+            "blockFactory=com.attacker.Evil\n".getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesDjlClass_Allowed() throws IOException {
+        String zip = buildZip(
+            "serving.properties",
+            "translatorFactory=ai.djl.foo.Bar\n".getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelZipFile_ServingPropertiesApplicationPath_Allowed() throws IOException {
+        String zip = buildZip(
+            "serving.properties",
+            "application=nlp/text_embedding\n".getBytes(StandardCharsets.UTF_8),
+            "model.pt",
+            new byte[] { 1 },
+            "tokenizer.json",
+            "{}"
+        );
+        modelHelper.verifyModelZipFile(modelFormat, zip, FunctionName.TEXT_EMBEDDING.toString(), FunctionName.TEXT_EMBEDDING);
+    }
+
+    @Test
+    public void testVerifyModelDirSafety_ExecutableJar_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("disallowed executable file");
+        Path dir = tempFolder.newFolder("model_dir_jar").toPath();
+        Files.write(dir.resolve("model.pt"), new byte[] { 1 });
+        Files.write(dir.resolve("evil.jar"), "PK".getBytes(StandardCharsets.UTF_8));
+        ModelHelper.verifyModelDirSafety(dir);
+    }
+
+    @Test
+    public void testVerifyModelDirSafety_ServingPropertiesNonDjlClass_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("references a non-DJL class");
+        Path dir = tempFolder.newFolder("model_dir_props").toPath();
+        Files.write(dir.resolve("model.pt"), new byte[] { 1 });
+        Files.write(dir.resolve("serving.properties"), "blockFactory=com.attacker.Evil\n".getBytes(StandardCharsets.UTF_8));
+        ModelHelper.verifyModelDirSafety(dir);
+    }
+
+    @Test
+    public void testVerifyModelDirSafety_NestedExecutable_Rejected() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("disallowed executable file");
+        Path dir = tempFolder.newFolder("model_dir_nested").toPath();
+        Files.write(dir.resolve("model.pt"), new byte[] { 1 });
+        Path nested = Files.createDirectory(dir.resolve("nested"));
+        Files.write(nested.resolve("libx.so"), new byte[] { 1 });
+        ModelHelper.verifyModelDirSafety(dir);
+    }
+
+    @Test
+    public void testVerifyModelDirSafety_CleanDirectory_Allowed() throws IOException {
+        Path dir = tempFolder.newFolder("model_dir_clean").toPath();
+        Files.write(dir.resolve("model.pt"), new byte[] { 1 });
+        Files.write(dir.resolve("tokenizer.json"), "{}".getBytes(StandardCharsets.UTF_8));
+        Files.write(dir.resolve("serving.properties"), "translatorFactory=ai.djl.foo.Bar\n".getBytes(StandardCharsets.UTF_8));
+        ModelHelper.verifyModelDirSafety(dir);
+    }
+
+    /**
+     * Build a zip file on disk from (name, content) pairs and return its absolute path. Content may be a String or byte[].
+     */
+    private String buildZip(Object... nameThenContent) throws IOException {
+        File zipFile = tempFolder.newFile("model_" + tempFolder.getRoot().list().length + ".zip");
+        try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            for (int i = 0; i < nameThenContent.length; i += 2) {
+                String name = (String) nameThenContent[i];
+                Object content = nameThenContent[i + 1];
+                byte[] bytes = content instanceof byte[] ? (byte[]) content : ((String) content).getBytes(StandardCharsets.UTF_8);
+                zos.putNextEntry(new ZipEntry(name));
+                zos.write(bytes);
+                zos.closeEntry();
+            }
+        }
+        return zipFile.getAbsolutePath();
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLRAGSearchProcessorIT.java
@@ -207,6 +207,9 @@ public class RestMLRAGSearchProcessorIT extends MLCommonsRestTestCase {
         + "  \"description\": \"The connector to bedrock claude haiku 4.5 model\",\n"
         + "  \"version\": 1,\n"
         + "  \"protocol\": \"aws_sigv4\",\n"
+        + "  \"client_config\": {\n"
+        + "    \"max_connection\": 200\n"
+        + "  },\n"
         + "  \"parameters\": {\n"
         + "    \"region\": \""
         + GITHUB_CI_AWS_REGION


### PR DESCRIPTION
### Description
Validate custom model archives to prevent loading attacker-controlled executable code during model registration and deployment.

The fix has two complementary checks:
1. Reject executable file types in the archive: `.jar`, `.class`, `.so`, `.dylib`, `.dll`.
2. Constrain `serving.properties` class-loading keys (`blockFactory`, `translatorFactory`, `translator`) to DJL built-in classes only — values must start with `ai.djl.`. Non-class keys (e.g. application, which is a DJL
  Application descriptor path, not a class) are left untouched.

### Coverage — enforced on every registration/deploy route
The validation is applied at both choke points so no registration path is left uncovered:
  - Register time — `ModelHelper.verifyModelZipFile` (register-by-URL path), scanning zip entries before the archive is split/stored.
  - Deploy/load time — a new `ModelHelper.verifyModelDirSafety(Path)` walks the unzipped model directory right after `ZipUtils.unzip` and before DJL loads any class. It is wired into both `DLModel.loadModel` and `DLModelExecute.loadModel`.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
