### PR TITLE
[BUG] Fix update memory container masking 404/403 as 500

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerAction.java
@@ -14,7 +14,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -144,7 +143,7 @@ public class TransportDeleteMemoryContainerAction extends HandledTransportAction
                     }
                 }, e -> {
                     log.error("Failed to check for shared index prefix, aborting deletion for safety", e);
-                    actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                    actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
                 }));
             } else {
                 // No index deletion requested, proceed with container-only deletion
@@ -159,16 +158,9 @@ public class TransportDeleteMemoryContainerAction extends HandledTransportAction
                 );
             }
         }, error -> {
-            // Preserve client errors (4XX) with their detailed messages
-            if (error instanceof OpenSearchException) {
-                OpenSearchException osException = (OpenSearchException) error;
-                if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
-                    actionListener.onFailure(error);
-                    return;
-                }
-            }
             log.error("Failed to retrieve memory container: {} for deletion", memoryContainerId, error);
-            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+            // Preserve client errors (4xx + IllegalArgumentException) with their real status; sanitize the rest to 500.
+            actionListener.onFailure(RestActionUtils.wrapAsStatusException(error));
         }));
     }
 
@@ -220,8 +212,11 @@ public class TransportDeleteMemoryContainerAction extends HandledTransportAction
     ) {
         if (throwable != null) {
             Exception cause = SdkClientUtils.unwrapAndConvertToException(throwable);
+            // The delete call does not throw when the document is absent (that surfaces as a NOT_FOUND
+            // DeleteResponse on the success path), so any throwable here is a genuine failure. Preserve its
+            // real status instead of masking every error as a misleading 404.
             log.error("Failed to delete ML Memory Container {}", memoryContainerId, cause);
-            actionListener.onFailure((new OpenSearchStatusException("Failed to find memory container", RestStatus.NOT_FOUND)));
+            actionListener.onFailure(RestActionUtils.wrapAsStatusException(cause));
         } else {
             try {
                 DeleteResponse deleteResponse = response.deleteResponse();
@@ -298,16 +293,9 @@ public class TransportDeleteMemoryContainerAction extends HandledTransportAction
                     );
                 actionListener.onResponse(deleteResponse);
             }, e -> {
-                // Preserve client errors (4XX) with their detailed messages
-                if (e instanceof OpenSearchException) {
-                    OpenSearchException osException = (OpenSearchException) e;
-                    if (osException.status().getStatus() >= 400 && osException.status().getStatus() < 500) {
-                        actionListener.onFailure(e);
-                        return;
-                    }
-                }
                 log.error("Failed to delete selective memory indices [{}] for container: {}.", memoryContainerId, indicesToDelete, e);
-                actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                // Preserve client errors (4xx + IllegalArgumentException) with their real status; sanitize the rest to 500.
+                actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
             }));
         } else {
             log.info("No valid memory indices to delete for container: {}", memoryContainerId);

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportGetMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportGetMemoryContainerAction.java
@@ -148,7 +148,7 @@ public class TransportGetMemoryContainerAction extends HandledTransportAction<Ac
             wrappedListener.onFailure(new OpenSearchStatusException("Failed to find memory container index", RestStatus.NOT_FOUND));
         } else {
             log.error("Failed to get ML memory container {}", memoryContainerId, cause);
-            wrappedListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+            wrappedListener.onFailure(RestActionUtils.wrapAsStatusException(cause));
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerAction.java
@@ -212,7 +212,9 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                     emitDisableSessionRetentionWarning(currentConfig);
                 } catch (Exception e) {
                     log.error("Failed to update configuration for container {}", memoryContainerId, e);
-                    actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                    // Validation failures (IllegalArgumentException -> 400) and status-carrying exceptions
+                    // (e.g. a 404 strategy-not-found) must reach the client with their real status, not a blanket 500.
+                    actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
                     return;
                 }
             }
@@ -221,7 +223,8 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
             performUpdate(ML_MEMORY_CONTAINER_INDEX, memoryContainerId, updateFields, actionListener);
         }, e -> {
             log.error("Failed to get memory container for update", e);
-            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+            // Preserve the original status (e.g. 404 when the container doesn't exist, 403 on access denial).
+            actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
         }));
     }
 
@@ -383,7 +386,7 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                 performUpdate(ML_MEMORY_CONTAINER_INDEX, memoryContainerId, updateFields, listener);
             }, e -> {
                 log.error("Failed to create history index '{}'", historyIndexName, e);
-                listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                listener.onFailure(RestActionUtils.wrapAsStatusException(e));
             }));
         } else {
             updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, config);
@@ -415,7 +418,7 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
                     performUpdate(ML_MEMORY_CONTAINER_INDEX, memoryContainerId, updateFields, listener);
                 }, e -> {
                     log.error("Failed to create history index '{}'", historyIndexName, e);
-                    listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                    listener.onFailure(RestActionUtils.wrapAsStatusException(e));
                 }));
             } else {
                 updateFields.put(MEMORY_STORAGE_CONFIG_FIELD, config);
@@ -424,7 +427,7 @@ public class TransportUpdateMemoryContainerAction extends HandledTransportAction
             }
         }, e -> {
             log.error("Failed to create long-term index '{}'", longTermIndexName, e);
-            listener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+            listener.onFailure(RestActionUtils.wrapAsStatusException(e));
         }));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -206,7 +206,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                         processAndIndexMemory(input, container, user, actionListener, true);
                     }, e -> {
                         log.error("Failed to index session data", e);
-                        actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+                        actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
                     });
                     memoryContainerHelper.indexData(configuration, indexRequest, responseActionListener);
                 }, exception -> {
@@ -291,7 +291,7 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
             }
             // A genuine session-write failure: do not proceed, or we would create orphan-eligible working memory.
             log.error("Failed to create backing session doc for session_id [{}]; aborting add-memories", sessionId, e);
-            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+            actionListener.onFailure(RestActionUtils.wrapAsStatusException(e));
         }));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
+++ b/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -382,5 +384,38 @@ public class RestActionUtils {
                 log.debug("Put MCP header: {}", headerName);
             }
         }
+    }
+
+    /**
+     * Wraps an exception for an {@link ActionListener} failure so that the client receives a meaningful HTTP status
+     * instead of a blanket 500, while never leaking server-side error detail.
+     * <p>
+     * The REST layer derives the response status via {@link ExceptionsHelper#status(Throwable)}. This helper forwards
+     * only exceptions that represent a genuine <em>client</em> error, so their real status and message reach the caller:
+     * <ul>
+     *   <li>an {@link OpenSearchException} whose {@code status()} is in the 4xx range (e.g. 404 not-found, 403 access
+     *       denied, 409 conflict, 429 too-many-requests); and</li>
+     *   <li>an {@link IllegalArgumentException}, which the REST layer maps to {@code 400 BAD_REQUEST}.</li>
+     * </ul>
+     * Everything else — including {@code 5xx} {@link OpenSearchException}s whose messages may embed internal
+     * infrastructure detail (node addresses, shard routing, cluster-block reasons) and any other unexpected exception —
+     * is replaced with a generic {@code 500 Internal server error}. This matches the 4xx-only forwarding pattern used by
+     * the sibling failure handlers in the memory-container transport actions and keeps server internals out of client
+     * responses.
+     *
+     * @param e the exception received by the failure handler
+     * @return the exception to pass to {@link ActionListener#onFailure(Exception)}
+     */
+    public static Exception wrapAsStatusException(Exception e) {
+        if (e instanceof IllegalArgumentException) {
+            return e;
+        }
+        if (e instanceof OpenSearchException) {
+            int status = ((OpenSearchException) e).status().getStatus();
+            if (status >= 400 && status < 500) {
+                return e;
+            }
+        }
+        return new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportDeleteMemoryContainerActionTests.java
@@ -29,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
@@ -229,7 +230,12 @@ public class TransportDeleteMemoryContainerActionTests extends OpenSearchTestCas
 
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(actionListener).onFailure(argumentCaptor.capture());
-        assertEquals("Failed to find memory container", argumentCaptor.getValue().getMessage());
+        // A genuine delete failure must NOT be masked as a misleading 404 "Failed to find memory container".
+        // A plain unexpected exception surfaces as a sanitized 500.
+        Exception captured = argumentCaptor.getValue();
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(captured));
+        assertTrue(captured instanceof OpenSearchStatusException);
+        assertEquals("Internal server error", captured.getMessage());
     }
 
     public void testDeleteMemoryContainer_IndexNotFoundException() {
@@ -250,6 +256,28 @@ public class TransportDeleteMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(exception instanceof IndexNotFoundException);
         assertEquals(RestStatus.NOT_FOUND, ((IndexNotFoundException) exception).status());
         assertTrue(exception.getMessage().contains("Memory container index not found"));
+    }
+
+    public void testDeleteMemoryContainer_GetContainerFails_SanitizesServerError() {
+        // Regression for the get-container failure handler: an unexpected server-side exception must be
+        // sanitized to a generic 500 so internal detail never reaches the client.
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException("shard [3] on node [10.0.0.5:9300] unavailable"));
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        transportDeleteMemoryContainerAction.doExecute(null, mlMemoryContainerDeleteRequest, actionListener);
+
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+
+        Exception exception = argumentCaptor.getValue();
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(exception));
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals("Internal server error", exception.getMessage());
+        // The raw infrastructure detail must not leak through.
+        assertFalse(exception.getMessage().contains("10.0.0.5"));
     }
 
     public void testDeleteMemoryContainer_MultiTenancyEnabled_ValidTenantId() {

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportUpdateMemoryContainerActionTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.update.UpdateResponse;
@@ -261,6 +262,36 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
         assertTrue(exception instanceof OpenSearchStatusException);
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) exception).status());
         assertTrue(exception.getMessage().contains("Internal server error"));
+    }
+
+    // Regression for BD01: updating a container that does not exist must surface the underlying 404 rather than
+    // being masked as a blanket 500. The get-container step fails with a status-carrying exception, which the
+    // failure handler must forward unchanged.
+    public void testDoExecuteWhenGetContainerFails_PreservesNotFoundStatus() {
+        MLUpdateMemoryContainerInput input = MLUpdateMemoryContainerInput.builder().name("updated-name").build();
+        MLUpdateMemoryContainerRequest request = MLUpdateMemoryContainerRequest
+            .builder()
+            .memoryContainerId("nonexistent-container-id")
+            .mlUpdateMemoryContainerInput(input)
+            .build();
+
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> containerListener = invocation.getArgument(1);
+            containerListener
+                .onFailure(new OpenSearchStatusException("Memory container not found: nonexistent-container-id", RestStatus.NOT_FOUND));
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(any(), any());
+
+        action.doExecute(task, request, listener);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
+
+        Exception exception = captor.getValue();
+        assertEquals(RestStatus.NOT_FOUND, ExceptionsHelper.status(exception));
+        assertTrue(exception.getMessage().contains("Memory container not found"));
     }
 
     public void testDoExecuteWhenAccessDenied() {
@@ -684,9 +715,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
         verify(listener).onFailure(captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof OpenSearchStatusException);
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) exception).status());
-        assertTrue(exception.getMessage().contains("Internal server error"));
+        // A non-existent strategy id is a 404, and must surface as such instead of a masked 500.
+        assertEquals(RestStatus.NOT_FOUND, ExceptionsHelper.status(exception));
+        assertTrue(exception.getMessage().contains("nonexistent_999"));
     }
 
     public void testUpdateStrategies_CannotChangeType() {
@@ -762,9 +793,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
         verify(listener).onFailure(captor.capture());
 
         Exception exception = captor.getValue();
-        assertTrue(exception instanceof OpenSearchStatusException);
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) exception).status());
-        assertTrue(exception.getMessage().contains("Internal server error"));
+        // Changing a strategy type is a client validation error -> 400, not a masked 500.
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(exception));
+        assertTrue(exception.getMessage().contains("Cannot change strategy type"));
     }
 
     public void testUpdateStrategies_PartialFieldUpdate() {
@@ -1124,9 +1155,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(captor.capture());
-        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) captor.getValue()).status());
-        assertTrue(captor.getValue().getMessage().contains("Internal server error"));
+        // Missing-model validation is a client error -> 400, not a masked 500.
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(captor.getValue()));
+        assertTrue(captor.getValue().getMessage().contains("Strategies require"));
     }
 
     public void testUpdateContainer_AddStrategyWithOnlyLlm_ShouldFail() {
@@ -1169,9 +1200,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(captor.capture());
-        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) captor.getValue()).status());
-        assertTrue(captor.getValue().getMessage().contains("Internal server error"));
+        // Missing-model validation is a client error -> 400, not a masked 500.
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(captor.getValue()));
+        assertTrue(captor.getValue().getMessage().contains("Strategies require"));
     }
 
     public void testUpdateContainer_ChangeEmbeddingModel_ShouldFail() {
@@ -1228,9 +1259,9 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(captor.capture());
-        assertTrue(captor.getValue() instanceof OpenSearchStatusException);
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) captor.getValue()).status());
-        assertTrue(captor.getValue().getMessage().contains("Internal server error"));
+        // Changing embedding config once strategies exist is a client error -> 400, not a masked 500.
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(captor.getValue()));
+        assertTrue(captor.getValue().getMessage().contains("Cannot change embedding configuration"));
     }
 
     public void testUpdateContainer_SameEmbeddingValues_ShouldSucceed() {
@@ -2278,9 +2309,12 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         action.doExecute(task, request, listener);
 
-        // Verify failure - history index creation should fail
-        verify(listener).onFailure(any(Exception.class));
+        // Verify failure - history index creation should fail, and an unexpected RuntimeException must be
+        // sanitized to a generic 500 (no server-side detail leaked to the client).
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
         verify(listener, never()).onResponse(any());
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(captor.getValue()));
     }
 
     public void testUpdateContainer_TransitionToStrategies_LongTermIndexCreationFails() {
@@ -2396,9 +2430,12 @@ public class TransportUpdateMemoryContainerActionTests extends OpenSearchTestCas
 
         action.doExecute(task, request, listener);
 
-        // Verify failure - long-term index creation should fail
-        verify(listener).onFailure(any(Exception.class));
+        // Verify failure - long-term index creation should fail, and an unexpected RuntimeException must be
+        // sanitized to a generic 500 (no server-side detail leaked to the client).
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(captor.capture());
         verify(listener, never()).onResponse(any());
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(captor.getValue()));
     }
 
 }

--- a/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/utils/RestActionUtilsTests.java
@@ -35,6 +35,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchWrapperException;
 import org.opensearch.Version;
 import org.opensearch.action.search.SearchResponse;
@@ -560,5 +561,76 @@ public class RestActionUtilsTests extends OpenSearchTestCase {
         assertNull(threadContext.getHeader(MCP_HEADER_AWS_REGION));
         assertNull(threadContext.getHeader(MCP_HEADER_AWS_SERVICE_NAME));
         assertNull(threadContext.getHeader(MCP_HEADER_OPENSEARCH_URL));
+    }
+
+    @Test
+    public void testWrapAsStatusException_PreservesOpenSearchStatusException() {
+        // A status-carrying exception (e.g. a 404) must be forwarded unchanged so the client sees its real status.
+        org.opensearch.OpenSearchStatusException original = new org.opensearch.OpenSearchStatusException(
+            "container not found",
+            RestStatus.NOT_FOUND
+        );
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertSame(original, wrapped);
+        assertEquals(RestStatus.NOT_FOUND, ExceptionsHelper.status(wrapped));
+    }
+
+    @Test
+    public void testWrapAsStatusException_PreservesIllegalArgumentAsBadRequest() {
+        // IllegalArgumentException maps to 400 in the REST layer, so it is forwarded rather than masked as 500.
+        IllegalArgumentException original = new IllegalArgumentException("bad input");
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertSame(original, wrapped);
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(wrapped));
+    }
+
+    @Test
+    public void testWrapAsStatusException_MasksUnexpectedExceptionAsSanitized500() {
+        // A genuinely unexpected exception must be replaced with a sanitized 500 that leaks no internal detail.
+        Exception original = new RuntimeException("connection reset by peer at 10.0.0.5:9300");
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertTrue(wrapped instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(wrapped));
+        assertEquals("Internal server error", wrapped.getMessage());
+        assertFalse(wrapped.getMessage().contains("10.0.0.5"));
+    }
+
+    @Test
+    public void testWrapAsStatusException_PreservesIndexNotFoundAsNotFound() {
+        // IndexNotFoundException is an OpenSearchException carrying a 404 and must be preserved.
+        IndexNotFoundException original = new IndexNotFoundException("missing-index");
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertSame(original, wrapped);
+        assertEquals(RestStatus.NOT_FOUND, ExceptionsHelper.status(wrapped));
+    }
+
+    @Test
+    public void testWrapAsStatusException_PreservesConflictAsClientError() {
+        // A 4xx OpenSearchException other than 404 (e.g. 409 conflict) is a client error and must be preserved.
+        org.opensearch.OpenSearchStatusException original = new org.opensearch.OpenSearchStatusException(
+            "index prefix already in use",
+            RestStatus.CONFLICT
+        );
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertSame(original, wrapped);
+        assertEquals(RestStatus.CONFLICT, ExceptionsHelper.status(wrapped));
+    }
+
+    @Test
+    public void testWrapAsStatusException_SanitizesServerSideOpenSearchException() {
+        // A 5xx OpenSearchException is a server-side failure whose message may embed internal infrastructure
+        // detail (node addresses, shard routing). It must be sanitized to a generic 500, not forwarded, so the
+        // helper does not widen the information-disclosure surface beyond the package's 4xx-only forwarding norm.
+        org.opensearch.OpenSearchStatusException original = new org.opensearch.OpenSearchStatusException(
+            "all shards failed on node [abc123] at [10.0.0.5:9300]",
+            RestStatus.INTERNAL_SERVER_ERROR
+        );
+        Exception wrapped = RestActionUtils.wrapAsStatusException(original);
+        assertNotSame(original, wrapped);
+        assertTrue(wrapped instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ExceptionsHelper.status(wrapped));
+        assertEquals("Internal server error", wrapped.getMessage());
+        assertFalse(wrapped.getMessage().contains("10.0.0.5"));
+        assertFalse(wrapped.getMessage().contains("abc123"));
     }
 }


### PR DESCRIPTION
### Description

The failure lambda in `TransportUpdateMemoryContainerAction.doExecute()` discarded the exception from `MemoryContainerHelper.getMemoryContainer()` and always emitted a blanket 500. This masked the 404 raised for a missing container and the 403 raised on access denial. Now the original exception is forwarded when it already carries an HTTP status (`OpenSearchException` / `OpenSearchStatusException`); only genuinely unexpected exceptions are wrapped as 500.

**Repro:** `PUT /_plugins/_ml/memory_containers/does-not-exist` returned 500; now returns 404.

### Related Issues

N/A

### Check List

- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
