### PR TITLE
Harden MCP tool input handling, serving, and error status codes

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpSseTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpSseTool.java
@@ -61,7 +61,7 @@ public class McpSseTool implements WithModelTool {
         try {
             Map<String, String> parameters = ToolUtils.extractInputParameters(originalParameters, attributes);
             String input = parameters.get("input");
-            Map<String, Object> inputArgs = StringUtils.fromJson(input, "input");
+            Map<String, Object> inputArgs = StringUtils.fromJson(input == null || input.isBlank() ? "{}" : input, "input");
             McpSchema.CallToolResult result = mcpSyncClient.callTool(new McpSchema.CallToolRequest(this.name, inputArgs));
             String resultJson = StringUtils.toJson(result.content());
             listener.onResponse((T) resultJson);

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/McpStreamableHttpTool.java
@@ -60,7 +60,7 @@ public class McpStreamableHttpTool implements WithModelTool {
         try {
             Map<String, String> parameters = ToolUtils.extractInputParameters(originalParameters, attributes);
             String input = parameters.get("input");
-            Map<String, Object> inputArgs = StringUtils.fromJson(input, "input");
+            Map<String, Object> inputArgs = StringUtils.fromJson(input == null || input.isBlank() ? "{}" : input, "input");
             McpSchema.CallToolResult result = mcpSyncClient.callTool(new McpSchema.CallToolRequest(this.name, inputArgs));
             String resultJson = StringUtils.toJson(result.content());
             @SuppressWarnings("unchecked")

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpSseToolTests.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
@@ -21,6 +22,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.core.action.ActionListener;
@@ -88,12 +90,22 @@ public class McpSseToolTests {
     }
 
     @Test
-    public void testRunMissingInputParam() {
-        // No "input" key in parameters should be caught
-        tool.run(Collections.emptyMap(), listener);
+    public void testRunNoArguments() {
+        McpSchema.CallToolResult result = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("{}")), false, null, Map.of());
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
-        verify(listener).onFailure(any(Exception.class));
-        verify(listener, never()).onResponse(any());
+        tool.run(Collections.emptyMap(), listener);
+        tool.run(Map.of("input", ""), listener);
+        tool.run(Map.of("input", "   "), listener);
+        tool.run(Map.of("input", "{}"), listener);
+
+        ArgumentCaptor<McpSchema.CallToolRequest> requestCaptor = ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+        verify(mcpSyncClient, times(4)).callTool(requestCaptor.capture());
+        for (McpSchema.CallToolRequest request : requestCaptor.getAllValues()) {
+            assertTrue(request.arguments().isEmpty());
+        }
+        verify(listener, times(4)).onResponse("[{\"text\":\"{}\"}]");
+        verify(listener, never()).onFailure(any());
     }
 
     @Test

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/McpStreamableHttpToolTests.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.MCP_SYNC_CLIENT;
@@ -21,6 +22,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.core.action.ActionListener;
@@ -88,12 +90,22 @@ public class McpStreamableHttpToolTests {
     }
 
     @Test
-    public void testRunMissingInputParam() {
-        // No "input" key in parameters should be caught
-        tool.run(Collections.emptyMap(), listener);
+    public void testRunNoArguments() {
+        McpSchema.CallToolResult result = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("{}")), false, null, Map.of());
+        when(mcpSyncClient.callTool(any(McpSchema.CallToolRequest.class))).thenReturn(result);
 
-        verify(listener).onFailure(any(Exception.class));
-        verify(listener, never()).onResponse(any());
+        tool.run(Collections.emptyMap(), listener);
+        tool.run(Map.of("input", ""), listener);
+        tool.run(Map.of("input", "   "), listener);
+        tool.run(Map.of("input", "{}"), listener);
+
+        ArgumentCaptor<McpSchema.CallToolRequest> requestCaptor = ArgumentCaptor.forClass(McpSchema.CallToolRequest.class);
+        verify(mcpSyncClient, times(4)).callTool(requestCaptor.capture());
+        for (McpSchema.CallToolRequest request : requestCaptor.getAllValues()) {
+            assertTrue(request.arguments().isEmpty());
+        }
+        verify(listener, times(4)).onResponse("[{\"text\":\"{}\"}]");
+        verify(listener, never()).onFailure(any());
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/McpToolsHelper.java
@@ -138,33 +138,24 @@ public class McpToolsHelper {
             ActionListener<List<McpToolRegisterInput>> restoreListener = ActionListener.runBefore(listener, context::restore);
             ActionListener<SearchResponse> actionListener = ActionListener.wrap(r -> {
                 List<McpToolRegisterInput> mcpTools = new ArrayList<>();
-                List<IOException> errors = new ArrayList<>();
 
+                // Leniency is intentional and confined to this serving read path; write paths remain strict.
                 Arrays.stream(Objects.requireNonNull(r.getHits().getHits())).forEach(x -> {
                     try {
                         McpToolRegisterInput mcpTool = parseMcpTool(x.getSourceAsString());
                         mcpTools.add(mcpTool);
-                    } catch (IOException e) {
-                        errors.add(e); // Collect the error instead of calling listener.onFailure
+                    } catch (IOException | RuntimeException e) {
+                        log
+                            .error(
+                                "Skipping MCP tool document that failed to parse in index [{}]: {}",
+                                MLIndex.MCP_TOOLS.getIndexName(),
+                                x.getId(),
+                                e
+                            );
                     }
                 });
 
-                if (!errors.isEmpty()) {
-                    // Create a composite exception with all errors
-                    String errorMessage = String
-                        .format("Failed to parse %d out of %d MCP tools", errors.size(), r.getHits().getHits().length);
-                    OpenSearchException compositeException = new OpenSearchException(errorMessage);
-
-                    // Add all errors as suppressed exceptions
-                    for (IOException error : errors) {
-                        compositeException.addSuppressed(error);
-                    }
-
-                    log.error("Multiple parsing errors occurred: {}", errorMessage);
-                    restoreListener.onFailure(compositeException);
-                } else {
-                    restoreListener.onResponse(mcpTools);
-                }
+                restoreListener.onResponse(mcpTools);
             }, e -> {
                 if (e instanceof IndexNotFoundException) {
                     restoreListener.onResponse(new ArrayList<>());

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveAction.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
@@ -23,6 +24,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.MLIndex;
@@ -98,7 +100,7 @@ public class TransportMcpToolsRemoveAction extends HandledTransportAction<Action
                                 removeToolsOnNodesRequest.getMcpTools()
                             );
                         log.info(exceptionMessage);
-                        restoreListener.onFailure(new OpenSearchException(exceptionMessage));
+                        restoreListener.onFailure(new OpenSearchStatusException(exceptionMessage, RestStatus.BAD_REQUEST));
                     } else {
                         bulkDeleteMcpTools(removeToolsOnNodesRequest, foundTools, restoreListener);
                     }
@@ -106,7 +108,7 @@ public class TransportMcpToolsRemoveAction extends HandledTransportAction<Action
                     // No results found searching tools, do not proceed.
                     String exceptionMessage = "Unable to remove tools as no tool in the request found in system index";
                     log.warn(exceptionMessage);
-                    restoreListener.onFailure(new OpenSearchException(exceptionMessage));
+                    restoreListener.onFailure(new OpenSearchStatusException(exceptionMessage, RestStatus.BAD_REQUEST));
                 }
             }, e -> {
                 log.error("Failed to search mcp tools index", e);

--- a/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsUpdateAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsUpdateAction.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkResponse;
@@ -37,6 +38,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
@@ -135,12 +137,24 @@ public class TransportMcpToolsUpdateAction extends HandledTransportAction<Action
                     // If any to update tool not found, return error.
                     if (!updateToolSet.isEmpty()) {
                         log.warn("Failed to find tools: {} in system index", updateToolSet);
-                        restoreListener.onFailure(new OpenSearchException("Failed to find one or more requested tools in system index"));
+                        restoreListener
+                            .onFailure(
+                                new OpenSearchStatusException(
+                                    "Failed to find one or more requested tools in system index",
+                                    RestStatus.BAD_REQUEST
+                                )
+                            );
                     } else {
                         updateMcpTools(updateNodesRequest, searchedMcpToolWrappers, restoreListener);
                     }
                 } else {
-                    restoreListener.onFailure(new OpenSearchException("Failed to update tools as none of them is found in index"));
+                    restoreListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "Failed to update tools as none of them is found in index",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
                 }
             }, e -> {
                 log.error("Failed to search mcp tools index", e);

--- a/plugin/src/test/java/org/opensearch/ml/action/mcpserver/McpToolsHelperTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/mcpserver/McpToolsHelperTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -230,11 +231,29 @@ public class McpToolsHelperTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void test_searchAllTools_parseIOException() throws IOException {
+    public void test_searchAllTools_skipsToolMissingType() throws IOException {
+        SearchHit validHit = createSearchResultResponse().getHits().getHits()[0];
+        setupSearchResponse(new SearchHit[] { validHit, createMissingTypeSearchHit(1, "MissingTypeTool") });
+        ActionListener<List<McpToolRegisterInput>> actionListener = mock(ActionListener.class);
+        mcpToolsHelper.searchAllTools(actionListener);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<McpToolRegisterInput>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertEquals(1, argumentCaptor.getValue().size());
+        assertEquals("ListIndexTool", argumentCaptor.getValue().get(0).getName());
+        verify(actionListener, never()).onFailure(any());
+    }
+
+    @Test
+    public void test_searchAllTools_allUnparseableTools_returnsEmpty() throws IOException {
         setupMalformedJsonResponse();
         ActionListener<List<McpToolRegisterInput>> actionListener = mock(ActionListener.class);
         mcpToolsHelper.searchAllTools(actionListener);
-        verifyCompositeIOException(actionListener);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<McpToolRegisterInput>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(actionListener).onResponse(argumentCaptor.capture());
+        assertTrue(argumentCaptor.getValue().isEmpty());
+        verify(actionListener, never()).onFailure(any());
     }
 
     @Test
@@ -324,15 +343,28 @@ public class McpToolsHelperTests extends OpenSearchTestCase {
     }
 
     private void setupMalformedJsonResponse() throws IOException {
+        setupSearchResponse(new SearchHit[] { createMalformedSearchHit(0, "ListIndexTool") });
+    }
+
+    private SearchHit createMalformedSearchHit(int docId, String id) {
         String malformedJson =
             "{\"name\":\"test\",\"type\":\"test\",\"description\":\"test\",\"parameters\":{},\"attributes\":{},\"version\":1,\"malformed\":}";
-        SearchHit[] hits = new SearchHit[1];
-        hits[0] = new SearchHit(0, "ListIndexTool", null, null).sourceRef(new BytesArray(malformedJson.getBytes()));
-        hits[0].version(1L);
+        SearchHit hit = new SearchHit(docId, id, null, null).sourceRef(new BytesArray(malformedJson.getBytes()));
+        hit.version(1L);
+        return hit;
+    }
 
+    private SearchHit createMissingTypeSearchHit(int docId, String id) {
+        String missingTypeJson = "{\"name\":\"test\",\"description\":\"test\",\"parameters\":{},\"attributes\":{},\"version\":1}";
+        SearchHit hit = new SearchHit(docId, id, null, null).sourceRef(new BytesArray(missingTypeJson.getBytes()));
+        hit.version(1L);
+        return hit;
+    }
+
+    private void setupSearchResponse(SearchHit[] hits) {
         SearchResponse searchResponse = new SearchResponse(
             new InternalSearchResponse(
-                new SearchHits(hits, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f),
+                new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f),
                 InternalAggregations.EMPTY,
                 new Suggest(Collections.emptyList()),
                 new SearchProfileShardResults(Collections.emptyMap()),

--- a/plugin/src/test/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRemoveActionTests.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import java.util.Set;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.Version;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkItemResponse;
@@ -36,6 +38,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
@@ -220,7 +223,11 @@ public class TransportMcpToolsRemoveActionTests extends OpenSearchTestCase {
         transportMcpToolsRemoveAction.doExecute(task, nodesRequest, listener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
-        assertEquals("Unable to remove tools as no tool in the request found in system index", argumentCaptor.getValue().getMessage());
+        Exception exception = argumentCaptor.getValue();
+        assertEquals("Unable to remove tools as no tool in the request found in system index", exception.getMessage());
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) exception).status());
+        verify(client, never()).bulk(any(), isA(ActionListener.class));
     }
 
     public void test_doExecute_partialToolsNotExists() {
@@ -236,10 +243,11 @@ public class TransportMcpToolsRemoveActionTests extends OpenSearchTestCase {
         transportMcpToolsRemoveAction.doExecute(task, nodesRequest, listener);
         ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(argumentCaptor.capture());
-        assertEquals(
-            "Unable to remove tools as these tools: [SearchIndexTool] are not found in system index",
-            argumentCaptor.getValue().getMessage()
-        );
+        Exception exception = argumentCaptor.getValue();
+        assertEquals("Unable to remove tools as these tools: [SearchIndexTool] are not found in system index", exception.getMessage());
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) exception).status());
+        verify(client, never()).bulk(any(), isA(ActionListener.class));
     }
 
     public void test_doExecute_bulkIndexAllFailed() {

--- a/plugin/src/test/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsUpdateActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsUpdateActionTests.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
 import org.opensearch.Version;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkItemResponse;
@@ -40,6 +41,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.ml.cluster.DiscoveryNodeHelper;
 import org.opensearch.ml.common.MLIndex;
@@ -188,9 +190,12 @@ public class TransportMcpToolsUpdateActionTests extends OpenSearchTestCase {
 
         action.doExecute(task, request, listener);
 
-        ArgumentCaptor<OpenSearchException> captor = ArgumentCaptor.forClass(OpenSearchException.class);
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(captor.capture());
-        assertEquals("Failed to update tools as none of them is found in index", captor.getValue().getMessage());
+        Exception exception = captor.getValue();
+        assertEquals("Failed to update tools as none of them is found in index", exception.getMessage());
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) exception).status());
     }
 
     @Test
@@ -216,9 +221,12 @@ public class TransportMcpToolsUpdateActionTests extends OpenSearchTestCase {
 
         action.doExecute(task, request, listener);
 
-        ArgumentCaptor<OpenSearchException> captor = ArgumentCaptor.forClass(OpenSearchException.class);
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(captor.capture());
-        assertEquals("Failed to find one or more requested tools in system index", captor.getValue().getMessage());
+        Exception exception = captor.getValue();
+        assertEquals("Failed to find one or more requested tools in system index", exception.getMessage());
+        assertTrue(exception instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) exception).status());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes three MCP defects reported in #4938. All three predate the 3.8 MCP changes.

### 1. Blank MCP tool input is treated as no arguments

`McpStreamableHttpTool` and `McpSseTool` passed `input` straight to `StringUtils.fromJson`, which accepts only a JSON object or array. A null, empty, or blank input therefore failed with `Unsupported response type`.

This is reachable in ordinary use: for a no-argument MCP tool the LLM chooses `action_input` itself, and emitting `""` is a natural choice. Observed on an unprompted run, where the tool call failed and the agent burned an iteration recovering. The same tool succeeds when the model emits `{}`.

A null, empty, or blank `input` is now equivalent to `{}`. Behaviour for all valid JSON object and array inputs is unchanged.

### 2. One unparseable document no longer takes down the whole MCP surface

`McpToolsHelper.searchAllTools` collected per-document parse errors and then failed the entire search if any document failed. Because `/_plugins/_ml/mcp` builds its tool list from that search, a single bad document broke `tools/list` and `tools/call` for every healthy tool.

This was asymmetric with `TransportMcpServerAction`, which already skips and logs individual tools that fail to *build* while healthy tools continue to serve. `searchAllTools` now skips and logs individual documents that fail to *parse*, matching that behaviour.

The catch covers `RuntimeException` as well as `IOException`. This is load-bearing: a document missing the required `type` field throws `IllegalArgumentException` from `McpToolRegisterInput`, and that, not a malformed-JSON `IOException`, is the failure mode actually reported in the issue. A narrower `catch (IOException)` does not fix the reported bug. The added test `test_searchAllTools_skipsToolMissingType` covers exactly this case, and I verified it fails without the broadened catch.

The leniency is deliberately confined to this serving read path, and there is a comment saying so. The write paths (`_register`, `_update`, `_remove`) continue to use the strict search methods, where a parse failure should still surface as an error.

### 3. Unknown tool name on `_remove` and `_update` returns 400 instead of 500

`POST /_plugins/_ml/mcp/tools/_remove` with a name that does not exist returned HTTP 500. A caller-supplied unknown name is a client error, not a server error, and a 5xx invites client retries that can never succeed.

`_update` carried the identical condition at two sites and is changed alongside `_remove`, so the MCP tool family stays internally consistent. Fixing only one would leave `_remove` at 400 and `_update` at 500 for the same condition.

`BAD_REQUEST` rather than `NOT_FOUND` is deliberate: removal and update are all-or-nothing, so an unknown name makes the whole request unprocessable rather than addressing one missing resource. Consistency within the MCP tool family was weighted above matching the sibling delete-model actions, which use 404.

## Behaviour changes for reviewers

Two user-visible changes worth calling out explicitly:

- `tools/list` and `GET /_plugins/_ml/mcp/tools/_list` may now return a **partial** result when a document in `.plugins-ml-mcp-tools` cannot be parsed. Previously the request failed outright. The skip is logged at `ERROR` with the index name and document id. There is no API field indicating a partial result, so the log is the only signal. This trade was made because one poison document previously caused a total MCP outage for every healthy tool, which is the worse failure mode.
- `_remove` and `_update` return **400 instead of 500** for an unknown tool name. This is technically a breaking change for a client keying on 500, though such a client is keying on a bug. There is recent precedent on this branch: #4930 applied the same class of fix across 9 sites.

Deliberately **not** changed: the all-or-nothing removal and update semantics. Only the status code changed.

## Testing

Unit tests added or updated in `McpToolsHelperTests`, `McpStreamableHttpToolTests`, `McpSseToolTests`, `TransportMcpToolsRemoveActionTests`, and `TransportMcpToolsUpdateActionTests`. Covers null, empty, blank, and valid `{}` input with assertions on the resulting empty argument map; `searchAllTools` with a document missing `type`, with malformed JSON, and with all documents unparseable; and the 400 status on both the none-found and partial-found branches of remove and update.

Each fix was checked to be rollback-sensitive rather than merely passing. For fix 1 I reverted the one-line change in place and confirmed `testRunNoArguments` fails, then restored it. For fix 2 I confirmed the missing-`type` test fails under the previous `catch (IOException)`.

Verified end to end on a live 2-node cluster:

- A document missing `type` injected directly into `.plugins-ml-mcp-tools` no longer breaks `tools/list` on either node; healthy tools remain listable and callable; the malformed-JSON case is also skipped.
- `_remove` and `_update` return 400 for an unknown name and 200 for a valid request, and the tool that does exist is still not removed, confirming the semantics are unchanged.

`:opensearch-ml-algorithms:test --tests "*Mcp*"`, `:opensearch-ml-plugin:test --tests "*mcpserver*"`, `MLFlowAgentRunnerTest`, `MLChatAgentRunnerTest`, and `spotlessJavaCheck` all pass on JDK 21.

## Follow-ups not included here

- Integration test coverage for the 400 status and the poison-document skip. Both are unit-tested only; `RestMcpToolsRemoveActionIT` asserts no status for the not-found case.
- `CallToolResult.isError()` is still discarded by both MCP tools, so a tool-level error from a remote MCP server is returned to the agent as a successful result. Handling it turned out to be a larger change than it appears, because `MLFlowAgentRunner` routes tool failures to a fatal `onFailure`, so throwing would abort an entire flow-agent run on a recoverable per-call error. That needs its own decision on flow-agent semantics and is left out of this PR.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
