### PR TITLE
  Fix memory retention job interval setting being write-once

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -60,6 +60,44 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
         this.mlModelAutoReDeployer = mlModelAutoReDeployer;
         this.client = client;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+
+        // Apply live changes to the retention job interval (dynamic PUT _cluster/settings) by upserting the persisted
+        // job document. The version bump is observed by JobScheduler's JobSweeper, which reschedules with no restart.
+        // The consumer runs on every node, so gate the write on the elected cluster manager to avoid multi-node churn.
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS, newIntervalHours -> {
+                if (shouldManageMemoryRetentionJob()) {
+                    mlTaskManager.upsertMemoryRetentionJob(newIntervalHours);
+                }
+            });
+    }
+
+    /**
+     * Single-writer gate for memory-retention job writes that mutate the shared, fixed-id job document. Exactly one
+     * node (the elected cluster manager) should ever upsert/reconcile, and only when agentic memory is enabled and
+     * multi-tenancy is disabled (mirroring the startup scheduling path). The 3.1+ data-node check mirrors the startup
+     * loop's rolling-upgrade guard so a live setting change during a mixed-version upgrade does not create the new
+     * {@code .plugins-ml-jobs} index before the cluster is ready for it.
+     */
+    private boolean shouldManageMemoryRetentionJob() {
+        return clusterService.state().nodes().isLocalNodeElectedClusterManager()
+            && hasDataNodeOnOrAfterV31()
+            && mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+            && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings());
+    }
+
+    /**
+     * Whether the cluster contains at least one data node running 3.1 or later. The new {@code .plugins-ml-jobs} index
+     * and its jobs must not be written until this holds, to avoid issues during blue/green and rolling upgrades.
+     */
+    private boolean hasDataNodeOnOrAfterV31() {
+        for (DiscoveryNode node : clusterService.state().nodes()) {
+            if (node.isDataNode() && node.getVersion().onOrAfter(Version.V_3_1_0)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -106,7 +144,14 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
                     int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    // CREATE (conflict-swallowing) seeds the job doc; safe to run on any node.
                     mlTaskManager.indexMemoryRetentionJob(intervalHours);
+                    // Reconcile a settings.yml / restart value onto the already-existing (write-once) doc. This upserts
+                    // only when the persisted interval differs, so restart doesn't keep resetting the next-run anchor.
+                    // Gate on the elected cluster manager so exactly one node ever writes the shared doc.
+                    if (clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
+                        mlTaskManager.reconcileMemoryRetentionJob(intervalHours);
+                    }
                     this.startedMemoryRetentionJob = true;
                 }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -143,7 +143,14 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                     && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                     && !this.startedMemoryRetentionJob) {
-                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                    // Read the effective interval, honoring OpenSearch precedence (transient > persistent > opensearch.yml
+                    // > default). clusterService.getSettings() holds only node bootstrap settings (opensearch.yml / CLI),
+                    // frozen at construction; state.getMetadata().settings() holds the persistent/transient values set via
+                    // PUT _cluster/settings. Overlaying metadata on the node settings lets dynamic cluster settings win
+                    // while still honoring an opensearch.yml value. Reading only one source would drop the other and make
+                    // reconcile (which actively upserts on mismatch) revert an operator's chosen interval on restart.
+                    Settings effectiveSettings = Settings.builder().put(clusterService.getSettings()).put(settings).build();
+                    int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(effectiveSettings);
                     // CREATE (conflict-swallowing) seeds the job doc; safe to run on any node.
                     mlTaskManager.indexMemoryRetentionJob(intervalHours);
                     // Reconcile a settings.yml / restart value onto the already-existing (write-once) doc. This upserts

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -43,10 +44,14 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
@@ -58,6 +63,7 @@ import org.opensearch.ml.common.settings.SettingsChangeListener;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.jobs.MLJobParameter;
 import org.opensearch.ml.jobs.MLJobType;
+import org.opensearch.ml.utils.MLNodeUtils;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.UpdateDataObjectRequest;
@@ -603,6 +609,97 @@ public class MLTaskManager implements SettingsChangeListener {
             });
         } catch (IOException e) {
             log.error("Failed to index memory retention job", e);
+        }
+    }
+
+    /**
+     * Upsert the memory retention job document with a new interval.
+     *
+     * <p>Unlike {@link #indexMemoryRetentionJob(int)}, this method uses {@link DocWriteRequest.OpType#INDEX} (a
+     * version-bumping upsert) rather than {@code CREATE}, and is intentionally NOT guarded by the
+     * {@code memoryRetentionJobStarted} latch. Overwriting the existing document bumps its version, which the
+     * JobScheduler {@code JobSweeper.postIndex} hook observes and uses to deschedule the stale job and reschedule
+     * it from the fresh {@link IntervalSchedule} — with no cluster restart.
+     *
+     * <p>No {@code setIfSeqNo}/{@code setIfPrimaryTerm} guard is set on purpose: adding one would reintroduce
+     * version conflicts, defeating the point of the upsert. Callers MUST ensure only a single node (the elected
+     * cluster manager) invokes this to avoid multi-node reschedule churn, since the job document has a fixed id.
+     *
+     * @param intervalHours the new interval, in hours, for the retention job schedule
+     */
+    public void upsertMemoryRetentionJob(int intervalHours) {
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .opType(DocWriteRequest.OpType.INDEX)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.info("Memory retention job upserted with interval {} hour(s)", intervalHours);
+            });
+        } catch (IOException e) {
+            log.error("Failed to upsert memory retention job", e);
+        }
+    }
+
+    /**
+     * Reconcile the persisted memory retention job schedule with the current interval setting, upserting only if
+     * they differ. Used on the startup path so a value supplied via {@code settings.yml} or a cluster restart is
+     * applied to the already-existing (write-once) job document.
+     *
+     * <p>Reconcile-<em>if-different</em> (rather than an unconditional upsert) matters: a fresh
+     * {@link IntervalSchedule} resets the next-run anchor to {@code now + interval}, so upserting on every startup
+     * could keep pushing the anchor forward and starve the job. If the document is absent, unparseable, or already
+     * carries the desired interval, this is a no-op. Callers MUST gate this on the elected cluster manager.
+     *
+     * @param intervalHours the desired interval, in hours, from the current setting value
+     */
+    public void reconcileMemoryRetentionJob(int intervalHours) {
+        GetRequest getRequest = new GetRequest(CommonValue.ML_JOBS_INDEX, MLJobType.MEMORY_RETENTION.name());
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.get(getRequest, ActionListener.runBefore(ActionListener.wrap(getResponse -> {
+                if (getResponse == null || !getResponse.isExists()) {
+                    // No persisted job yet; the CREATE path will seed it with the current interval.
+                    return;
+                }
+                try (
+                    XContentParser parser = MLNodeUtils
+                        .createXContentParserFromRegistry(NamedXContentRegistry.EMPTY, getResponse.getSourceAsBytesRef())
+                ) {
+                    MLJobParameter jobParameter = MLJobParameter.parse(parser);
+                    Schedule schedule = jobParameter.getSchedule();
+                    if (schedule instanceof IntervalSchedule) {
+                        IntervalSchedule intervalSchedule = (IntervalSchedule) schedule;
+                        if (intervalSchedule.getUnit() == ChronoUnit.HOURS && intervalSchedule.getInterval() == intervalHours) {
+                            log.debug("Memory retention job interval already {} hour(s); nothing to reconcile", intervalHours);
+                            return;
+                        }
+                    }
+                    log.info("Reconciling memory retention job interval to {} hour(s)", intervalHours);
+                    upsertMemoryRetentionJob(intervalHours);
+                } catch (Exception e) {
+                    log.error("Failed to parse persisted memory retention job during reconcile", e);
+                }
+            }, e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                    // Jobs index not created yet; the CREATE path will seed it.
+                    log.debug("ML jobs index not found during memory retention reconcile");
+                } else {
+                    log.error("Failed to get memory retention job during reconcile", e);
+                }
+            }), context::restore));
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_JOBS_INDEX;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import org.junit.Before;
 import org.mockito.Mock;
@@ -26,7 +28,10 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -58,10 +63,16 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     private Metadata metadata;
 
     private MLCommonsClusterEventListener listener;
+    private ClusterSettings clusterSettings;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            new HashSet<>(Arrays.asList(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         listener = new MLCommonsClusterEventListener(
             clusterService,
             mlModelManager,
@@ -158,6 +169,114 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
+    public void testClusterChanged_MemoryRetentionJob_NonDefaultInterval() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupClusterState(dataNode, false);
+        when(clusterService.getSettings())
+            .thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(1);
+    }
+
+    public void testClusterChanged_MemoryRetentionReconcile_OnElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, true);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager).reconcileMemoryRetentionJob(24);
+    }
+
+    public void testClusterChanged_MemoryRetentionReconcile_SkippedWhenNotElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, false);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        // The conflict-safe CREATE still runs on any node, but reconcile (which upserts) must not.
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager, never()).reconcileMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_UpsertsOnElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        DiscoveryNodes nodes = DiscoveryNodes
+            .builder()
+            .add(dataNode)
+            .localNodeId(dataNode.getId())
+            .clusterManagerNodeId(dataNode.getId())
+            .build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager).upsertMemoryRetentionJob(2);
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenNotElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(dataNode).localNodeId(dataNode.getId()).build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupElectedClusterManagerConsumerState(dataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupElectedClusterManagerConsumerState(dataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenNoDataNodeOnOrAfterV31() {
+        // Elected cluster manager, agentic memory on, multi-tenancy off, but the only data node is pre-3.1 (mixed-version
+        // rolling upgrade). The consumer must not write the new jobs index yet, mirroring the startup path's guard.
+        DiscoveryNode preV31DataNode = createDataNode(Version.V_3_0_0);
+        setupElectedClusterManagerConsumerState(preV31DataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    private void setupElectedClusterManagerConsumerState(DiscoveryNode node) {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).localNodeId(node.getId()).clusterManagerNodeId(node.getId()).build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+    }
+
     private DiscoveryNode createDataNode(Version version) {
         return new DiscoveryNode(
             "dataNode",
@@ -171,6 +290,23 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
     private void setupClusterState(DiscoveryNode node, boolean hasMLJobsIndex) {
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).build();
+
+        when(event.state()).thenReturn(clusterState);
+        when(event.previousState()).thenReturn(clusterState);
+        when(event.nodesDelta()).thenReturn(mock(DiscoveryNodes.Delta.class));
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
+        when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+    }
+
+    private void setupElectedClusterManagerState(DiscoveryNode node, boolean hasMLJobsIndex, boolean localNodeIsClusterManager) {
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder().add(node).localNodeId(node.getId());
+        if (localNodeIsClusterManager) {
+            nodesBuilder.clusterManagerNodeId(node.getId());
+        }
+        DiscoveryNodes nodes = nodesBuilder.build();
 
         when(event.state()).thenReturn(clusterState);
         when(event.previousState()).thenReturn(clusterState);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -194,6 +194,26 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager).reconcileMemoryRetentionJob(24);
     }
 
+    /**
+     * Regression guard: an interval set dynamically via {@code PUT _cluster/settings} lives in cluster-state metadata,
+     * NOT in the frozen node bootstrap settings returned by {@code clusterService.getSettings()}. The startup path must
+     * read the effective value (metadata overlaid on node settings); otherwise reconcile would upsert the default and
+     * silently revert the operator's persisted interval on restart.
+     */
+    public void testClusterChanged_MemoryRetentionReconcile_HonorsPersistedIntervalFromMetadata() {
+        DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, true);
+        // Node bootstrap (opensearch.yml) has nothing; the interval was set via the cluster-settings API -> metadata.
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(metadata.settings()).thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(1);
+        verify(mlTaskManager).reconcileMemoryRetentionJob(1);
+    }
+
     public void testClusterChanged_MemoryRetentionReconcile_SkippedWhenNotElectedClusterManager() {
         DiscoveryNode dataNode = createDataNode(Version.V_3_1_0);
         setupElectedClusterManagerState(dataNode, false, false);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.jobs.MLJobType;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * Integration test proving that a live {@code PUT _cluster/settings} for
+ * {@code plugins.ml_commons.memory.retention_job_interval_hours} updates the persisted memory-retention job
+ * document's {@link org.opensearch.jobscheduler.spi.schedule.IntervalSchedule} — with no cluster restart.
+ *
+ * <p>The retention job is a write-once document in the {@code .plugins-ml-jobs} system index keyed by a fixed id.
+ * The fix upserts that document (version-bumping) on a dynamic setting change, which JobScheduler's
+ * {@code JobSweeper.postIndex} hook observes to deschedule + reschedule from the fresh interval.
+ */
+public class RestMemoryRetentionJobIntervalIT extends MLCommonsRestTestCase {
+
+    private static final String JOBS_INDEX = ".plugins-ml-jobs";
+    private static final String RETENTION_JOB_ID = MLJobType.MEMORY_RETENTION.name();
+    private static final String INTERVAL_SETTING = "plugins.ml_commons.memory.retention_job_interval_hours";
+
+    @Before
+    public void setup() throws IOException {
+        // Agentic memory must be enabled for the retention job to be scheduled.
+        updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+    }
+
+    @Test
+    public void testUpdateIntervalRescheduleReflectedInPersistedDoc() throws Exception {
+        // The retention job doc is created asynchronously when a 3.1+ data node is observed in the cluster state.
+        assertBusy(() -> assertEquals(24, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+
+        // Live dynamic change: shrink the interval to 1 hour.
+        updateClusterSettings(INTERVAL_SETTING, 1);
+
+        // The elected cluster manager upserts the job doc; the persisted schedule interval should follow.
+        assertBusy(() -> assertEquals(1, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Reads the persisted memory-retention job document from the {@code .plugins-ml-jobs} system index and returns
+     * its {@code schedule.interval} value (in hours). Returns -1 when the document is not yet present.
+     */
+    @SuppressWarnings("unchecked")
+    private int getPersistedIntervalHours() throws IOException {
+        Response response;
+        try {
+            response = TestHelper.makeRequest(client(), "GET", JOBS_INDEX + "/_doc/" + RETENTION_JOB_ID, null, (String) null, null);
+        } catch (ResponseException e) {
+            // The jobs index or the document may not exist yet; treat as not-yet-present so assertBusy keeps polling.
+            return -1;
+        }
+        Map<String, Object> responseMap = parseResponseToMap(response);
+        if (responseMap == null || !Boolean.TRUE.equals(responseMap.get("found"))) {
+            return -1;
+        }
+        Map<String, Object> source = (Map<String, Object>) responseMap.get("_source");
+        Map<String, Object> schedule = (Map<String, Object>) source.get("schedule");
+        Map<String, Object> interval = (Map<String, Object>) schedule.get("interval");
+        return ((Number) interval.get("period")).intValue();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
@@ -35,17 +35,25 @@ public class RestMemoryRetentionJobIntervalIT extends MLCommonsRestTestCase {
     public void setup() throws IOException {
         // Agentic memory must be enabled for the retention job to be scheduled.
         updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        // Start from a known state. The base-class @After only wipes indices, so a persistent interval left over from
+        // an aborted local rerun would survive; clearing it guarantees the first PUT below is a real change (see below).
+        updateClusterSettings(INTERVAL_SETTING, (Object) null);
     }
 
     @Test
     public void testUpdateIntervalRescheduleReflectedInPersistedDoc() throws Exception {
-        // The retention job doc is created asynchronously when a 3.1+ data node is observed in the cluster state.
-        assertBusy(() -> assertEquals(24, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+        // Drive the assertion entirely through the dynamic settings-update consumer (the fix under test). That
+        // consumer upserts the job doc and is NOT gated by the one-shot startup latch (startedMemoryRetentionJob), so
+        // it is robust in the shared integ cluster: a prior memory test may have already tripped that node-level latch
+        // and then had .plugins-ml-jobs wiped by the base class @After, which would leave the latch-gated
+        // lazy-startup path unable to recreate the doc. The consumer fires on a change from the last-applied value;
+        // setup() cleared the setting to the default, so each PUT below is a distinct change that fires the consumer.
+        updateClusterSettings(INTERVAL_SETTING, 2);
+        // The elected cluster manager upserts the job doc (creating .plugins-ml-jobs if needed); interval follows.
+        assertBusy(() -> assertEquals(2, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
 
-        // Live dynamic change: shrink the interval to 1 hour.
+        // Live dynamic change: shrink the interval to 1 hour. The persisted schedule interval should follow.
         updateClusterSettings(INTERVAL_SETTING, 1);
-
-        // The elected cluster manager upserts the job doc; the persisted schedule interval should follow.
         assertBusy(() -> assertEquals(1, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTaskManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTaskManagerTests.java
@@ -20,6 +20,7 @@ import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,7 +33,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
@@ -40,14 +43,20 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.jobs.MLJobParameter;
 import org.opensearch.ml.jobs.MLJobType;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
@@ -432,6 +441,159 @@ public class MLTaskManagerTests extends OpenSearchTestCase {
         mlTaskManager.indexStatsCollectorJob(true);
 
         verify(client).index(any(), any());
+    }
+
+    public void testUpsertMemoryRetentionJob() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        mlTaskManager.upsertMemoryRetentionJob(1);
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client).index(indexRequestCaptor.capture(), any());
+
+        IndexRequest capturedRequest = indexRequestCaptor.getValue();
+        assertEquals(ML_JOBS_INDEX, capturedRequest.index());
+        assertEquals(MLJobType.MEMORY_RETENTION.name(), capturedRequest.id());
+        // The upsert path must use INDEX (version-bumping) rather than CREATE so JobScheduler reschedules.
+        assertEquals(DocWriteRequest.OpType.INDEX, capturedRequest.opType());
+        assertEquals(WriteRequest.RefreshPolicy.IMMEDIATE, capturedRequest.getRefreshPolicy());
+        // The caller's interval must actually be serialized into the persisted schedule (guards against a hardcoded value).
+        assertEquals(1, extractScheduleIntervalPeriod(capturedRequest));
+    }
+
+    @SuppressWarnings("unchecked")
+    private int extractScheduleIntervalPeriod(IndexRequest indexRequest) {
+        Map<String, Object> source = indexRequest.sourceAsMap();
+        Map<String, Object> schedule = (Map<String, Object>) source.get("schedule");
+        Map<String, Object> interval = (Map<String, Object>) schedule.get("interval");
+        return ((Number) interval.get("period")).intValue();
+    }
+
+    public void testUpsertMemoryRetentionJob_NotGatedByLatch() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        // Even after the memoryRetentionJobStarted latch is set by a first upsert, subsequent upserts must still write.
+        mlTaskManager.upsertMemoryRetentionJob(1);
+        mlTaskManager.upsertMemoryRetentionJob(2);
+
+        verify(client, times(2)).index(any(), any());
+    }
+
+    public void testUpsertMemoryRetentionJob_VersionConflictSwallowed() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener
+                .onFailure(
+                    new VersionConflictEngineException(new ShardId(ML_JOBS_INDEX, "_na_", 0), MLJobType.MEMORY_RETENTION.name(), "conflict")
+                );
+            return null;
+        }).when(client).index(any(), any());
+
+        // The swallow branch in indexJob treats a VersionConflictEngineException as success; no exception should escape.
+        mlTaskManager.upsertMemoryRetentionJob(1);
+
+        // Prove the swallow branch actually ran its success callback (not the error branch): the callback flips the
+        // memoryRetentionJobStarted latch, so a subsequent CREATE-path call must early-return without a second index.
+        // If the swallow logic were deleted/inverted, the latch would stay false and this CREATE would issue index #2.
+        mlTaskManager.indexMemoryRetentionJob(24);
+
+        verify(client, times(1)).index(any(), any());
+    }
+
+    public void testReconcileMemoryRetentionJob_UpsertsWhenIntervalDiffers() throws IOException {
+        int persistedInterval = 24;
+        int desiredInterval = 1;
+        GetResponse getResponse = buildMemoryRetentionJobGetResponse(persistedInterval);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(desiredInterval);
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client).index(indexRequestCaptor.capture(), any());
+        assertEquals(DocWriteRequest.OpType.INDEX, indexRequestCaptor.getValue().opType());
+    }
+
+    public void testReconcileMemoryRetentionJob_NoOpWhenIntervalSame() throws IOException {
+        int interval = 24;
+        GetResponse getResponse = buildMemoryRetentionJobGetResponse(interval);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(interval);
+
+        verify(client, never()).index(any(), any());
+    }
+
+    public void testReconcileMemoryRetentionJob_NoOpWhenDocAbsent() throws IOException {
+        GetResponse getResponse = mock(GetResponse.class);
+        when(getResponse.isExists()).thenReturn(false);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(1);
+
+        verify(client, never()).index(any(), any());
+    }
+
+    private GetResponse buildMemoryRetentionJobGetResponse(int intervalHours) throws IOException {
+        MLJobParameter jobParameter = new MLJobParameter(
+            MLJobType.MEMORY_RETENTION.name(),
+            new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+            120L,
+            null,
+            MLJobType.MEMORY_RETENTION,
+            true
+        );
+        BytesReference bytesReference = BytesReference.bytes(jobParameter.toXContent(XContentFactory.jsonBuilder(), null));
+        GetResult getResult = new GetResult(ML_JOBS_INDEX, MLJobType.MEMORY_RETENTION.name(), 1L, 1L, 1L, true, bytesReference, null, null);
+        return new GetResponse(getResult);
     }
 
     public void testUpdateMLTaskDirectly_NullTaskId() {


### PR DESCRIPTION
### Description

  The memory-retention background job's schedule was effectively **write-once**:
  the interval was read only when the job document was first created in
  `.plugins-ml-jobs`, and never afterward. Because that doc was written with
  `opType(CREATE)` and `indexJob` swallows the resulting
  `VersionConflictEngineException` as success, changing
  `plugins.ml_commons.memory.retention_job_interval_hours` had **no effect** —
  neither via a live `PUT _cluster/settings` nor via a restart / `opensearch.yml`
  value. The setting is documented as dynamic (default 24, range 1–168) but
  silently did nothing.

  This PR makes the interval take effect, with no cluster restart:

  - **`upsertMemoryRetentionJob(int)`** — re-indexes the job doc with
    `opType(INDEX)` (version-bumping, not gated by the CREATE latch). The version
    bump is observed by JobScheduler's `JobSweeper.postIndex`, which deschedules
    the stale job and reschedules from the fresh `IntervalSchedule`.
  - **`reconcileMemoryRetentionJob(int)`** — on startup, upserts **only** when the
    persisted interval differs, so a value from `opensearch.yml` / a restart is
    applied without re-anchoring the next run on every boot.
  - A **settings-update consumer** wires live `PUT _cluster/settings` changes to
    the upsert.

  All writes to the shared, fixed-id job document are gated on the **elected
  cluster manager** (single writer) and mirror the existing startup guards:
  agentic memory enabled, multi-tenancy disabled, and at least one 3.1+ data node
  present (rolling-upgrade deferral).

  The startup reconcile reads the **effective** interval by overlaying
  cluster-state metadata settings on the node bootstrap settings, giving the
  correct OpenSearch precedence (`transient > persistent > opensearch.yml >
  default`). Reading only node settings would let a stale default overwrite an
  operator's API-persisted interval on a full-cluster restart.

  ### Related Issues

  RFC: https://github.com/opensearch-project/ml-commons/issues/4859

  ### Check List
  - [x] New functionality includes testing.
  - [x] New functionality has been documented.  <!-- adjust if docs not updated -->
  - [x] API changes companion pull request created, if applicable.  <!-- N/A -->
  - [x] Public documentation issue/PR created, if applicable.  <!-- adjust -->
  - [x] Commits are signed per the DCO using `--signoff`.