### PR TITLE
Add agentic search template param-schema derivation

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/CommonValue.java
+++ b/common/src/main/java/org/opensearch/ml/common/CommonValue.java
@@ -63,6 +63,8 @@ public class CommonValue {
     public static final String MCP_SESSION_MANAGEMENT_INDEX = ".plugins-ml-mcp-session-management";
     public static final String MCP_TOOLS_INDEX = ".plugins-ml-mcp-tools";
     public static final String ML_CONTEXT_MANAGEMENT_TEMPLATES_INDEX = ".plugins-ml-context-management-templates";
+    // param-schema for agentic-search template fill (one doc per registered search template)
+    public static final String ML_AGENTIC_SEARCH_TEMPLATES_INDEX = ".plugins-ml-agentic-search-templates";
     // index created in 3.1 to track all ml jobs created via job scheduler
     public static final String ML_JOBS_INDEX = ".plugins-ml-jobs";
     public static final Set<String> stopWordsIndices = ImmutableSet.of(".plugins-ml-stop-words");
@@ -86,6 +88,7 @@ public class CommonValue {
     public static final String ML_MCP_SESSION_MANAGEMENT_INDEX_MAPPING_PATH = "index-mappings/ml_mcp_session_management.json";
     public static final String ML_MCP_TOOLS_INDEX_MAPPING_PATH = "index-mappings/ml_mcp_tools.json";
     public static final String ML_CONTEXT_MANAGEMENT_TEMPLATES_INDEX_MAPPING_PATH = "index-mappings/ml_context_management_templates.json";
+    public static final String ML_AGENTIC_SEARCH_TEMPLATES_INDEX_MAPPING_PATH = "index-mappings/ml_agentic_search_templates.json";
     public static final String ML_JOBS_INDEX_MAPPING_PATH = "index-mappings/ml_jobs.json";
     public static final String ML_INDEX_INSIGHT_CONFIG_INDEX_MAPPING_PATH = "index-mappings/ml_index_insight_config.json";
     public static final String ML_INDEX_INSIGHT_STORAGE_INDEX_MAPPING_PATH = "index-mappings/ml_index_insight_storage.json";

--- a/common/src/main/java/org/opensearch/ml/common/MLIndex.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLIndex.java
@@ -7,6 +7,8 @@ package org.opensearch.ml.common;
 
 import static org.opensearch.ml.common.CommonValue.MCP_SESSION_MANAGEMENT_INDEX;
 import static org.opensearch.ml.common.CommonValue.MCP_TOOLS_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_SEARCH_TEMPLATES_INDEX;
+import static org.opensearch.ml.common.CommonValue.ML_AGENTIC_SEARCH_TEMPLATES_INDEX_MAPPING_PATH;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX_MAPPING_PATH;
 import static org.opensearch.ml.common.CommonValue.ML_CONFIG_INDEX;
@@ -56,7 +58,8 @@ public enum MLIndex {
     MCP_TOOLS(MCP_TOOLS_INDEX, false, ML_MCP_TOOLS_INDEX_MAPPING_PATH),
     JOBS(ML_JOBS_INDEX, false, ML_JOBS_INDEX_MAPPING_PATH),
     INDEX_INSIGHT_CONFIG(ML_INDEX_INSIGHT_CONFIG_INDEX, false, ML_INDEX_INSIGHT_CONFIG_INDEX_MAPPING_PATH),
-    INDEX_INSIGHT_STORAGE(ML_INDEX_INSIGHT_STORAGE_INDEX, false, ML_INDEX_INSIGHT_STORAGE_INDEX_MAPPING_PATH);
+    INDEX_INSIGHT_STORAGE(ML_INDEX_INSIGHT_STORAGE_INDEX, false, ML_INDEX_INSIGHT_STORAGE_INDEX_MAPPING_PATH),
+    AGENTIC_SEARCH_TEMPLATES(ML_AGENTIC_SEARCH_TEMPLATES_INDEX, false, ML_AGENTIC_SEARCH_TEMPLATES_INDEX_MAPPING_PATH);
 
     private final String indexName;
     // whether we use an alias for the index

--- a/common/src/main/java/org/opensearch/ml/common/agenticsearch/AgenticSearchTemplate.java
+++ b/common/src/main/java/org/opensearch/ml/common/agenticsearch/AgenticSearchTemplate.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agenticsearch;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Param-schema for agentic-search template fill: the typed "slots" an LLM fills for
+ * one registered OpenSearch search template. One document per template in the
+ * {@code .plugins-ml-agentic-search-templates} system index, keyed by
+ * {@code template_id} (which is also the core {@code _scripts} template name — one
+ * identifier keys the schema doc, rides in the connector, and renders the body).
+ *
+ * <p>The Mustache body itself lives in core {@code _scripts} and is owned by
+ * opensearch-core; this artifact is ml-commons' metadata beside it. The schema is
+ * assembled from three inputs at registration (body parse-tree → param names/types;
+ * index mapping → field-name enums; customer → value enums/descriptions), so it is
+ * stored and editable rather than re-parsed per query.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class AgenticSearchTemplate implements ToXContentObject, Writeable {
+
+    public static final String TEMPLATE_ID_FIELD = "template_id";
+    public static final String INDEX_BINDING_FIELD = "index_binding";
+    public static final String DESCRIPTION_FIELD = "description";
+    public static final String PARAM_SCHEMA_FIELD = "param_schema";
+    public static final String CREATED_TIME_FIELD = "created_time";
+    public static final String LAST_UPDATED_TIME_FIELD = "last_updated_time";
+    public static final String CREATED_BY_FIELD = "created_by";
+
+    // Same grammar as the core _scripts template name it mirrors.
+    private static final Pattern VALID_TEMPLATE_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_\\-.]{1,255}$");
+
+    /** The core {@code _scripts} template name; also this doc's {@code _id}. */
+    private String templateId;
+
+    /** The index this template targets (used to derive field-name enums). */
+    private String indexBinding;
+
+    /** Human-readable description of what the template searches. */
+    private String description;
+
+    /**
+     * The typed slots the model fills, keyed by param name. Each value is a spec
+     * map: {@code {type, required?, enum?, description?, source?}}. Stored opaquely
+     * ({@code enabled:false} in the mapping) because keys are per-template.
+     */
+    private Map<String, Object> paramSchema;
+
+    private Instant createdTime;
+    private Instant lastUpdatedTime;
+    private String createdBy;
+
+    public AgenticSearchTemplate(StreamInput input) throws IOException {
+        this.templateId = input.readString();
+        this.indexBinding = input.readOptionalString();
+        this.description = input.readOptionalString();
+        if (input.readBoolean()) {
+            this.paramSchema = input.readMap();
+        }
+        this.createdTime = input.readOptionalInstant();
+        this.lastUpdatedTime = input.readOptionalInstant();
+        this.createdBy = input.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(templateId);
+        out.writeOptionalString(indexBinding);
+        out.writeOptionalString(description);
+        if (paramSchema != null) {
+            out.writeBoolean(true);
+            out.writeMap(paramSchema);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalInstant(createdTime);
+        out.writeOptionalInstant(lastUpdatedTime);
+        out.writeOptionalString(createdBy);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        if (templateId != null) {
+            builder.field(TEMPLATE_ID_FIELD, templateId);
+        }
+        if (indexBinding != null) {
+            builder.field(INDEX_BINDING_FIELD, indexBinding);
+        }
+        if (description != null) {
+            builder.field(DESCRIPTION_FIELD, description);
+        }
+        if (paramSchema != null) {
+            builder.field(PARAM_SCHEMA_FIELD, paramSchema);
+        }
+        if (createdTime != null) {
+            builder.field(CREATED_TIME_FIELD, createdTime.toEpochMilli());
+        }
+        if (lastUpdatedTime != null) {
+            builder.field(LAST_UPDATED_TIME_FIELD, lastUpdatedTime.toEpochMilli());
+        }
+        if (createdBy != null) {
+            builder.field(CREATED_BY_FIELD, createdBy);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static AgenticSearchTemplate parse(XContentParser parser) throws IOException {
+        String templateId = null;
+        String indexBinding = null;
+        String description = null;
+        Map<String, Object> paramSchema = null;
+        Instant createdTime = null;
+        Instant lastUpdatedTime = null;
+        String createdBy = null;
+
+        if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+        }
+
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case TEMPLATE_ID_FIELD:
+                    templateId = parser.text();
+                    break;
+                case INDEX_BINDING_FIELD:
+                    indexBinding = parser.text();
+                    break;
+                case DESCRIPTION_FIELD:
+                    description = parser.text();
+                    break;
+                case PARAM_SCHEMA_FIELD:
+                    paramSchema = parser.map();
+                    break;
+                case CREATED_TIME_FIELD:
+                    createdTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
+                case LAST_UPDATED_TIME_FIELD:
+                    lastUpdatedTime = Instant.ofEpochMilli(parser.longValue());
+                    break;
+                case CREATED_BY_FIELD:
+                    createdBy = parser.text();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+
+        return AgenticSearchTemplate
+            .builder()
+            .templateId(templateId)
+            .indexBinding(indexBinding)
+            .description(description)
+            .paramSchema(paramSchema)
+            .createdTime(createdTime)
+            .lastUpdatedTime(lastUpdatedTime)
+            .createdBy(createdBy)
+            .build();
+    }
+
+    /** Whether the template id is well-formed (matches the {@code _scripts} name grammar). */
+    public boolean isValidTemplateId() {
+        return templateId != null && VALID_TEMPLATE_ID_PATTERN.matcher(templateId).matches();
+    }
+
+    /** A stored schema is usable only if it declares at least one param. */
+    public boolean hasParams() {
+        return paramSchema != null && !paramSchema.isEmpty();
+    }
+}

--- a/common/src/main/resources/index-mappings/ml_agentic_search_templates.json
+++ b/common/src/main/resources/index-mappings/ml_agentic_search_templates.json
@@ -1,0 +1,31 @@
+{
+  "_meta": {
+    "schema_version": 1
+  },
+  "properties": {
+    "template_id": {
+      "type": "keyword"
+    },
+    "index_binding": {
+      "type": "keyword"
+    },
+    "description": {
+      "type": "text"
+    },
+    "param_schema": {
+      "type": "object",
+      "enabled": false
+    },
+    "created_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "last_updated_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "created_by": {
+      "type": "keyword"
+    }
+  }
+}

--- a/common/src/test/java/org/opensearch/ml/common/agenticsearch/AgenticSearchTemplateTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/agenticsearch/AgenticSearchTemplateTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.agenticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+public class AgenticSearchTemplateTests {
+
+    private AgenticSearchTemplate template;
+
+    @Before
+    public void setUp() {
+        Map<String, Object> lexQuery = new LinkedHashMap<>();
+        lexQuery.put("type", "string");
+        lexQuery.put("required", true);
+        lexQuery.put("description", "content words only");
+
+        Map<String, Object> sortBy = new LinkedHashMap<>();
+        sortBy.put("type", "string");
+        sortBy.put("enum", java.util.List.of("price", "rating"));
+        sortBy.put("source", "mapping");
+
+        Map<String, Object> paramSchema = new LinkedHashMap<>();
+        paramSchema.put("lex_query", lexQuery);
+        paramSchema.put("sort_by", sortBy);
+
+        template = AgenticSearchTemplate
+            .builder()
+            .templateId("product_search")
+            .indexBinding("products")
+            .description("Product search with filters/sort")
+            .paramSchema(paramSchema)
+            .createdTime(Instant.ofEpochMilli(1_700_000_000_000L))
+            .lastUpdatedTime(Instant.ofEpochMilli(1_700_000_050_000L))
+            .createdBy("alice")
+            .build();
+    }
+
+    @Test
+    public void streamRoundTrip_preservesAllFields() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+        template.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        AgenticSearchTemplate parsed = new AgenticSearchTemplate(in);
+
+        assertEquals(template.getTemplateId(), parsed.getTemplateId());
+        assertEquals(template.getIndexBinding(), parsed.getIndexBinding());
+        assertEquals(template.getDescription(), parsed.getDescription());
+        assertEquals(template.getParamSchema(), parsed.getParamSchema());
+        assertEquals(template.getCreatedTime(), parsed.getCreatedTime());
+        assertEquals(template.getLastUpdatedTime(), parsed.getLastUpdatedTime());
+        assertEquals(template.getCreatedBy(), parsed.getCreatedBy());
+    }
+
+    @Test
+    public void xContentRoundTrip_preservesFields() throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.JSON.contentBuilder();
+        template.toXContent(builder, ToXContentObject.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        XContentParser parser = MediaTypeRegistry.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, json);
+        AgenticSearchTemplate parsed = AgenticSearchTemplate.parse(parser);
+
+        assertEquals(template.getTemplateId(), parsed.getTemplateId());
+        assertEquals(template.getIndexBinding(), parsed.getIndexBinding());
+        assertEquals(template.getParamSchema(), parsed.getParamSchema());
+        assertEquals(template.getCreatedTime(), parsed.getCreatedTime());
+    }
+
+    @Test
+    public void streamRoundTrip_nullParamSchema() throws IOException {
+        AgenticSearchTemplate minimal = AgenticSearchTemplate.builder().templateId("t1").build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        minimal.writeTo(out);
+        AgenticSearchTemplate parsed = new AgenticSearchTemplate(out.bytes().streamInput());
+        assertEquals("t1", parsed.getTemplateId());
+        assertFalse(parsed.hasParams());
+    }
+
+    @Test
+    public void validation_templateIdAndParams() {
+        assertTrue(template.isValidTemplateId());
+        assertTrue(template.hasParams());
+        assertFalse(AgenticSearchTemplate.builder().templateId("bad id with spaces").build().isValidTemplateId());
+        assertFalse(AgenticSearchTemplate.builder().templateId("ok").build().hasParams());
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
+import org.opensearch.action.admin.indices.get.GetIndexRequest;
+import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.ml.common.CommonValue;
+import org.opensearch.ml.common.MLIndex;
+import org.opensearch.ml.common.agenticsearch.AgenticSearchTemplate;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptService;
+import org.opensearch.script.ScriptType;
+import org.opensearch.script.TemplateScript;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.Client;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * All index I/O and registration logic for agentic-search template param-schemas.
+ *
+ * <p>Registration (§4.5) is the interesting path: given only a {@code _scripts}
+ * template name + target index, it (1) fetches the stored Mustache body, (2) fetches
+ * the index mapping, (3) derives the param-schema — {@link MustacheTemplateAnalyzer}
+ * for names/types/required, the mapping for field-name enums — and (4) pre-flight
+ * validates by rendering the body twice (all-filled and required-only) through the
+ * cluster's own Mustache engine, so a broken body fails here, not on the customer's
+ * first query. The derived schema is then the customer's editable tuning surface.
+ */
+@Log4j2
+public class AgenticSearchTemplateService {
+
+    private static final int DEFAULT_MAX_TEMPLATES = 1000;
+    private static final String INDEX = CommonValue.ML_AGENTIC_SEARCH_TEMPLATES_INDEX;
+    private static final String NOT_FOUND_ERROR = "Agentic search template not found: ";
+    // param-schema entry keys shared with the analyzer.
+    private static final String TYPE_KEY = "type";
+    private static final String ENUM_KEY = "enum";
+    private static final String SOURCE_KEY = "source";
+
+    private final MLIndicesHandler mlIndicesHandler;
+    private final Client client;
+    private final ClusterService clusterService;
+    private final ScriptService scriptService;
+    private final NamedXContentRegistry xContentRegistry;
+
+    @Inject
+    public AgenticSearchTemplateService(
+        MLIndicesHandler mlIndicesHandler,
+        Client client,
+        ClusterService clusterService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        this.mlIndicesHandler = mlIndicesHandler;
+        this.client = client;
+        this.clusterService = clusterService;
+        this.scriptService = scriptService;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    // ---- Register (derive + validate + store) ------------------------------
+
+    /**
+     * Register a template for filling: derive its param-schema and store it.
+     *
+     * @param templateId the {@code _scripts} template name (also the doc id)
+     * @param index the target index (for field-name enums)
+     * @param description optional human description
+     * @param user the caller, captured by the transport action before it stashed the
+     *     thread context (reading it here would be too late — the stash below drops the
+     *     security-user transient); may be null when security is disabled
+     * @param listener yields the stored {@link AgenticSearchTemplate}
+     */
+    public void register(String templateId, String index, String description, User user, ActionListener<AgenticSearchTemplate> listener) {
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<AgenticSearchTemplate> wrapped = ActionListener.runBefore(listener, ctx::restore);
+
+            // 1. Fetch the stored Mustache body from core _scripts.
+            fetchTemplateBody(templateId, ActionListener.wrap(body -> {
+                // 2. Fetch the index mapping for field-name enums.
+                fetchFlattenedMapping(index, ActionListener.wrap(mappingFields -> {
+                    try {
+                        // 3. Derive the schema: parse-tree for names/types/required,
+                        // mapping for field-name enums (a param whose name is *_field
+                        // or that targets a field can only choose an existing field).
+                        Map<String, Object> paramSchema = deriveSchema(body, mappingFields);
+                        // 4. Pre-flight validate: render all-filled + required-only.
+                        preflightValidate(body, paramSchema);
+
+                        Instant now = Instant.now();
+                        AgenticSearchTemplate template = AgenticSearchTemplate
+                            .builder()
+                            .templateId(templateId)
+                            .indexBinding(index)
+                            .description(description)
+                            .paramSchema(paramSchema)
+                            .createdTime(now)
+                            .lastUpdatedTime(now)
+                            .createdBy(user != null ? user.getName() : null)
+                            .build();
+
+                        storeTemplate(template, ActionListener.wrap(ignored -> wrapped.onResponse(template), wrapped::onFailure));
+                    } catch (Exception e) {
+                        wrapped.onFailure(e);
+                    }
+                }, wrapped::onFailure));
+            }, wrapped::onFailure));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void storeTemplate(AgenticSearchTemplate template, ActionListener<Boolean> listener) {
+        mlIndicesHandler.initMLIndexIfAbsent(MLIndex.AGENTIC_SEARCH_TEMPLATES, ActionListener.wrap(created -> {
+            try {
+                IndexRequest indexRequest = new IndexRequest(INDEX)
+                    .id(template.getTemplateId())
+                    .source(template.toXContent(jsonXContent.contentBuilder(), ToXContentObject.EMPTY_PARAMS))
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                client.index(indexRequest, ActionListener.wrap(r -> {
+                    log.info("Registered agentic search template: {}", template.getTemplateId());
+                    listener.onResponse(true);
+                }, listener::onFailure));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, listener::onFailure));
+    }
+
+    // ---- Derivation helpers ------------------------------------------------
+
+    /**
+     * Combine the two automatic inputs into a param-schema: parse-tree structure
+     * (names/types/required) plus mapping-derived field-name enums. A param named
+     * like {@code sort_by}/{@code *_field} that selects a field is scoped to the
+     * mapping's field names, so the model can only target an existing field.
+     */
+    Map<String, Object> deriveSchema(String body, List<String> mappingFields) {
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive(body);
+        if (mappingFields == null || mappingFields.isEmpty()) {
+            return schema;
+        }
+        for (Map.Entry<String, Object> e : schema.entrySet()) {
+            String name = e.getKey();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> spec = (Map<String, Object>) e.getValue();
+            // Field-selector params (e.g. sort_by, *_field): scope them to the mapping's
+            // field names so the model can only target an existing field. Only for
+            // string-typed params that don't already carry an enum.
+            if (targetsAField(name) && MustacheTemplateAnalyzer.TYPE_STRING.equals(spec.get(TYPE_KEY)) && !spec.containsKey(ENUM_KEY)) {
+                spec.put(ENUM_KEY, new ArrayList<>(mappingFields));
+                spec.put(SOURCE_KEY, "mapping");
+            }
+        }
+        return schema;
+    }
+
+    /** Heuristic: a param that selects a field (name ends with _field/_by or is "field"). */
+    private static boolean targetsAField(String name) {
+        String n = name.toLowerCase(java.util.Locale.ROOT);
+        return n.equals("field") || n.endsWith("_field") || n.endsWith("_by") || n.equals("sort_by");
+    }
+
+    /**
+     * Render the body twice through the cluster's Mustache engine — once with every
+     * param filled, once with only required params — and confirm each renders to
+     * legal JSON. Exercises the optional-clause sections so a body that can't render
+     * to legal DSL fails here, not on the first query.
+     */
+    void preflightValidate(String body, Map<String, Object> paramSchema) {
+        Map<String, Object> allFilled = sampleParams(paramSchema, false);
+        renderAndCheckJson(body, allFilled, "all-filled");
+        Map<String, Object> requiredOnly = sampleParams(paramSchema, true);
+        renderAndCheckJson(body, requiredOnly, "required-only");
+    }
+
+    private void renderAndCheckJson(String body, Map<String, Object> params, String label) {
+        String rendered;
+        try {
+            Script script = new Script(ScriptType.INLINE, "mustache", body, Collections.emptyMap());
+            TemplateScript.Factory factory = scriptService.compile(script, TemplateScript.CONTEXT);
+            rendered = factory.newInstance(params).execute();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Template failed to render (" + label + "): " + e.getMessage(), e);
+        }
+        // JSON-legality only. Parsing as a search body would be stricter, but the
+        // sampleValue placeholders aren't domain-valid ("x" for a sort order or a
+        // boost_mode), so real templates would fail here on the placeholder, not the body.
+        try (
+            XContentParser parser = MediaTypeRegistry.JSON
+                .xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, rendered)
+        ) {
+            parser.map();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Template rendered invalid JSON (" + label + "): " + e.getMessage(), e);
+        }
+    }
+
+    /** Build a placeholder param set for pre-flight: sample values by type. */
+    private static Map<String, Object> sampleParams(Map<String, Object> paramSchema, boolean requiredOnly) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> e : paramSchema.entrySet()) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> spec = (Map<String, Object>) e.getValue();
+            boolean required = Boolean.TRUE.equals(spec.get(MustacheTemplateAnalyzer.REQUIRED_KEY));
+            if (requiredOnly && !required) {
+                continue;
+            }
+            params.put(e.getKey(), sampleValue(spec));
+        }
+        return params;
+    }
+
+    private static Object sampleValue(Map<String, Object> spec) {
+        Object enumValues = spec.get(ENUM_KEY);
+        if (enumValues instanceof List && !((List<?>) enumValues).isEmpty()) {
+            return ((List<?>) enumValues).get(0);
+        }
+        String type = String.valueOf(spec.get(TYPE_KEY));
+        switch (type) {
+            case MustacheTemplateAnalyzer.TYPE_NUMBER:
+                return 1;
+            case MustacheTemplateAnalyzer.TYPE_BOOLEAN:
+                return true;
+            case MustacheTemplateAnalyzer.TYPE_ARRAY:
+                return "[]"; // triple-stache injects raw JSON; an empty array is legal
+            default:
+                return "x";
+        }
+    }
+
+    // ---- _scripts + mapping fetch ------------------------------------------
+
+    private void fetchTemplateBody(String templateId, ActionListener<String> listener) {
+        GetStoredScriptRequest request = new GetStoredScriptRequest(templateId);
+        client.admin().cluster().getStoredScript(request, ActionListener.wrap(response -> {
+            if (response.getSource() == null || response.getSource().getSource() == null) {
+                listener
+                    .onFailure(
+                        new OpenSearchStatusException("No stored search template found at _scripts/" + templateId, RestStatus.BAD_REQUEST)
+                    );
+                return;
+            }
+            listener.onResponse(response.getSource().getSource());
+        }, listener::onFailure));
+    }
+
+    /** Fetch the index mapping and flatten it to the list of leaf field names. */
+    private void fetchFlattenedMapping(String index, ActionListener<List<String>> listener) {
+        GetIndexRequest request = new GetIndexRequest().indices(index).indicesOptions(IndicesOptions.strictExpand()).local(false);
+        client.admin().indices().getIndex(request, ActionListener.wrap(response -> {
+            try {
+                listener.onResponse(extractFieldNames(response));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, e -> {
+            if (e instanceof IndexNotFoundException) {
+                listener.onFailure(new OpenSearchStatusException("Index does not exist: " + index, RestStatus.BAD_REQUEST));
+            } else {
+                listener.onFailure(e);
+            }
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> extractFieldNames(GetIndexResponse response) {
+        Map<String, MappingMetadata> mappings = response.mappings();
+        List<String> fields = new ArrayList<>();
+        if (mappings == null || mappings.isEmpty()) {
+            return fields;
+        }
+        MappingMetadata mapping = mappings.values().iterator().next();
+        Map<String, Object> source = mapping.getSourceAsMap();
+        Object props = source.get("properties");
+        if (props instanceof Map) {
+            collectFieldNames((Map<String, Object>) props, "", fields);
+        }
+        return fields;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void collectFieldNames(Map<String, Object> properties, String prefix, List<String> out) {
+        for (Map.Entry<String, Object> e : properties.entrySet()) {
+            String name = prefix.isEmpty() ? e.getKey() : prefix + "." + e.getKey();
+            out.add(name);
+            Object value = e.getValue();
+            if (value instanceof Map) {
+                Map<String, Object> field = (Map<String, Object>) value;
+                if (field.get("properties") instanceof Map) {
+                    collectFieldNames((Map<String, Object>) field.get("properties"), name, out);
+                }
+                // Expose a text field's keyword sub-field (used for exact/sort).
+                if (field.get("fields") instanceof Map) {
+                    for (String sub : ((Map<String, Object>) field.get("fields")).keySet()) {
+                        out.add(name + "." + sub);
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Get / List / Delete / Update --------------------------------------
+
+    public void getTemplate(String templateId, ActionListener<AgenticSearchTemplate> listener) {
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<AgenticSearchTemplate> wrapped = ActionListener.runBefore(listener, ctx::restore);
+            client.get(new GetRequest(INDEX, templateId), ActionListener.wrap(response -> {
+                if (!response.isExists()) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                    return;
+                }
+                try {
+                    wrapped.onResponse(parse(response.getSourceAsBytesRef()));
+                } catch (Exception e) {
+                    wrapped.onFailure(e);
+                }
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                } else {
+                    wrapped.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    public void listTemplates(int from, int size, ActionListener<MLListResult> listener) {
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLListResult> wrapped = ActionListener.runBefore(listener, ctx::restore);
+            SearchRequest searchRequest = new SearchRequest(INDEX)
+                .source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).from(from).size(size));
+            client.search(searchRequest, ActionListener.wrap(response -> {
+                try {
+                    List<AgenticSearchTemplate> templates = new ArrayList<>();
+                    for (SearchHit hit : response.getHits().getHits()) {
+                        templates.add(parse(hit.getSourceRef()));
+                    }
+                    long total = response.getHits().getTotalHits() != null ? response.getHits().getTotalHits().value() : templates.size();
+                    wrapped.onResponse(new MLListResult(templates, total));
+                } catch (Exception e) {
+                    wrapped.onFailure(e);
+                }
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    wrapped.onResponse(new MLListResult(new ArrayList<>(), 0));
+                } else {
+                    wrapped.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    public void deleteTemplate(String templateId, ActionListener<Boolean> listener) {
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<Boolean> wrapped = ActionListener.runBefore(listener, ctx::restore);
+            DeleteRequest deleteRequest = new DeleteRequest(INDEX, templateId).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            client.delete(deleteRequest, ActionListener.wrap(response -> {
+                boolean deleted = response.getResult() == DeleteResponse.Result.DELETED;
+                if (!deleted) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                    return;
+                }
+                wrapped.onResponse(true);
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                } else {
+                    wrapped.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Merge a partial schema edit into the stored doc (§4.5): only the fields the
+     * customer sent are written, via a doc-merge update.
+     *
+     * <p>Validated like a registration, but against the <em>merged</em> schema, since a
+     * per-param edit must not fail for params it didn't mention. An edit carrying no
+     * params skips validation — nothing schema-shaped to check.
+     */
+    public void updateTemplate(String templateId, AgenticSearchTemplate patch, ActionListener<UpdateResponse> listener) {
+        try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<UpdateResponse> wrapped = ActionListener.runBefore(listener, ctx::restore);
+            if (patch.getParamSchema() == null || patch.getParamSchema().isEmpty()) {
+                writeTemplatePatch(templateId, patch, wrapped);
+                return;
+            }
+            // Validate the merged schema against the live body before persisting.
+            client.get(new GetRequest(INDEX, templateId), ActionListener.wrap(response -> {
+                if (!response.isExists()) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                    return;
+                }
+                final Map<String, Object> merged;
+                try {
+                    merged = mergeParamSchema(parse(response.getSourceAsBytesRef()).getParamSchema(), patch.getParamSchema());
+                } catch (Exception e) {
+                    wrapped.onFailure(e);
+                    return;
+                }
+                fetchTemplateBody(templateId, ActionListener.wrap(body -> {
+                    try {
+                        validateParamSchema(merged);
+                        preflightValidate(body, merged);
+                    } catch (Exception e) {
+                        wrapped.onFailure(new OpenSearchStatusException(e.getMessage(), RestStatus.BAD_REQUEST));
+                        return;
+                    }
+                    writeTemplatePatch(templateId, patch, wrapped);
+                }, wrapped::onFailure));
+            }, e -> {
+                if (e instanceof IndexNotFoundException) {
+                    wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                } else {
+                    wrapped.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private void writeTemplatePatch(String templateId, AgenticSearchTemplate patch, ActionListener<UpdateResponse> listener) {
+        patch.setLastUpdatedTime(Instant.now());
+        try {
+            UpdateRequest updateRequest = new UpdateRequest(INDEX, templateId)
+                .doc(patch.toXContent(jsonXContent.contentBuilder(), ToXContentObject.EMPTY_PARAMS))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            client.update(updateRequest, ActionListener.wrap(listener::onResponse, e -> {
+                if (e instanceof org.opensearch.index.engine.DocumentMissingException || e instanceof IndexNotFoundException) {
+                    listener.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
+                } else {
+                    listener.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Overlay a partial param-schema on the stored one, per param and per key, mirroring
+     * the doc-merge update's own recursive merge so the schema validated is the schema
+     * stored. An edit may not introduce a param absent from the stored schema: it could
+     * never be filled, and signals drift from the template body.
+     */
+    static Map<String, Object> mergeParamSchema(Map<String, Object> stored, Map<String, Object> patch) {
+        Map<String, Object> merged = new LinkedHashMap<>(stored == null ? Collections.emptyMap() : stored);
+        for (Map.Entry<String, Object> e : patch.entrySet()) {
+            String name = e.getKey();
+            if (!(e.getValue() instanceof Map)) {
+                throw new IllegalArgumentException("param '" + name + "' schema entry must be an object");
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> patchSpec = (Map<String, Object>) e.getValue();
+            Object storedSpec = merged.get(name);
+            if (storedSpec == null) {
+                throw new IllegalArgumentException(
+                    "param '"
+                        + name
+                        + "' is not a parameter of template body; "
+                        + "cannot add params that the Mustache body never references"
+                );
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> mergedSpec = new LinkedHashMap<>((Map<String, Object>) storedSpec);
+            mergedSpec.putAll(patchSpec);
+            merged.put(name, mergedSpec);
+        }
+        return merged;
+    }
+
+    /**
+     * Check a param-schema is internally consistent. {@link #preflightValidate} renders
+     * from {@link #sampleValue} placeholders, so it cannot see a self-contradictory
+     * spec: an {@code enum} whose values don't fit the declared {@code type}, or an
+     * empty {@code enum}, which the agent server rejects only when building its model.
+     */
+    static void validateParamSchema(Map<String, Object> paramSchema) {
+        for (Map.Entry<String, Object> e : paramSchema.entrySet()) {
+            String name = e.getKey();
+            if (!(e.getValue() instanceof Map)) {
+                throw new IllegalArgumentException("param '" + name + "' schema entry must be an object");
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> spec = (Map<String, Object>) e.getValue();
+            Object type = spec.get(TYPE_KEY);
+            if (!(type instanceof String) || ((String) type).isEmpty()) {
+                throw new IllegalArgumentException("param '" + name + "' must declare a non-empty string 'type'");
+            }
+            Object required = spec.get(MustacheTemplateAnalyzer.REQUIRED_KEY);
+            if (required != null && !(required instanceof Boolean)) {
+                throw new IllegalArgumentException("param '" + name + "' has a non-boolean 'required'");
+            }
+            Object enumValues = spec.get(ENUM_KEY);
+            if (enumValues == null) {
+                continue;
+            }
+            if (!(enumValues instanceof List) || ((List<?>) enumValues).isEmpty()) {
+                throw new IllegalArgumentException("param '" + name + "' has an empty or non-list 'enum'");
+            }
+            for (Object value : (List<?>) enumValues) {
+                if (!valueFitsType(value, (String) type)) {
+                    throw new IllegalArgumentException(
+                        "param '" + name + "' enum value '" + value + "' does not fit declared type '" + type + "'"
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether a schema-supplied value is usable for a param of {@code type}. An
+     * {@code array} param is a triple-stache slot and must carry raw JSON as a string:
+     * the Mustache engine stringifies a {@code List} instead of emitting JSON
+     * ({@code [{"term":{"t":"a"}}]} becomes {@code {0={term={t=a}}}}).
+     */
+    private static boolean valueFitsType(Object value, String type) {
+        if (value == null) {
+            return false;
+        }
+        switch (type) {
+            case MustacheTemplateAnalyzer.TYPE_NUMBER:
+                return value instanceof Number;
+            case MustacheTemplateAnalyzer.TYPE_BOOLEAN:
+                return value instanceof Boolean;
+            case MustacheTemplateAnalyzer.TYPE_ARRAY:
+                return value instanceof String;
+            default:
+                return value instanceof String;
+        }
+    }
+
+    private AgenticSearchTemplate parse(BytesReference source) throws Exception {
+        XContentParser parser = MediaTypeRegistry.JSON
+            .xContent()
+            .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source.streamInput());
+        return AgenticSearchTemplate.parse(parser);
+    }
+
+    /** Small carrier so the list transport action can build its paged response. */
+    public static final class MLListResult {
+        public final List<AgenticSearchTemplate> templates;
+        public final long total;
+
+        public MLListResult(List<AgenticSearchTemplate> templates, long total) {
+            this.templates = templates;
+            this.total = total;
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
@@ -321,22 +321,34 @@ public class AgenticSearchTemplateService {
         return fields;
     }
 
+    /**
+     * Collect the mapping's leaf field names, skipping the {@code object}/{@code nested}
+     * containers on the way down.
+     *
+     * <p>Only leaves are valid targets for a field-selector param: a container like
+     * {@code spec} in {@code spec.os} cannot be sorted on or matched against, so
+     * including it would let the model pick a field that fails at query time.
+     */
     @SuppressWarnings("unchecked")
-    private static void collectFieldNames(Map<String, Object> properties, String prefix, List<String> out) {
+    static void collectFieldNames(Map<String, Object> properties, String prefix, List<String> out) {
         for (Map.Entry<String, Object> e : properties.entrySet()) {
             String name = prefix.isEmpty() ? e.getKey() : prefix + "." + e.getKey();
-            out.add(name);
             Object value = e.getValue();
-            if (value instanceof Map) {
-                Map<String, Object> field = (Map<String, Object>) value;
-                if (field.get("properties") instanceof Map) {
-                    collectFieldNames((Map<String, Object>) field.get("properties"), name, out);
-                }
-                // Expose a text field's keyword sub-field (used for exact/sort).
-                if (field.get("fields") instanceof Map) {
-                    for (String sub : ((Map<String, Object>) field.get("fields")).keySet()) {
-                        out.add(name + "." + sub);
-                    }
+            if (!(value instanceof Map)) {
+                out.add(name);
+                continue;
+            }
+            Map<String, Object> field = (Map<String, Object>) value;
+            if (field.get("properties") instanceof Map) {
+                // A container: recurse for its leaves and don't offer the container itself.
+                collectFieldNames((Map<String, Object>) field.get("properties"), name, out);
+            } else {
+                out.add(name);
+            }
+            // Expose a text field's keyword sub-field (used for exact/sort).
+            if (field.get("fields") instanceof Map) {
+                for (String sub : ((Map<String, Object>) field.get("fields")).keySet()) {
+                    out.add(name + "." + sub);
                 }
             }
         }
@@ -582,10 +594,13 @@ public class AgenticSearchTemplateService {
     }
 
     private AgenticSearchTemplate parse(BytesReference source) throws Exception {
-        XContentParser parser = MediaTypeRegistry.JSON
-            .xContent()
-            .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source.streamInput());
-        return AgenticSearchTemplate.parse(parser);
+        try (
+            XContentParser parser = MediaTypeRegistry.JSON
+                .xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, source.streamInput())
+        ) {
+            return AgenticSearchTemplate.parse(parser);
+        }
     }
 
     /** Small carrier so the list transport action can build its paged response. */

--- a/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateService.java
@@ -70,13 +70,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class AgenticSearchTemplateService {
 
-    private static final int DEFAULT_MAX_TEMPLATES = 1000;
     private static final String INDEX = CommonValue.ML_AGENTIC_SEARCH_TEMPLATES_INDEX;
     private static final String NOT_FOUND_ERROR = "Agentic search template not found: ";
-    // param-schema entry keys shared with the analyzer.
-    private static final String TYPE_KEY = "type";
-    private static final String ENUM_KEY = "enum";
-    private static final String SOURCE_KEY = "source";
 
     private final MLIndicesHandler mlIndicesHandler;
     private final Client client;
@@ -188,18 +183,20 @@ public class AgenticSearchTemplateService {
             // Field-selector params (e.g. sort_by, *_field): scope them to the mapping's
             // field names so the model can only target an existing field. Only for
             // string-typed params that don't already carry an enum.
-            if (targetsAField(name) && MustacheTemplateAnalyzer.TYPE_STRING.equals(spec.get(TYPE_KEY)) && !spec.containsKey(ENUM_KEY)) {
-                spec.put(ENUM_KEY, new ArrayList<>(mappingFields));
-                spec.put(SOURCE_KEY, "mapping");
+            if (targetsAField(name)
+                && MustacheTemplateAnalyzer.TYPE_STRING.equals(spec.get(MustacheTemplateAnalyzer.TYPE_KEY))
+                && !spec.containsKey(MustacheTemplateAnalyzer.ENUM_KEY)) {
+                spec.put(MustacheTemplateAnalyzer.ENUM_KEY, new ArrayList<>(mappingFields));
+                spec.put(MustacheTemplateAnalyzer.SOURCE_KEY, MustacheTemplateAnalyzer.SOURCE_MAPPING);
             }
         }
         return schema;
     }
 
-    /** Heuristic: a param that selects a field (name ends with _field/_by or is "field"). */
+    /** Heuristic: a param that selects a field (named "field", "sort_by", or ending in _field). */
     private static boolean targetsAField(String name) {
         String n = name.toLowerCase(java.util.Locale.ROOT);
-        return n.equals("field") || n.endsWith("_field") || n.endsWith("_by") || n.equals("sort_by");
+        return n.equals("field") || n.equals("sort_by") || n.endsWith("_field");
     }
 
     /**
@@ -254,11 +251,11 @@ public class AgenticSearchTemplateService {
     }
 
     private static Object sampleValue(Map<String, Object> spec) {
-        Object enumValues = spec.get(ENUM_KEY);
+        Object enumValues = spec.get(MustacheTemplateAnalyzer.ENUM_KEY);
         if (enumValues instanceof List && !((List<?>) enumValues).isEmpty()) {
             return ((List<?>) enumValues).get(0);
         }
-        String type = String.valueOf(spec.get(TYPE_KEY));
+        String type = String.valueOf(spec.get(MustacheTemplateAnalyzer.TYPE_KEY));
         switch (type) {
             case MustacheTemplateAnalyzer.TYPE_NUMBER:
                 return 1;
@@ -444,15 +441,20 @@ public class AgenticSearchTemplateService {
         try (ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<UpdateResponse> wrapped = ActionListener.runBefore(listener, ctx::restore);
             if (patch.getParamSchema() == null || patch.getParamSchema().isEmpty()) {
-                writeTemplatePatch(templateId, patch, wrapped);
+                // No schema to validate, so no read is needed before the write.
+                writeTemplatePatch(templateId, patch, null, null, wrapped);
                 return;
             }
-            // Validate the merged schema against the live body before persisting.
+            // A schema edit is validated against the merge of the stored schema and the
+            // patch, so gate the write on the read's seqNo/primaryTerm to avoid validating
+            // against stale content and overwriting a concurrent edit.
             client.get(new GetRequest(INDEX, templateId), ActionListener.wrap(response -> {
                 if (!response.isExists()) {
                     wrapped.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
                     return;
                 }
+                final long seqNo = response.getSeqNo();
+                final long primaryTerm = response.getPrimaryTerm();
                 final Map<String, Object> merged;
                 try {
                     merged = mergeParamSchema(parse(response.getSourceAsBytesRef()).getParamSchema(), patch.getParamSchema());
@@ -468,7 +470,7 @@ public class AgenticSearchTemplateService {
                         wrapped.onFailure(new OpenSearchStatusException(e.getMessage(), RestStatus.BAD_REQUEST));
                         return;
                     }
-                    writeTemplatePatch(templateId, patch, wrapped);
+                    writeTemplatePatch(templateId, patch, seqNo, primaryTerm, wrapped);
                 }, wrapped::onFailure));
             }, e -> {
                 if (e instanceof IndexNotFoundException) {
@@ -482,12 +484,27 @@ public class AgenticSearchTemplateService {
         }
     }
 
-    private void writeTemplatePatch(String templateId, AgenticSearchTemplate patch, ActionListener<UpdateResponse> listener) {
+    /**
+     * Persist a partial edit via a doc-merge update. When {@code seqNo} and
+     * {@code primaryTerm} are non-null the write is gated on them so a concurrent
+     * modification since the read fails with a version conflict; callers that do not read
+     * first pass null for both.
+     */
+    private void writeTemplatePatch(
+        String templateId,
+        AgenticSearchTemplate patch,
+        Long seqNo,
+        Long primaryTerm,
+        ActionListener<UpdateResponse> listener
+    ) {
         patch.setLastUpdatedTime(Instant.now());
         try {
             UpdateRequest updateRequest = new UpdateRequest(INDEX, templateId)
                 .doc(patch.toXContent(jsonXContent.contentBuilder(), ToXContentObject.EMPTY_PARAMS))
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            if (seqNo != null && primaryTerm != null) {
+                updateRequest.setIfSeqNo(seqNo).setIfPrimaryTerm(primaryTerm);
+            }
             client.update(updateRequest, ActionListener.wrap(listener::onResponse, e -> {
                 if (e instanceof org.opensearch.index.engine.DocumentMissingException || e instanceof IndexNotFoundException) {
                     listener.onFailure(new OpenSearchStatusException(NOT_FOUND_ERROR + templateId, RestStatus.NOT_FOUND));
@@ -546,7 +563,7 @@ public class AgenticSearchTemplateService {
             }
             @SuppressWarnings("unchecked")
             Map<String, Object> spec = (Map<String, Object>) e.getValue();
-            Object type = spec.get(TYPE_KEY);
+            Object type = spec.get(MustacheTemplateAnalyzer.TYPE_KEY);
             if (!(type instanceof String) || ((String) type).isEmpty()) {
                 throw new IllegalArgumentException("param '" + name + "' must declare a non-empty string 'type'");
             }
@@ -554,7 +571,7 @@ public class AgenticSearchTemplateService {
             if (required != null && !(required instanceof Boolean)) {
                 throw new IllegalArgumentException("param '" + name + "' has a non-boolean 'required'");
             }
-            Object enumValues = spec.get(ENUM_KEY);
+            Object enumValues = spec.get(MustacheTemplateAnalyzer.ENUM_KEY);
             if (enumValues == null) {
                 continue;
             }

--- a/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzer.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzer.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.opensearch.ml.common.agenticsearch.AgenticSearchTemplate;
+
+/**
+ * Derives a template's parameter structure from its Mustache body (design D6 / the
+ * Appendix rule table). A single scope-aware pass over the body's {@code {{...}}}
+ * tags yields, per parameter, a structural type and whether it is required.
+ *
+ * <p>This is deliberately a focused tag scanner, not a full Mustache engine: it
+ * pairs sections, tracks nesting/scope, and distinguishes {@code {{{triple}}}} from
+ * {@code {{escaped}}}, {@code {{#section}}}, {@code {{^inverted}}}, {@code
+ * {{!comments}}}, and delimiter changes ({@code {{=<% %>=}}}). It cannot recover
+ * string-vs-number (Mustache is untyped about the surrounding JSON), so a scalar is
+ * inferred as string when it sits in a quoted position and number otherwise — a
+ * sound heuristic the customer can override, and the render-parse pre-flight
+ * backstops any miss. The rule table:
+ *
+ * <table>
+ *   <tr><td>bare {@code {{x}}} at root</td><td>required scalar</td></tr>
+ *   <tr><td>{@code {{#x}}..{{/x}}} where x is never a plain value</td><td>boolean (section guard)</td></tr>
+ *   <tr><td>{@code {{x}}{{^x}}default{{/x}}}</td><td>optional, with default</td></tr>
+ *   <tr><td>{@code {{{x}}}} (triple)</td><td>unescaped scalar (often an array/object injected as JSON)</td></tr>
+ * </table>
+ *
+ * The output is the {@code param_schema} map the customer then enriches (value
+ * enums, descriptions) and the field-name enums the index mapping supplies.
+ */
+public class MustacheTemplateAnalyzer {
+
+    /** param-schema entry keys, matching what the agent server reads. */
+    static final String TYPE_KEY = "type";
+    static final String REQUIRED_KEY = "required";
+    static final String DESCRIPTION_KEY = "description";
+
+    // Structural types we can infer from the body alone.
+    static final String TYPE_STRING = "string";
+    static final String TYPE_NUMBER = "number";
+    static final String TYPE_BOOLEAN = "boolean";
+    static final String TYPE_ARRAY = "array";
+
+    private MustacheTemplateAnalyzer() {}
+
+    /** Per-parameter facts accumulated while scanning; folded into a schema at the end. */
+    private static final class ParamFacts {
+        boolean usedAsSection;      // appeared as {{#x}} or {{^x}} (a guard/default -> optional)
+        boolean usedAsValue;        // appeared as {{x}} or {{{x}}} (a substituted value)
+        boolean usedAsValueAtRoot;  // a value use OUTSIDE any section -> unconditionally rendered
+        boolean triple;             // appeared as {{{x}}} -> unescaped (JSON array/object)
+        boolean quotedScalar;       // a {{x}} that sat inside "..." -> string, else number
+    }
+
+    /**
+     * Analyze a Mustache body and return the derived {@code param_schema} map
+     * (ordered by first appearance), suitable for {@link AgenticSearchTemplate}.
+     *
+     * @throws IllegalArgumentException if the body has an unbalanced section.
+     */
+    public static Map<String, Object> derive(String body) {
+        if (body == null || body.isEmpty()) {
+            throw new IllegalArgumentException("Template body is empty");
+        }
+
+        Map<String, ParamFacts> facts = new LinkedHashMap<>();
+        Deque<String> openSections = new ArrayDeque<>();
+
+        String open = "{{";
+        String close = "}}";
+        int i = 0;
+        int n = body.length();
+        while (i < n) {
+            int start = body.indexOf(open, i);
+            if (start < 0) {
+                break;
+            }
+            int end = body.indexOf(close, start + open.length());
+            if (end < 0) {
+                break; // trailing unclosed tag — ignore
+            }
+
+            // A triple-stache {{{x}}} is an open of "{{" immediately followed by "{".
+            boolean triple = "{{".equals(open) && start + 2 < n && body.charAt(start + 2) == '{';
+            int contentStart = start + open.length() + (triple ? 1 : 0);
+            int contentEnd = end;
+            String raw = body.substring(contentStart, contentEnd).trim();
+            int afterTag = end + close.length();
+            if (triple && afterTag < n && body.charAt(afterTag) == '}') {
+                afterTag += 1; // consume the extra closing brace of }}}
+            }
+
+            if (raw.isEmpty()) {
+                i = afterTag;
+                continue;
+            }
+
+            char sigil = raw.charAt(0);
+            switch (sigil) {
+                case '!': // comment
+                    break;
+                case '=': // delimiter change, e.g. {{=<% %>=}}
+                    String spec = raw.substring(1, raw.endsWith("=") ? raw.length() - 1 : raw.length()).trim();
+                    String[] delims = spec.split("\\s+");
+                    if (delims.length == 2 && !delims[0].isEmpty() && !delims[1].isEmpty()) {
+                        open = delims[0];
+                        close = delims[1];
+                    }
+                    break;
+                case '#': // section open
+                case '^': { // inverted section open
+                    String name = raw.substring(1).trim();
+                    openSections.push(name);
+                    facts.computeIfAbsent(name, k -> new ParamFacts()).usedAsSection = true;
+                    break;
+                }
+                case '/': { // section close
+                    String name = raw.substring(1).trim();
+                    if (openSections.isEmpty() || !openSections.peek().equals(name)) {
+                        throw new IllegalArgumentException("Unbalanced Mustache section near '" + name + "'");
+                    }
+                    openSections.pop();
+                    break;
+                }
+                case '>': // partial — not a fillable param
+                case '&': { // {{&x}} unescaped, same as triple
+                    if (sigil == '&') {
+                        recordValue(facts, raw.substring(1).trim(), true, isQuotedPosition(body, start), openSections.isEmpty());
+                    }
+                    break;
+                }
+                default: { // a plain value {{x}} or {{{x}}}
+                    recordValue(facts, raw, triple, isQuotedPosition(body, start), openSections.isEmpty());
+                    break;
+                }
+            }
+            i = afterTag;
+        }
+
+        if (!openSections.isEmpty()) {
+            throw new IllegalArgumentException("Unclosed Mustache section '" + openSections.peek() + "'");
+        }
+
+        return toSchema(facts);
+    }
+
+    private static void recordValue(Map<String, ParamFacts> facts, String name, boolean triple, boolean quoted, boolean atRoot) {
+        if (name.isEmpty() || ".".equals(name)) {
+            return; // implicit iterator / empty
+        }
+        ParamFacts f = facts.computeIfAbsent(name, k -> new ParamFacts());
+        f.usedAsValue = true;
+        if (atRoot) {
+            f.usedAsValueAtRoot = true;
+        }
+        if (triple) {
+            f.triple = true;
+        }
+        if (quoted) {
+            f.quotedScalar = true;
+        }
+    }
+
+    /**
+     * Heuristic: does the tag at {@code tagStart} sit inside a JSON string literal?
+     * Walk the current line counting quote toggles; an odd count before the tag means
+     * it sits inside a string (so the scalar is a string, otherwise a number).
+     *
+     * <p>A quote is a real delimiter only when it is not escaped, and it is escaped
+     * only when preceded by an <em>odd</em> run of backslashes — {@code \"} is escaped,
+     * but {@code \\"} is a literal backslash followed by a closing quote. Counting the
+     * run (rather than testing the single previous char) is what tells those apart.
+     * The scan resets at each newline: JSON string literals don't span raw newlines, so
+     * a stray/miscounted quote stays contained to its line instead of flipping the
+     * classification of every later parameter.
+     */
+    private static boolean isQuotedPosition(String body, int tagStart) {
+        boolean inQuote = false;
+        for (int j = 0; j < tagStart; j++) {
+            char c = body.charAt(j);
+            if (c == '\n') {
+                inQuote = false; // strings don't span raw newlines; contain any miscount
+            } else if (c == '"' && !isEscaped(body, j)) {
+                inQuote = !inQuote;
+            }
+        }
+        return inQuote;
+    }
+
+    /** True if the char at {@code pos} is escaped, i.e. preceded by an odd run of backslashes. */
+    private static boolean isEscaped(String body, int pos) {
+        int backslashes = 0;
+        for (int k = pos - 1; k >= 0 && body.charAt(k) == '\\'; k--) {
+            backslashes++;
+        }
+        return (backslashes & 1) == 1;
+    }
+
+    private static Map<String, Object> toSchema(Map<String, ParamFacts> facts) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        for (Map.Entry<String, ParamFacts> e : facts.entrySet()) {
+            ParamFacts f = e.getValue();
+            Map<String, Object> spec = new LinkedHashMap<>();
+
+            // A name used ONLY as a section guard (never substituted as a value) is a
+            // boolean flag. A name used as both a section and a value is a scalar with
+            // an inverted-section default (optional). A triple-stache is an injected
+            // JSON array/object.
+            if (f.triple) {
+                spec.put(TYPE_KEY, TYPE_ARRAY);
+            } else if (f.usedAsSection && !f.usedAsValue) {
+                spec.put(TYPE_KEY, TYPE_BOOLEAN);
+            } else if (f.quotedScalar) {
+                spec.put(TYPE_KEY, TYPE_STRING);
+            } else {
+                spec.put(TYPE_KEY, TYPE_NUMBER);
+            }
+
+            // Required only for a bare value at ROOT scope that is never wrapped in its
+            // own section guard (the Appendix rule). A param used only inside a section
+            // ({{#other}}..{{x}}..{{/other}}) renders conditionally, and one wrapped in
+            // its own {{#x}}/{{^x}} disappears when absent — both are optional, so the
+            // body still renders a legal query without them.
+            boolean required = f.usedAsValueAtRoot && !f.usedAsSection;
+            spec.put(REQUIRED_KEY, required);
+            spec.put(DESCRIPTION_KEY, "");
+
+            schema.put(e.getKey(), spec);
+        }
+        return schema;
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzer.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzer.java
@@ -27,6 +27,7 @@ import org.opensearch.ml.common.agenticsearch.AgenticSearchTemplate;
  * backstops any miss. The rule table:
  *
  * <table>
+ *   <caption>Mustache tag to derived param type and required-ness</caption>
  *   <tr><td>bare {@code {{x}}} at root</td><td>required scalar</td></tr>
  *   <tr><td>{@code {{#x}}..{{/x}}} where x is never a plain value</td><td>boolean (section guard)</td></tr>
  *   <tr><td>{@code {{x}}{{^x}}default{{/x}}}</td><td>optional, with default</td></tr>
@@ -38,16 +39,21 @@ import org.opensearch.ml.common.agenticsearch.AgenticSearchTemplate;
  */
 public class MustacheTemplateAnalyzer {
 
-    /** param-schema entry keys, matching what the agent server reads. */
+    // param-schema entry keys, shared with AgenticSearchTemplateService.
     static final String TYPE_KEY = "type";
     static final String REQUIRED_KEY = "required";
     static final String DESCRIPTION_KEY = "description";
+    static final String ENUM_KEY = "enum";
+    static final String SOURCE_KEY = "source";
 
     // Structural types we can infer from the body alone.
     static final String TYPE_STRING = "string";
     static final String TYPE_NUMBER = "number";
     static final String TYPE_BOOLEAN = "boolean";
     static final String TYPE_ARRAY = "array";
+
+    // Value of SOURCE_KEY for an enum derived from the index mapping.
+    static final String SOURCE_MAPPING = "mapping";
 
     private MustacheTemplateAnalyzer() {}
 

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -1574,6 +1574,8 @@ public class MachineLearningPlugin extends Plugin
         systemIndexDescriptors.add(new SystemIndexDescriptor(ML_AGENTIC_MEMORY_INDEX_PATTERN, "ML Commons Agentic Memory Index Pattern"));
         systemIndexDescriptors
             .add(new SystemIndexDescriptor(ML_CONTEXT_MANAGEMENT_TEMPLATES_INDEX, "ML Commons Context Management Index "));
+        systemIndexDescriptors
+            .add(new SystemIndexDescriptor(ML_AGENTIC_SEARCH_TEMPLATES_INDEX, "ML Commons Agentic Search Templates Index"));
 
         return systemIndexDescriptors;
     }

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateFieldNamesTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateFieldNamesTests.java
@@ -95,4 +95,40 @@ public class AgenticSearchTemplateFieldNamesTests {
 
         assertEquals(List.of("weird"), collect(props));
     }
+
+    // A body with a field-selector param (sort_by), a *_field param, and a value param
+    // whose name ends in _by (created_by). Only the field selectors should get the enum.
+    private static final String BODY = "{\"query\":{\"bool\":{\"filter\":["
+        + "{{#created_by}}{\"term\":{\"created_by\":\"{{created_by}}\"}}{{/created_by}}"
+        + "{{#group_field}},{\"term\":{\"{{group_field}}\":\"x\"}}{{/group_field}}]}},"
+        + "\"sort\":[{{#sort_by}}{\"{{sort_by}}\":\"desc\"}{{/sort_by}}]}";
+
+    @Test
+    public void deriveSchema_scopesFieldSelectorsToMappingFields() {
+        AgenticSearchTemplateService service = new AgenticSearchTemplateService(null, null, null, null, null);
+        Map<String, Object> schema = service.deriveSchema(BODY, List.of("price", "brand", "created_at"));
+
+        assertEquals(List.of("price", "brand", "created_at"), enumOf(schema, "sort_by"));
+        assertEquals(List.of("price", "brand", "created_at"), enumOf(schema, "group_field"));
+    }
+
+    @Test
+    public void deriveSchema_leavesValueParamEndingInByUnscoped() {
+        AgenticSearchTemplateService service = new AgenticSearchTemplateService(null, null, null, null, null);
+        Map<String, Object> schema = service.deriveSchema(BODY, List.of("price", "brand", "created_at"));
+
+        // created_by is a filter value, not a field selector; it must not be given the
+        // field-name enum (which would force the model to fill it with a field name).
+        assertFalse(specOf(schema, "created_by").containsKey("enum"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> specOf(Map<String, Object> schema, String param) {
+        return (Map<String, Object>) schema.get(param);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> enumOf(Map<String, Object> schema, String param) {
+        return (List<String>) specOf(schema, param).get("enum");
+    }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateFieldNamesTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateFieldNamesTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+/** Mapping flattening that backs the field-selector enums. */
+public class AgenticSearchTemplateFieldNamesTests {
+
+    private static Map<String, Object> map(Object... keyValues) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            m.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return m;
+    }
+
+    private static List<String> collect(Map<String, Object> properties) {
+        List<String> out = new ArrayList<>();
+        AgenticSearchTemplateService.collectFieldNames(properties, "", out);
+        return out;
+    }
+
+    @Test
+    public void flatFields_allCollected() {
+        List<String> fields = collect(map("price", map("type", "double"), "brand", map("type", "keyword")));
+
+        assertEquals(List.of("price", "brand"), fields);
+    }
+
+    @Test
+    public void objectContainer_excludedButLeavesCollected() {
+        // `spec` cannot be sorted on or matched against, so offering it to the model
+        // would let it pick a field that fails at query time.
+        Map<String, Object> props = map("spec", map("properties", map("os", map("type", "keyword"), "vendor", map("type", "keyword"))));
+
+        List<String> fields = collect(props);
+
+        assertFalse(fields.contains("spec"));
+        assertTrue(fields.containsAll(List.of("spec.os", "spec.vendor")));
+        assertEquals(2, fields.size());
+    }
+
+    @Test
+    public void nestedContainers_recurseToLeavesOnly() {
+        Map<String, Object> props = map(
+            "recall",
+            map("properties", map("date", map("type", "date"), "detail", map("properties", map("note", map("type", "text")))))
+        );
+
+        List<String> fields = collect(props);
+
+        assertEquals(List.of("recall.date", "recall.detail.note"), fields);
+    }
+
+    @Test
+    public void textField_exposesKeywordSubField() {
+        Map<String, Object> props = map("title", map("type", "text", "fields", map("keyword", map("type", "keyword"))));
+
+        List<String> fields = collect(props);
+
+        assertEquals(List.of("title", "title.keyword"), fields);
+    }
+
+    @Test
+    public void containerWithSubFields_keepsSubFieldsWithoutContainer() {
+        // A container carrying `fields` still must not offer itself as a target.
+        Map<String, Object> props = map(
+            "meta",
+            map("properties", map("code", map("type", "keyword")), "fields", map("raw", map("type", "keyword")))
+        );
+
+        List<String> fields = collect(props);
+
+        assertFalse(fields.contains("meta"));
+        assertTrue(fields.contains("meta.code"));
+        assertTrue(fields.contains("meta.raw"));
+    }
+
+    @Test
+    public void nonMapProperty_collectedAsLeaf() {
+        Map<String, Object> props = map("weird", "not-a-map");
+
+        assertEquals(List.of("weird"), collect(props));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateSchemaEditTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateSchemaEditTests.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+/** The checks {@code updateTemplate} runs before persisting a partial param-schema edit. */
+public class AgenticSearchTemplateSchemaEditTests {
+
+    private static Map<String, Object> spec(Object... keyValues) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            m.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return m;
+    }
+
+    private static Map<String, Object> storedSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("size", spec("type", "number", "required", false, "description", ""));
+        schema.put("lex_query", spec("type", "string", "required", true, "description", ""));
+        schema.put("sort_by", spec("type", "string", "required", false, "enum", List.of("price", "rating"), "source", "mapping"));
+        return schema;
+    }
+
+    // ---- mergeParamSchema --------------------------------------------------
+
+    @Test
+    public void merge_editsOneKey_keepsDerivedFactsAndOtherParams() {
+        Map<String, Object> patch = Map.of("size", spec("description", "How many results to return."));
+
+        Map<String, Object> merged = AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch);
+
+        // Edited key applied.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> size = (Map<String, Object>) merged.get("size");
+        assertEquals("How many results to return.", size.get("description"));
+        // Derived facts for that param survive; the spec is not replaced wholesale.
+        assertEquals("number", size.get("type"));
+        assertEquals(false, size.get("required"));
+        // Unmentioned params untouched.
+        assertEquals(3, merged.size());
+        assertTrue(merged.containsKey("lex_query"));
+        assertTrue(merged.containsKey("sort_by"));
+    }
+
+    @Test
+    public void merge_canFlipRequired() {
+        Map<String, Object> patch = Map.of("size", spec("required", true));
+
+        Map<String, Object> merged = AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> size = (Map<String, Object>) merged.get("size");
+        assertEquals(true, size.get("required"));
+    }
+
+    @Test
+    public void merge_unknownParam_rejected() {
+        // A param the body has no placeholder for can never be filled.
+        Map<String, Object> patch = Map.of("nonexistent", spec("type", "string"));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch)
+        );
+        assertTrue(e.getMessage().contains("nonexistent"));
+    }
+
+    @Test
+    public void merge_nonObjectSpec_rejected() {
+        Map<String, Object> patch = Map.of("size", "not-an-object");
+
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch));
+    }
+
+    @Test
+    public void merge_nullStored_treatedAsEmptySoAnyParamIsUnknown() {
+        Map<String, Object> patch = Map.of("size", spec("description", "x"));
+
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.mergeParamSchema(null, patch));
+    }
+
+    // ---- validateParamSchema ----------------------------------------------
+
+    @Test
+    public void validate_derivedSchema_passes() {
+        AgenticSearchTemplateService.validateParamSchema(storedSchema());
+    }
+
+    @Test
+    public void validate_emptyEnum_rejected() {
+        // An empty enum becomes an empty Literal, which the agent server rejects later.
+        Map<String, Object> schema = storedSchema();
+        schema.put("sort_by", spec("type", "string", "enum", List.of()));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgenticSearchTemplateService.validateParamSchema(schema)
+        );
+        assertTrue(e.getMessage().contains("enum"));
+    }
+
+    @Test
+    public void validate_enumValueNotFittingType_rejected() {
+        // A string enum on a number param renders an unquoted word into the body.
+        Map<String, Object> schema = storedSchema();
+        schema.put("size", spec("type", "number", "enum", List.of("ten")));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgenticSearchTemplateService.validateParamSchema(schema)
+        );
+        assertTrue(e.getMessage().contains("does not fit declared type"));
+    }
+
+    @Test
+    public void validate_numericEnumOnNumberParam_passes() {
+        Map<String, Object> schema = storedSchema();
+        schema.put("size", spec("type", "number", "enum", List.of(10, 25, 50)));
+
+        AgenticSearchTemplateService.validateParamSchema(schema);
+    }
+
+    @Test
+    public void validate_missingOrBlankType_rejected() {
+        Map<String, Object> noType = storedSchema();
+        noType.put("size", spec("required", false));
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.validateParamSchema(noType));
+
+        Map<String, Object> blankType = storedSchema();
+        blankType.put("size", spec("type", ""));
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.validateParamSchema(blankType));
+    }
+
+    @Test
+    public void validate_nonBooleanRequired_rejected() {
+        Map<String, Object> schema = storedSchema();
+        schema.put("size", spec("type", "number", "required", "yes"));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgenticSearchTemplateService.validateParamSchema(schema)
+        );
+        assertTrue(e.getMessage().contains("required"));
+    }
+
+    @Test
+    public void validate_arrayParamRequiresRawJsonString() {
+        // A triple-stache slot takes raw JSON as a string, substituted verbatim.
+        Map<String, Object> asString = storedSchema();
+        asString.put("size", spec("type", "array", "enum", List.of("[\"a\",\"b\"]")));
+        AgenticSearchTemplateService.validateParamSchema(asString);
+    }
+
+    @Test
+    public void validate_arrayParamRejectsJsonArray() {
+        // The engine stringifies a List instead of emitting JSON, and a multi-element
+        // list makes the guarding section iterate. Both render invalid JSON.
+        Map<String, Object> asList = storedSchema();
+        asList.put("size", spec("type", "array", "enum", List.of(List.of("a", "b"))));
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> AgenticSearchTemplateService.validateParamSchema(asList)
+        );
+        assertTrue(e.getMessage().contains("does not fit declared type"));
+    }
+
+    @Test
+    public void validate_nullEnumValue_rejected() {
+        Map<String, Object> schema = storedSchema();
+        Map<String, Object> withNull = new LinkedHashMap<>();
+        withNull.put("type", "string");
+        withNull.put("enum", java.util.Arrays.asList("price", null));
+        schema.put("sort_by", withNull);
+
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.validateParamSchema(schema));
+    }
+
+    // ---- merge + validate, as updateTemplate runs them ---------------------
+
+    @Test
+    public void mergeThenValidate_editThatBreaksTypeIsCaught() {
+        // Narrowing sort_by to an enum, but with numbers for a string param.
+        Map<String, Object> patch = Map.of("sort_by", spec("enum", List.of(1, 2)));
+
+        Map<String, Object> merged = AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch);
+        // The merge succeeds (the param exists); validation rejects the values.
+        assertFalse(merged.isEmpty());
+        assertThrows(IllegalArgumentException.class, () -> AgenticSearchTemplateService.validateParamSchema(merged));
+    }
+
+    @Test
+    public void mergeThenValidate_descriptionOnlyEdit_passes() {
+        Map<String, Object> patch = Map.of("lex_query", spec("description", "The shopper's search words."));
+
+        Map<String, Object> merged = AgenticSearchTemplateService.mergeParamSchema(storedSchema(), patch);
+        AgenticSearchTemplateService.validateParamSchema(merged);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> lex = (Map<String, Object>) merged.get("lex_query");
+        assertEquals("The shopper's search words.", lex.get("description"));
+        assertEquals(true, lex.get("required"));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateServiceTests.java
@@ -24,10 +24,14 @@ import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
 import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptResponse;
 import org.opensearch.action.admin.indices.get.GetIndexRequest;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
@@ -45,6 +49,8 @@ import org.opensearch.script.Script;
 import org.opensearch.script.ScriptService;
 import org.opensearch.script.StoredScriptSource;
 import org.opensearch.script.TemplateScript;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
@@ -243,7 +249,221 @@ public class AgenticSearchTemplateServiceTests extends OpenSearchTestCase {
         verify(listener).onResponse(updateResponse);
     }
 
+    // ---- get ---------------------------------------------------------------
+
+    @Test
+    public void getTemplate_success_parsesStoredDoc() {
+        stubGet(TEMPLATE_DOC, true);
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.getTemplate("tmpl", listener);
+
+        ArgumentCaptor<AgenticSearchTemplate> captor = ArgumentCaptor.forClass(AgenticSearchTemplate.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals("tmpl", captor.getValue().getTemplateId());
+    }
+
+    @Test
+    public void getTemplate_notFound_failsNotFound() {
+        stubGet(null, false);
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.getTemplate("missing", listener);
+        assertStatus(listener, RestStatus.NOT_FOUND, "not found");
+    }
+
+    @Test
+    public void getTemplate_indexNotFound_failsNotFound() {
+        stubGetFailure(new IndexNotFoundException("idx"));
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.getTemplate("tmpl", listener);
+        assertStatus(listener, RestStatus.NOT_FOUND, "not found");
+    }
+
+    @Test
+    public void getTemplate_otherException_propagates() {
+        stubGetFailure(new RuntimeException("boom"));
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.getTemplate("tmpl", listener);
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertEquals("boom", ex.getValue().getMessage());
+    }
+
+    // ---- list --------------------------------------------------------------
+
+    @Test
+    public void listTemplates_success_returnsParsedTemplatesAndTotal() {
+        stubSearch(new BytesArray(TEMPLATE_DOC), 5L);
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplateService.MLListResult> listener = mock(ActionListener.class);
+        service.listTemplates(0, 10, listener);
+
+        ArgumentCaptor<AgenticSearchTemplateService.MLListResult> captor = ArgumentCaptor
+            .forClass(AgenticSearchTemplateService.MLListResult.class);
+        verify(listener).onResponse(captor.capture());
+        assertEquals(1, captor.getValue().templates.size());
+        assertEquals(5L, captor.getValue().total);
+        assertEquals("tmpl", captor.getValue().templates.get(0).getTemplateId());
+    }
+
+    @Test
+    public void listTemplates_indexNotFound_returnsEmpty() {
+        stubSearchFailure(new IndexNotFoundException("idx"));
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplateService.MLListResult> listener = mock(ActionListener.class);
+        service.listTemplates(0, 10, listener);
+
+        ArgumentCaptor<AgenticSearchTemplateService.MLListResult> captor = ArgumentCaptor
+            .forClass(AgenticSearchTemplateService.MLListResult.class);
+        verify(listener).onResponse(captor.capture());
+        assertTrue(captor.getValue().templates.isEmpty());
+        assertEquals(0L, captor.getValue().total);
+    }
+
+    @Test
+    public void listTemplates_otherException_propagates() {
+        stubSearchFailure(new RuntimeException("search boom"));
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplateService.MLListResult> listener = mock(ActionListener.class);
+        service.listTemplates(0, 10, listener);
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertEquals("search boom", ex.getValue().getMessage());
+    }
+
+    // ---- delete ------------------------------------------------------------
+
+    @Test
+    public void deleteTemplate_deleted_returnsTrue() {
+        stubDelete(DeleteResponse.Result.DELETED, null);
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        service.deleteTemplate("tmpl", listener);
+        verify(listener).onResponse(true);
+    }
+
+    @Test
+    public void deleteTemplate_notFoundResult_failsNotFound() {
+        stubDelete(DeleteResponse.Result.NOT_FOUND, null);
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        service.deleteTemplate("tmpl", listener);
+        assertStatus(listener, RestStatus.NOT_FOUND, "not found");
+    }
+
+    @Test
+    public void deleteTemplate_indexNotFound_failsNotFound() {
+        stubDelete(null, new IndexNotFoundException("idx"));
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        service.deleteTemplate("tmpl", listener);
+        assertStatus(listener, RestStatus.NOT_FOUND, "not found");
+    }
+
+    @Test
+    public void deleteTemplate_otherException_propagates() {
+        stubDelete(null, new RuntimeException("del boom"));
+        @SuppressWarnings("unchecked")
+        ActionListener<Boolean> listener = mock(ActionListener.class);
+        service.deleteTemplate("tmpl", listener);
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertEquals("del boom", ex.getValue().getMessage());
+    }
+
+    // ---- update: not-found -------------------------------------------------
+
+    @Test
+    public void update_noParamSchema_documentMissing_failsNotFound() {
+        AgenticSearchTemplate patch = AgenticSearchTemplate.builder().templateId("tmpl").description("d").build();
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<UpdateResponse> l = inv.getArgument(1);
+            l.onFailure(new org.opensearch.index.engine.DocumentMissingException(null, "tmpl"));
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        service.updateTemplate("tmpl", patch, listener);
+        assertStatus(listener, RestStatus.NOT_FOUND, "not found");
+    }
+
     // ---- helpers -----------------------------------------------------------
+
+    // A stored template doc as persisted in the system index (parsed by get/list).
+    private static final String TEMPLATE_DOC = "{\"template_id\":\"tmpl\",\"index_binding\":\"my-index\","
+        + "\"param_schema\":{\"lex_query\":{\"type\":\"string\",\"required\":true}}}";
+
+    private void stubGet(String source, boolean exists) {
+        GetResponse response = mock(GetResponse.class);
+        when(response.isExists()).thenReturn(exists);
+        if (source != null) {
+            when(response.getSourceAsBytesRef()).thenReturn(new BytesArray(source));
+        }
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onResponse(response);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+    }
+
+    private void stubGetFailure(Exception e) {
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onFailure(e);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+    }
+
+    private void stubSearch(BytesArray hitSource, long total) {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHit hit = new SearchHit(1);
+        hit.sourceRef(hitSource);
+        SearchHits hits = new SearchHits(
+            new SearchHit[] { hit },
+            new org.apache.lucene.search.TotalHits(total, org.apache.lucene.search.TotalHits.Relation.EQUAL_TO),
+            1.0f
+        );
+        when(response.getHits()).thenReturn(hits);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(response);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+    }
+
+    private void stubSearchFailure(Exception e) {
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onFailure(e);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any());
+    }
+
+    private void stubDelete(DeleteResponse.Result result, Exception failure) {
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<DeleteResponse> l = inv.getArgument(1);
+            if (failure != null) {
+                l.onFailure(failure);
+            } else {
+                DeleteResponse response = mock(DeleteResponse.class);
+                when(response.getResult()).thenReturn(result);
+                l.onResponse(response);
+            }
+            return null;
+        }).when(client).delete(any(DeleteRequest.class), any());
+    }
+
+    private static void assertStatus(ActionListener<?> listener, RestStatus expected, String messageSubstring) {
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertTrue(ex.getValue() instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals(expected, ((org.opensearch.OpenSearchStatusException) ex.getValue()).status());
+        assertTrue(ex.getValue().getMessage().contains(messageSubstring));
+    }
 
     /** Stub the script-compile chain so pre-flight rendering returns a fixed legal body. */
     private void stubRenderSucceeds() {

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateServiceTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/AgenticSearchTemplateServiceTests.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptRequest;
+import org.opensearch.action.admin.cluster.storedscripts.GetStoredScriptResponse;
+import org.opensearch.action.admin.indices.get.GetIndexRequest;
+import org.opensearch.action.admin.indices.get.GetIndexResponse;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.agenticsearch.AgenticSearchTemplate;
+import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptService;
+import org.opensearch.script.StoredScriptSource;
+import org.opensearch.script.TemplateScript;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.IndicesAdminClient;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests for {@link AgenticSearchTemplateService} register and update: the
+ * derive/validate/store path, the no-stored-script and missing-index error cases, and
+ * the version gate on the validated schema update.
+ */
+public class AgenticSearchTemplateServiceTests extends OpenSearchTestCase {
+
+    @Mock
+    private MLIndicesHandler mlIndicesHandler;
+    @Mock
+    private Client client;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ScriptService scriptService;
+    @Mock
+    private ThreadPool threadPool;
+
+    private AgenticSearchTemplateService service;
+
+    // A minimal but real Mustache _search body: one required root value (lex_query) and
+    // one optional section (size with an inverted-section default). Renders to legal JSON
+    // both all-filled and required-only, so pre-flight passes.
+    private static final String TEMPLATE_BODY = "{\"size\":{{size}}{{^size}}10{{/size}},"
+        + "\"query\":{\"multi_match\":{\"query\":\"{{lex_query}}\",\"fields\":[\"title\"]}}}";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        ThreadContext threadContext = new ThreadContext(Settings.builder().build());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+        service = new AgenticSearchTemplateService(mlIndicesHandler, client, clusterService, scriptService, NamedXContentRegistry.EMPTY);
+    }
+
+    // ---- register ----------------------------------------------------------
+
+    @Test
+    public void register_noStoredScript_failsBadRequest() {
+        stubStoredScript(null); // no _scripts body
+
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.register("missing_tmpl", "my-index", "desc", null, listener);
+
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertTrue(ex.getValue() instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((org.opensearch.OpenSearchStatusException) ex.getValue()).status());
+        assertTrue(ex.getValue().getMessage().contains("No stored search template"));
+    }
+
+    @Test
+    public void register_missingTargetIndex_failsBadRequest() {
+        stubStoredScript(TEMPLATE_BODY);
+        // A missing target index is a bad request, not a missing template resource.
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetIndexResponse> l = inv.getArgument(1);
+            l.onFailure(new IndexNotFoundException("my-index"));
+            return null;
+        }).when(indicesAdminClient).getIndex(any(GetIndexRequest.class), any());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.register("tmpl", "my-index", "desc", null, listener);
+
+        ArgumentCaptor<Exception> ex = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(ex.capture());
+        assertTrue(ex.getValue() instanceof org.opensearch.OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((org.opensearch.OpenSearchStatusException) ex.getValue()).status());
+        assertTrue(ex.getValue().getMessage().contains("Index does not exist"));
+    }
+
+    @Test
+    public void register_success_derivesSchemaAndStores() throws Exception {
+        stubStoredScript(TEMPLATE_BODY);
+        stubIndexMapping(ImmutableMap.of("properties", ImmutableMap.of("title", ImmutableMap.of("type", "text"))));
+        stubRenderSucceeds();
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<Boolean> l = inv.getArgument(1);
+            l.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLIndexIfAbsent(any(), any());
+        IndexResponse indexResponse = mock(IndexResponse.class);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<IndexResponse> l = inv.getArgument(1);
+            l.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(IndexRequest.class), any());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<AgenticSearchTemplate> listener = mock(ActionListener.class);
+        service.register("tmpl", "my-index", "desc", null, listener);
+
+        ArgumentCaptor<AgenticSearchTemplate> captor = ArgumentCaptor.forClass(AgenticSearchTemplate.class);
+        verify(listener).onResponse(captor.capture());
+        AgenticSearchTemplate stored = captor.getValue();
+        assertEquals("tmpl", stored.getTemplateId());
+        assertEquals("my-index", stored.getIndexBinding());
+        // Derived from the body: lex_query is a required root value, size is optional.
+        Map<String, Object> schema = stored.getParamSchema();
+        assertTrue(schema.containsKey("lex_query"));
+        assertTrue(schema.containsKey("size"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> lex = (Map<String, Object>) schema.get("lex_query");
+        assertEquals(Boolean.TRUE, lex.get("required"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> size = (Map<String, Object>) schema.get("size");
+        assertEquals(Boolean.FALSE, size.get("required"));
+    }
+
+    // ---- update: optimistic concurrency ------------------------------------
+
+    @Test
+    public void update_noParamSchema_isBlindMergeWithoutVersionGate() {
+        // A patch with no param_schema does not read first, so the write is not gated.
+        AgenticSearchTemplate patch = AgenticSearchTemplate.builder().templateId("tmpl").description("new desc").build();
+        UpdateResponse updateResponse = mock(UpdateResponse.class);
+        ArgumentCaptor<UpdateRequest> reqCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<UpdateResponse> l = inv.getArgument(1);
+            l.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        @SuppressWarnings("unchecked")
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        service.updateTemplate("tmpl", patch, listener);
+
+        verify(client).update(reqCaptor.capture(), any());
+        // No version gate: seqNo stays at the unassigned sentinel.
+        assertEquals(org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO, reqCaptor.getValue().ifSeqNo());
+        verify(client, never()).get(any(GetRequest.class), any());
+        verify(listener).onResponse(updateResponse);
+    }
+
+    @Test
+    public void update_withParamSchema_gatesWriteOnReadSeqNoAndPrimaryTerm() {
+        // A schema edit reads the stored doc, so the write is gated on that read's
+        // seqNo/primaryTerm.
+        String stored = "{\"template_id\":\"tmpl\",\"param_schema\":{"
+            + "\"lex_query\":{\"type\":\"string\",\"required\":true},"
+            + "\"size\":{\"type\":\"number\",\"required\":false}}}";
+        GetResponse getResponse = mock(GetResponse.class);
+        when(getResponse.isExists()).thenReturn(true);
+        when(getResponse.getSourceAsBytesRef()).thenReturn(new BytesArray(stored));
+        when(getResponse.getSeqNo()).thenReturn(7L);
+        when(getResponse.getPrimaryTerm()).thenReturn(3L);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(GetRequest.class), any());
+        stubStoredScript(TEMPLATE_BODY);
+        stubRenderSucceeds();
+        UpdateResponse updateResponse = mock(UpdateResponse.class);
+        ArgumentCaptor<UpdateRequest> reqCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<UpdateResponse> l = inv.getArgument(1);
+            l.onResponse(updateResponse);
+            return null;
+        }).when(client).update(any(UpdateRequest.class), any());
+
+        // Edit a description on an existing param: a valid, renderable merge.
+        AgenticSearchTemplate patch = AgenticSearchTemplate
+            .builder()
+            .templateId("tmpl")
+            .paramSchema(ImmutableMap.of("size", ImmutableMap.of("description", "How many results.")))
+            .build();
+
+        @SuppressWarnings("unchecked")
+        ActionListener<UpdateResponse> listener = mock(ActionListener.class);
+        service.updateTemplate("tmpl", patch, listener);
+
+        verify(client).update(reqCaptor.capture(), any());
+        assertEquals(7L, reqCaptor.getValue().ifSeqNo());
+        assertEquals(3L, reqCaptor.getValue().ifPrimaryTerm());
+        verify(listener).onResponse(updateResponse);
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    /** Stub the script-compile chain so pre-flight rendering returns a fixed legal body. */
+    private void stubRenderSucceeds() {
+        TemplateScript.Factory factory = mock(TemplateScript.Factory.class);
+        TemplateScript templateScript = mock(TemplateScript.class);
+        when(scriptService.compile(any(Script.class), any())).thenReturn(factory);
+        when(factory.newInstance(any())).thenReturn(templateScript);
+        when(templateScript.execute()).thenReturn("{\"query\":{\"match_all\":{}}}");
+    }
+
+    private void stubStoredScript(String body) {
+        GetStoredScriptResponse response = mock(GetStoredScriptResponse.class);
+        when(response.getSource())
+            .thenReturn(body == null ? null : new StoredScriptSource("mustache", body, java.util.Collections.emptyMap()));
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetStoredScriptResponse> l = inv.getArgument(1);
+            l.onResponse(response);
+            return null;
+        }).when(clusterAdminClient).getStoredScript(any(GetStoredScriptRequest.class), any());
+    }
+
+    private void stubIndexMapping(Map<String, Object> mappingSource) {
+        GetIndexResponse response = mock(GetIndexResponse.class);
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.getSourceAsMap()).thenReturn(mappingSource);
+        Map<String, MappingMetadata> mappings = ImmutableMap.of("my-index", mappingMetadata);
+        when(response.mappings()).thenReturn(mappings);
+        doAnswer((Answer<Void>) inv -> {
+            ActionListener<GetIndexResponse> l = inv.getArgument(1);
+            l.onResponse(response);
+            return null;
+        }).when(indicesAdminClient).getIndex(any(GetIndexRequest.class), any());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/agenticsearch/MustacheTemplateAnalyzerTests.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.agenticsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.ml.engine.tools.QueryPlanningPromptTemplate;
+
+public class MustacheTemplateAnalyzerTests {
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> spec(Map<String, Object> schema, String name) {
+        return (Map<String, Object>) schema.get(name);
+    }
+
+    /** The worked example from the design doc (§4.3), abbreviated. */
+    private static final String PRODUCT_BODY = "{ \"size\": {{size}}{{^size}}10{{/size}},"
+        + "  \"query\": { \"bool\": {"
+        + "    \"must\": [ { \"multi_match\": { \"query\": \"{{lex_query}}\", \"fields\": [\"title\"] } } ],"
+        + "    \"filter\": [ { \"match_all\": {} }"
+        + "      {{#color}},{ \"term\": { \"color\": \"{{color}}\" } }{{/color}}"
+        + "      {{#price_max}},{ \"range\": { \"price\": { \"lte\": {{price_max}} } } }{{/price_max}}"
+        + "    ]{{#sort_by}}, \"sort\": [ { \"{{sort_by}}\": { \"order\": \"{{sort_order}}\" } } ]{{/sort_by}} } } }";
+
+    @Test
+    public void derive_workedExample_paramsAndTypes() {
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive(PRODUCT_BODY);
+
+        // All the template's params are discovered.
+        assertTrue(schema.keySet().containsAll(java.util.List.of("size", "lex_query", "color", "price_max", "sort_by", "sort_order")));
+
+        // lex_query sits inside quotes -> string, and is required (plain value, no default).
+        assertEquals("string", spec(schema, "lex_query").get("type"));
+        assertEquals(Boolean.TRUE, spec(schema, "lex_query").get("required"));
+
+        // size has an inverted-section default {{^size}}10{{/size}} -> optional number.
+        assertEquals("number", spec(schema, "size").get("type"));
+        assertEquals(Boolean.FALSE, spec(schema, "size").get("required"));
+
+        // price_max is used both as a section guard AND a value -> optional (guarded).
+        assertEquals(Boolean.FALSE, spec(schema, "price_max").get("required"));
+
+        // color/sort_by/sort_order are optional (guarded / defaulted), never required.
+        assertFalse((Boolean) spec(schema, "color").get("required"));
+        assertFalse((Boolean) spec(schema, "sort_order").get("required"));
+    }
+
+    @Test
+    public void derive_sectionGuardOnly_isBoolean() {
+        // {{#flag}}...{{/flag}} where flag is never substituted -> boolean guard.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ {{#flag}}\"a\":1{{/flag}} }");
+        assertEquals("boolean", spec(schema, "flag").get("type"));
+        assertEquals(Boolean.FALSE, spec(schema, "flag").get("required"));
+    }
+
+    @Test
+    public void derive_tripleStache_isArray() {
+        // {{{x}}} injects raw JSON (an array/object), not an escaped scalar.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ \"fields\": {{{lex_fields}}} }");
+        assertEquals("array", spec(schema, "lex_fields").get("type"));
+    }
+
+    @Test
+    public void derive_unquotedScalar_isNumber() {
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ \"from\": {{from}} }");
+        assertEquals("number", spec(schema, "from").get("type"));
+        assertEquals(Boolean.TRUE, spec(schema, "from").get("required"));
+    }
+
+    @Test
+    public void derive_ignoresComments() {
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ {{! a comment }} \"q\": \"{{lex}}\" }");
+        assertEquals(1, schema.size());
+        assertTrue(schema.containsKey("lex"));
+    }
+
+    @Test
+    public void derive_escapedBackslashBeforeQuote_scalarStaysNumber() {
+        // The closing quote of "C:\\" is preceded by an escaped backslash, NOT an
+        // escaped quote, so the string literal DOES close. {{from}} then sits outside
+        // any string and must classify as number, not string.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ \"path\": \"C:\\\\\", \"from\": {{from}} }");
+        assertEquals("number", spec(schema, "from").get("type"));
+    }
+
+    @Test
+    public void derive_escapedQuoteInString_scalarStaysString() {
+        // An escaped quote (\") inside a string does NOT close it, so {{lex}} is still
+        // inside the string literal -> string.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ \"q\": \"say \\\"hi\\\" {{lex}}\" }");
+        assertEquals("string", spec(schema, "lex").get("type"));
+    }
+
+    @Test
+    public void derive_quoteScanResetsPerLine_laterScalarUnaffected() {
+        // A lone quote on an earlier line must not leak "inside string" state onto a
+        // later line's scalar. {{from}} is unquoted on its own line -> number.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive("{ \"note\": \"unterminated\n, \"from\": {{from}} }");
+        assertEquals("number", spec(schema, "from").get("type"));
+    }
+
+    @Test
+    public void derive_unbalancedSection_throws() {
+        assertThrows(IllegalArgumentException.class, () -> MustacheTemplateAnalyzer.derive("{ {{#a}} x {{/b}} }"));
+        assertThrows(IllegalArgumentException.class, () -> MustacheTemplateAnalyzer.derive("{ {{#a}} x }"));
+    }
+
+    @Test
+    public void derive_emptyBody_throws() {
+        assertThrows(IllegalArgumentException.class, () -> MustacheTemplateAnalyzer.derive(""));
+        assertThrows(IllegalArgumentException.class, () -> MustacheTemplateAnalyzer.derive(null));
+    }
+
+    @Test
+    public void derive_realDefaultSearchTemplate_findsExpectedParams() {
+        // The production DEFAULT_SEARCH_TEMPLATE exercises triples, inverted defaults,
+        // and section guards; the analyzer should walk it without error.
+        Map<String, Object> schema = MustacheTemplateAnalyzer.derive(QueryPlanningPromptTemplate.DEFAULT_SEARCH_TEMPLATE);
+        assertTrue(schema.containsKey("lex_query"));
+        assertTrue(schema.containsKey("from"));
+        assertTrue(schema.containsKey("sem_enabled"));
+        // sem_enabled guards a section but is never substituted -> boolean.
+        assertEquals("boolean", spec(schema, "sem_enabled").get("type"));
+        // lex_fields is a triple-stache -> array.
+        assertEquals("array", spec(schema, "lex_fields").get("type"));
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
@@ -260,7 +260,7 @@ public class MachineLearningPluginTests {
         Settings settings = Settings.EMPTY;
         Collection<SystemIndexDescriptor> descriptors = plugin.getSystemIndexDescriptors(settings);
         assertNotNull(descriptors);
-        assertEquals(15, descriptors.size()); // Plugin defines 15 system indices
+        assertEquals(16, descriptors.size()); // Plugin defines 16 system indices
 
         // Verify we have system index descriptors
         assertFalse(descriptors.isEmpty());


### PR DESCRIPTION
### Description

Introduces the metadata layer for agentic search templates: given a stored Mustache search template, derive the typed parameter schema an LLM needs in order to fill it, and persist that schema alongside the template.

The Mustache body itself stays in core `_scripts`; this adds ml-commons metadata beside it, one document per template in a new system index keyed by the template name.

**What's here**

- `MustacheTemplateAnalyzer` walks the template body and infers each parameter's name, type, and whether it is required. A name used only as a section guard is a boolean; a triple-stache is an injected JSON value; a parameter is required only when it is a bare value at root scope never wrapped in its own section, since anything wrapped in a section renders conditionally.
- `AgenticSearchTemplateService` combines that parse with the target index's mapping, scoping field-selector parameters to the mapping's field names so a model can only target a field that exists.
- Registration pre-flight validates by rendering the body twice — all-filled and required-only — through the cluster's own Mustache engine, so a body that cannot render legal JSON fails at registration rather than on first query.
- A schema edit is validated the same way, against the merged schema, and additionally checked for internal consistency: an enum whose values do not fit the declared type, an empty enum, or a non-boolean `required` flag are all rejected. Without this an edit could be accepted and then silently break every subsequent render.

This PR is the derivation and validation core only; the transport and REST surface follows in a separate PR so this can be reviewed on its own. It compiles and tests standalone.

### Related Issues

Related to #4925

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
