### PR TITLE
[Memory] Retention job dynamic interval fix + dry-run API

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -135,7 +135,7 @@ public class MemoryContainerConstants {
         + "/{"
         + PARAMETER_MEMORY_CONTAINER_ID
         + "}/_retention/_dry_run";
-    public static final String RETENTION_DRY_RUN_ALL_PATH = "/_plugins/_ml/memory/_retention/_dry_run";
+    public static final String RETENTION_DRY_RUN_ALL_PATH = BASE_MEMORY_CONTAINERS_PATH + "/_retention/_dry_run";
 
     // Memory types are defined in MemoryType enum
     // Memory strategy types are defined in MemoryStrategyType enum

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -130,6 +130,12 @@ public class MemoryContainerConstants {
     public static final String DELETE_MEMORIES_BY_QUERY_PATH = MEMORIES_PATH + "/{" + PARAMETER_MEMORY_TYPE + "}" + "/_delete_by_query";
     public static final String SEMANTIC_SEARCH_MEMORIES_PATH = MEMORIES_PATH + "/long-term/_semantic_search";
     public static final String HYBRID_SEARCH_MEMORIES_PATH = MEMORIES_PATH + "/long-term/_hybrid_search";
+    // Retention dry-run: preview what the scheduled retention job would delete, without deleting.
+    public static final String RETENTION_DRY_RUN_PATH = BASE_MEMORY_CONTAINERS_PATH
+        + "/{"
+        + PARAMETER_MEMORY_CONTAINER_ID
+        + "}/_retention/_dry_run";
+    public static final String RETENTION_DRY_RUN_ALL_PATH = "/_plugins/_ml/memory/_retention/_dry_run";
 
     // Memory types are defined in MemoryType enum
     // Memory strategy types are defined in MemoryStrategyType enum

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunAction.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import org.opensearch.action.ActionType;
+
+public class MLMemoryRetentionDryRunAction extends ActionType<MLMemoryRetentionDryRunResponse> {
+    public static final MLMemoryRetentionDryRunAction INSTANCE = new MLMemoryRetentionDryRunAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/memory_containers/retention_dry_run";
+
+    private MLMemoryRetentionDryRunAction() {
+        super(NAME, MLMemoryRetentionDryRunResponse::new);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Request to preview what the scheduled retention job would delete.
+ *
+ * <p>When {@code memoryContainerId} is set, the dry-run targets a single container. When it is
+ * {@code null}, the dry-run runs cluster-wide across every container (the response is an array).
+ */
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+public class MLMemoryRetentionDryRunRequest extends ActionRequest {
+
+    String memoryContainerId;
+    String tenantId;
+
+    @Builder
+    public MLMemoryRetentionDryRunRequest(String memoryContainerId, String tenantId) {
+        this.memoryContainerId = memoryContainerId;
+        this.tenantId = tenantId;
+    }
+
+    public MLMemoryRetentionDryRunRequest(StreamInput in) throws IOException {
+        super(in);
+        this.memoryContainerId = in.readOptionalString();
+        this.tenantId = in.readOptionalString();
+    }
+
+    /** True when this dry-run targets every container in the cluster rather than a single one. */
+    public boolean isClusterWide() {
+        return memoryContainerId == null;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(memoryContainerId);
+        out.writeOptionalString(tenantId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        // memoryContainerId is intentionally optional: null means cluster-wide.
+        return null;
+    }
+
+    public static MLMemoryRetentionDryRunRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLMemoryRetentionDryRunRequest) {
+            return (MLMemoryRetentionDryRunRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLMemoryRetentionDryRunRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLMemoryRetentionDryRunRequest", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
@@ -35,11 +35,27 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
     private final List<MemoryRetentionDryRunResult> results;
     private final boolean clusterWide;
     private final int skippedCount;
+    // Cluster-wide only: true when the evaluated container count hit MAX_CONTAINERS_PER_DRY_RUN and remaining
+    // containers were not evaluated. 'warning' carries a human-readable explanation of the cap when truncated.
+    private final boolean truncated;
+    private final String warning;
 
     public MLMemoryRetentionDryRunResponse(List<MemoryRetentionDryRunResult> results, boolean clusterWide, int skippedCount) {
+        this(results, clusterWide, skippedCount, false, null);
+    }
+
+    public MLMemoryRetentionDryRunResponse(
+        List<MemoryRetentionDryRunResult> results,
+        boolean clusterWide,
+        int skippedCount,
+        boolean truncated,
+        String warning
+    ) {
         this.results = results;
         this.clusterWide = clusterWide;
         this.skippedCount = skippedCount;
+        this.truncated = truncated;
+        this.warning = warning;
     }
 
     public MLMemoryRetentionDryRunResponse(StreamInput in) throws IOException {
@@ -47,6 +63,10 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
         this.results = in.readList(MemoryRetentionDryRunResult::new);
         this.clusterWide = in.readBoolean();
         this.skippedCount = in.readVInt();
+        // Appended for wire-compat: older senders never wrote these, but this PR introduces the response, so all
+        // peers speak this layout. Read in the same order they are written.
+        this.truncated = in.readBoolean();
+        this.warning = in.readOptionalString();
     }
 
     @Override
@@ -54,6 +74,8 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
         out.writeList(results);
         out.writeBoolean(clusterWide);
         out.writeVInt(skippedCount);
+        out.writeBoolean(truncated);
+        out.writeOptionalString(warning);
     }
 
     @Override
@@ -61,6 +83,10 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
         if (clusterWide) {
             builder.startObject();
             builder.field("skipped_count", skippedCount);
+            builder.field("truncated", truncated);
+            if (warning != null) {
+                builder.field("warning", warning);
+            }
             builder.startArray("results");
             for (MemoryRetentionDryRunResult result : results) {
                 result.toXContent(builder, params);

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.Getter;
+
+/**
+ * Response for a retention dry-run.
+ *
+ * <p>Carries one or more {@link MemoryRetentionDryRunResult} objects. A single-container dry-run
+ * renders as a bare object; a cluster-wide dry-run renders as a JSON array of objects. The
+ * {@code clusterWide} flag drives which rendering is used so a single-element cluster-wide result
+ * still renders as an array.
+ */
+@Getter
+public class MLMemoryRetentionDryRunResponse extends ActionResponse implements ToXContentObject {
+
+    private final List<MemoryRetentionDryRunResult> results;
+    private final boolean clusterWide;
+
+    public MLMemoryRetentionDryRunResponse(List<MemoryRetentionDryRunResult> results, boolean clusterWide) {
+        this.results = results;
+        this.clusterWide = clusterWide;
+    }
+
+    public MLMemoryRetentionDryRunResponse(StreamInput in) throws IOException {
+        super(in);
+        this.results = in.readList(MemoryRetentionDryRunResult::new);
+        this.clusterWide = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(results);
+        out.writeBoolean(clusterWide);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (clusterWide) {
+            builder.startArray();
+            for (MemoryRetentionDryRunResult result : results) {
+                result.toXContent(builder, params);
+            }
+            builder.endArray();
+            return builder;
+        }
+        // Single-container dry-run: render the sole result as a bare object.
+        return results.get(0).toXContent(builder, params);
+    }
+
+    public static MLMemoryRetentionDryRunResponse fromActionResponse(ActionResponse actionResponse) {
+        if (actionResponse instanceof MLMemoryRetentionDryRunResponse) {
+            return (MLMemoryRetentionDryRunResponse) actionResponse;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionResponse.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLMemoryRetentionDryRunResponse(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionResponse into MLMemoryRetentionDryRunResponse", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
@@ -34,32 +34,39 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
 
     private final List<MemoryRetentionDryRunResult> results;
     private final boolean clusterWide;
+    private final int skippedCount;
 
-    public MLMemoryRetentionDryRunResponse(List<MemoryRetentionDryRunResult> results, boolean clusterWide) {
+    public MLMemoryRetentionDryRunResponse(List<MemoryRetentionDryRunResult> results, boolean clusterWide, int skippedCount) {
         this.results = results;
         this.clusterWide = clusterWide;
+        this.skippedCount = skippedCount;
     }
 
     public MLMemoryRetentionDryRunResponse(StreamInput in) throws IOException {
         super(in);
         this.results = in.readList(MemoryRetentionDryRunResult::new);
         this.clusterWide = in.readBoolean();
+        this.skippedCount = in.readVInt();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeList(results);
         out.writeBoolean(clusterWide);
+        out.writeVInt(skippedCount);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         if (clusterWide) {
-            builder.startArray();
+            builder.startObject();
+            builder.field("skipped_count", skippedCount);
+            builder.startArray("results");
             for (MemoryRetentionDryRunResult result : results) {
                 result.toXContent(builder, params);
             }
             builder.endArray();
+            builder.endObject();
             return builder;
         }
         // Single-container dry-run: render the sole result as a bare object.

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResult.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResult.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Immutable result of a single container's retention dry-run: exactly what the scheduled
+ * {@code MemoryRetentionJobProcessor} would delete on its next run, without deleting anything.
+ *
+ * <p>The counts here are produced by reusing the job's own read-only {@code identify*} / count
+ * logic (see the dry-run methods on the processor), so they cannot drift from the real job's
+ * deletion behavior.
+ */
+@Getter
+public class MemoryRetentionDryRunResult implements ToXContentObject, Writeable {
+
+    // Top-level response field names (kept local to this contract).
+    public static final String CONTAINER_ID_FIELD = "container_id";
+    public static final String EVALUATED_AT_FIELD = "evaluated_at";
+    public static final String POLICY_SOURCE_FIELD = "policy_source";
+    public static final String EFFECTIVE_POLICY_FIELD = "effective_policy";
+    public static final String WORKING_MEMORY_TTL_DAYS_FIELD = "working_memory_ttl_days";
+    public static final String WOULD_DELETE_FIELD = "would_delete";
+    public static final String TOTAL_WOULD_DELETE_FIELD = "total_would_delete";
+    public static final String PINNED_WOULD_SKIP_FIELD = "pinned_would_skip";
+    public static final String WARNINGS_FIELD = "warnings";
+
+    // would_delete sub-keys
+    public static final String SESSIONS_KEY = "sessions";
+    public static final String LONG_TERM_KEY = "long_term";
+    public static final String HISTORY_KEY = "history";
+    public static final String WORKING_MEMORY_KEY = "working_memory";
+
+    // TypeDeletion sub-keys
+    public static final String TOTAL_KEY = "total";
+    public static final String BY_REASON_KEY = "by_reason";
+
+    // by_reason reason keys
+    public static final String REASON_RETENTION_DAYS = "retention_days";
+    public static final String REASON_MAX_COUNT = "max_count";
+    public static final String REASON_CASCADE = "cascade";
+    public static final String REASON_TTL = "ttl";
+    public static final String REASON_ORPHAN = "orphan";
+
+    /** Valid values for {@link #policySource}. */
+    public static final String POLICY_SOURCE_STORED = "stored";
+    public static final String POLICY_SOURCE_DEFAULT = "default";
+    public static final String POLICY_SOURCE_NONE = "none";
+
+    private final String containerId;
+    private final long evaluatedAt;
+    private final String policySource;
+    /** The retention rules that would be applied (stored, backfilled default, or empty for none). */
+    private final Map<MemoryType, RetentionRule> effectivePolicy;
+    /** Cluster working-memory TTL in days; only rendered when {@code > 0} (session-less containers). */
+    private final Integer workingMemoryTtlDays;
+    private final TypeDeletion sessions;
+    private final TypeDeletion longTerm;
+    private final TypeDeletion history;
+    private final TypeDeletion workingMemory;
+    private final long totalWouldDelete;
+    private final long pinnedWouldSkip;
+    private final List<String> warnings;
+
+    @Builder
+    public MemoryRetentionDryRunResult(
+        String containerId,
+        long evaluatedAt,
+        String policySource,
+        Map<MemoryType, RetentionRule> effectivePolicy,
+        Integer workingMemoryTtlDays,
+        TypeDeletion sessions,
+        TypeDeletion longTerm,
+        TypeDeletion history,
+        TypeDeletion workingMemory,
+        long totalWouldDelete,
+        long pinnedWouldSkip,
+        List<String> warnings
+    ) {
+        this.containerId = containerId;
+        this.evaluatedAt = evaluatedAt;
+        this.policySource = policySource;
+        this.effectivePolicy = effectivePolicy;
+        this.workingMemoryTtlDays = workingMemoryTtlDays;
+        this.sessions = sessions;
+        this.longTerm = longTerm;
+        this.history = history;
+        this.workingMemory = workingMemory;
+        this.totalWouldDelete = totalWouldDelete;
+        this.pinnedWouldSkip = pinnedWouldSkip;
+        this.warnings = warnings;
+    }
+
+    public MemoryRetentionDryRunResult(StreamInput in) throws IOException {
+        this.containerId = in.readString();
+        this.evaluatedAt = in.readLong();
+        this.policySource = in.readString();
+        if (in.readBoolean()) {
+            int size = in.readVInt();
+            Map<MemoryType, RetentionRule> policy = new EnumMap<>(MemoryType.class);
+            for (int i = 0; i < size; i++) {
+                MemoryType key = in.readEnum(MemoryType.class);
+                policy.put(key, new RetentionRule(in));
+            }
+            this.effectivePolicy = policy;
+        } else {
+            this.effectivePolicy = null;
+        }
+        this.workingMemoryTtlDays = in.readOptionalInt();
+        this.sessions = new TypeDeletion(in);
+        this.longTerm = new TypeDeletion(in);
+        this.history = new TypeDeletion(in);
+        this.workingMemory = new TypeDeletion(in);
+        this.totalWouldDelete = in.readLong();
+        this.pinnedWouldSkip = in.readLong();
+        this.warnings = in.readStringList();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(containerId);
+        out.writeLong(evaluatedAt);
+        out.writeString(policySource);
+        if (effectivePolicy != null && !effectivePolicy.isEmpty()) {
+            out.writeBoolean(true);
+            out.writeVInt(effectivePolicy.size());
+            for (Map.Entry<MemoryType, RetentionRule> entry : effectivePolicy.entrySet()) {
+                out.writeEnum(entry.getKey());
+                entry.getValue().writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalInt(workingMemoryTtlDays);
+        sessions.writeTo(out);
+        longTerm.writeTo(out);
+        history.writeTo(out);
+        workingMemory.writeTo(out);
+        out.writeLong(totalWouldDelete);
+        out.writeLong(pinnedWouldSkip);
+        out.writeStringCollection(warnings == null ? new ArrayList<>() : warnings);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field(CONTAINER_ID_FIELD, containerId);
+        builder.field(EVALUATED_AT_FIELD, evaluatedAt);
+        builder.field(POLICY_SOURCE_FIELD, policySource);
+
+        builder.startObject(EFFECTIVE_POLICY_FIELD);
+        if (effectivePolicy != null) {
+            if (effectivePolicy.containsKey(MemoryType.SESSIONS)) {
+                builder.field(SESSIONS_KEY);
+                effectivePolicy.get(MemoryType.SESSIONS).toXContent(builder, params);
+            }
+            if (effectivePolicy.containsKey(MemoryType.LONG_TERM)) {
+                builder.field(LONG_TERM_KEY);
+                effectivePolicy.get(MemoryType.LONG_TERM).toXContent(builder, params);
+            }
+            if (effectivePolicy.containsKey(MemoryType.HISTORY)) {
+                builder.field(HISTORY_KEY);
+                effectivePolicy.get(MemoryType.HISTORY).toXContent(builder, params);
+            }
+        }
+        if (workingMemoryTtlDays != null && workingMemoryTtlDays > 0) {
+            builder.field(WORKING_MEMORY_TTL_DAYS_FIELD, workingMemoryTtlDays);
+        }
+        builder.endObject();
+
+        builder.startObject(WOULD_DELETE_FIELD);
+        builder.field(SESSIONS_KEY);
+        sessions.toXContent(builder, params);
+        builder.field(LONG_TERM_KEY);
+        longTerm.toXContent(builder, params);
+        builder.field(HISTORY_KEY);
+        history.toXContent(builder, params);
+        builder.field(WORKING_MEMORY_KEY);
+        workingMemory.toXContent(builder, params);
+        builder.endObject();
+
+        builder.field(TOTAL_WOULD_DELETE_FIELD, totalWouldDelete);
+        builder.field(PINNED_WOULD_SKIP_FIELD, pinnedWouldSkip);
+        builder.field(WARNINGS_FIELD, warnings == null ? new ArrayList<>() : warnings);
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Per-memory-type deletion count with a breakdown by the reason the job would evict each document.
+     * {@code total} is the number the job would actually delete (deduplicated where the job dedups);
+     * the {@code byReason} components are a disjoint attribution that sums to {@code total}.
+     */
+    @Getter
+    public static class TypeDeletion implements ToXContentObject, Writeable {
+        private final long total;
+        private final LinkedHashMap<String, Long> byReason;
+
+        public TypeDeletion(long total, LinkedHashMap<String, Long> byReason) {
+            this.total = total;
+            this.byReason = byReason == null ? new LinkedHashMap<>() : byReason;
+        }
+
+        public TypeDeletion(StreamInput in) throws IOException {
+            this.total = in.readLong();
+            int size = in.readVInt();
+            this.byReason = new LinkedHashMap<>();
+            for (int i = 0; i < size; i++) {
+                this.byReason.put(in.readString(), in.readLong());
+            }
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeLong(total);
+            out.writeVInt(byReason.size());
+            for (Map.Entry<String, Long> entry : byReason.entrySet()) {
+                out.writeString(entry.getKey());
+                out.writeLong(entry.getValue());
+            }
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            builder.startObject();
+            builder.field(TOTAL_KEY, total);
+            builder.startObject(BY_REASON_KEY);
+            for (Map.Entry<String, Long> entry : byReason.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue());
+            }
+            builder.endObject();
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunRequestTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLMemoryRetentionDryRunRequestTests {
+
+    @Test
+    public void testSingleContainerRequest() {
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest
+            .builder()
+            .memoryContainerId("container-1")
+            .tenantId("tenant-1")
+            .build();
+        assertEquals("container-1", request.getMemoryContainerId());
+        assertEquals("tenant-1", request.getTenantId());
+        assertFalse(request.isClusterWide());
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void testClusterWideRequest() {
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId(null).build();
+        assertTrue(request.isClusterWide());
+        // cluster-wide is valid (no container id required)
+        assertNull(request.validate());
+    }
+
+    @Test
+    public void testStreamRoundTripSingle() throws IOException {
+        MLMemoryRetentionDryRunRequest original = MLMemoryRetentionDryRunRequest
+            .builder()
+            .memoryContainerId("container-xyz")
+            .tenantId("tenant-abc")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryRetentionDryRunRequest parsed = new MLMemoryRetentionDryRunRequest(in);
+        assertEquals("container-xyz", parsed.getMemoryContainerId());
+        assertEquals("tenant-abc", parsed.getTenantId());
+        assertFalse(parsed.isClusterWide());
+    }
+
+    @Test
+    public void testStreamRoundTripClusterWide() throws IOException {
+        MLMemoryRetentionDryRunRequest original = MLMemoryRetentionDryRunRequest.builder().build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryRetentionDryRunRequest parsed = new MLMemoryRetentionDryRunRequest(in);
+        assertNull(parsed.getMemoryContainerId());
+        assertTrue(parsed.isClusterWide());
+    }
+
+    @Test
+    public void testFromActionRequestSameInstance() {
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c").build();
+        assertSame(request, MLMemoryRetentionDryRunRequest.fromActionRequest(request));
+    }
+
+    @Test
+    public void testFromActionRequestConverts() {
+        MLMemoryRetentionDryRunRequest original = MLMemoryRetentionDryRunRequest
+            .builder()
+            .memoryContainerId("container-9")
+            .tenantId("t9")
+            .build();
+        ActionRequest wrapper = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                original.writeTo(out);
+            }
+        };
+        MLMemoryRetentionDryRunRequest converted = MLMemoryRetentionDryRunRequest.fromActionRequest(wrapper);
+        assertNotNull(converted);
+        assertEquals("container-9", converted.getMemoryContainerId());
+        assertEquals("t9", converted.getTenantId());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void testFromActionRequestIOException() {
+        ActionRequest broken = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("boom");
+            }
+        };
+        MLMemoryRetentionDryRunRequest.fromActionRequest(broken);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResultTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResultTests.java
@@ -149,37 +149,41 @@ public class MemoryRetentionDryRunResultTests {
 
     @Test
     public void testResponseSingleRendersObject() throws IOException {
-        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false);
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false, 0);
         String json = toJson(response);
         // Single container: bare object, not an array
         assertTrue(json.startsWith("{"));
         assertTrue(json.contains("\"container_id\":\"agent-customer-support-abc123\""));
+        // Single-container branch does not surface skipped_count
+        assertTrue(!json.contains("skipped_count"));
     }
 
     @Test
     public void testResponseClusterWideRendersArray() throws IOException {
-        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), true);
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), true, 2);
         String json = toJson(response);
-        // Cluster-wide: array even with a single element
-        assertTrue(json.startsWith("["));
-        assertTrue(json.endsWith("]"));
+        // Cluster-wide: object wrapping a skipped_count and a results array (even with a single element)
+        assertTrue(json.startsWith("{"));
+        assertTrue(json.contains("\"skipped_count\":2"));
+        assertTrue(json.contains("\"results\":["));
     }
 
     @Test
     public void testResponseStreamRoundTrip() throws IOException {
-        MLMemoryRetentionDryRunResponse original = new MLMemoryRetentionDryRunResponse(List.of(sampleResult(), sampleResult()), true);
+        MLMemoryRetentionDryRunResponse original = new MLMemoryRetentionDryRunResponse(List.of(sampleResult(), sampleResult()), true, 3);
         BytesStreamOutput out = new BytesStreamOutput();
         original.writeTo(out);
         StreamInput in = out.bytes().streamInput();
         MLMemoryRetentionDryRunResponse parsed = new MLMemoryRetentionDryRunResponse(in);
         assertEquals(2, parsed.getResults().size());
         assertTrue(parsed.isClusterWide());
+        assertEquals(3, parsed.getSkippedCount());
         assertEquals("agent-customer-support-abc123", parsed.getResults().get(0).getContainerId());
     }
 
     @Test
     public void testResponseFromActionResponseSame() {
-        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false);
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false, 0);
         assertEquals(response, MLMemoryRetentionDryRunResponse.fromActionResponse(response));
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResultTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MemoryRetentionDryRunResultTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+
+public class MemoryRetentionDryRunResultTests {
+
+    private MemoryRetentionDryRunResult sampleResult() {
+        Map<MemoryType, RetentionRule> policy = new EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(30, 500));
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(180, 10000));
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 5000));
+
+        LinkedHashMap<String, Long> sessionsBr = new LinkedHashMap<>();
+        sessionsBr.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, 35L);
+        sessionsBr.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, 12L);
+
+        LinkedHashMap<String, Long> ltBr = new LinkedHashMap<>();
+        ltBr.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, 5L);
+        ltBr.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, 0L);
+
+        LinkedHashMap<String, Long> histBr = new LinkedHashMap<>();
+        histBr.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, 0L);
+        histBr.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, 8L);
+
+        LinkedHashMap<String, Long> workBr = new LinkedHashMap<>();
+        workBr.put(MemoryRetentionDryRunResult.REASON_CASCADE, 1380L);
+        workBr.put(MemoryRetentionDryRunResult.REASON_TTL, 34L);
+        workBr.put(MemoryRetentionDryRunResult.REASON_ORPHAN, 6L);
+
+        return MemoryRetentionDryRunResult
+            .builder()
+            .containerId("agent-customer-support-abc123")
+            .evaluatedAt(1752634800000L)
+            .policySource(MemoryRetentionDryRunResult.POLICY_SOURCE_STORED)
+            .effectivePolicy(policy)
+            .workingMemoryTtlDays(7)
+            .sessions(new MemoryRetentionDryRunResult.TypeDeletion(47, sessionsBr))
+            .longTerm(new MemoryRetentionDryRunResult.TypeDeletion(5, ltBr))
+            .history(new MemoryRetentionDryRunResult.TypeDeletion(8, histBr))
+            .workingMemory(new MemoryRetentionDryRunResult.TypeDeletion(1420, workBr))
+            .totalWouldDelete(1480)
+            .pinnedWouldSkip(3)
+            .warnings(List.of("pinned count (503) exceeds max_count (500) for sessions — container will grow unbounded"))
+            .build();
+    }
+
+    private String toJson(ToXContent obj) throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        obj.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return builder.toString();
+    }
+
+    @Test
+    public void testXContentShapeMatchesContract() throws IOException {
+        String json = toJson(sampleResult());
+
+        assertTrue(json.contains("\"container_id\":\"agent-customer-support-abc123\""));
+        assertTrue(json.contains("\"evaluated_at\":1752634800000"));
+        assertTrue(json.contains("\"policy_source\":\"stored\""));
+        // effective_policy
+        assertTrue(json.contains("\"effective_policy\":{"));
+        assertTrue(json.contains("\"sessions\":{\"retention_days\":30,\"max_count\":500}"));
+        assertTrue(json.contains("\"long_term\":{\"retention_days\":180,\"max_count\":10000}"));
+        assertTrue(json.contains("\"history\":{\"max_count\":5000}"));
+        assertTrue(json.contains("\"working_memory_ttl_days\":7"));
+        // would_delete
+        assertTrue(json.contains("\"would_delete\":{"));
+        assertTrue(json.contains("\"sessions\":{\"total\":47,\"by_reason\":{\"retention_days\":35,\"max_count\":12}}"));
+        assertTrue(json.contains("\"long_term\":{\"total\":5,\"by_reason\":{\"retention_days\":5,\"max_count\":0}}"));
+        assertTrue(json.contains("\"history\":{\"total\":8,\"by_reason\":{\"retention_days\":0,\"max_count\":8}}"));
+        assertTrue(json.contains("\"working_memory\":{\"total\":1420,\"by_reason\":{\"cascade\":1380,\"ttl\":34,\"orphan\":6}}"));
+        assertTrue(json.contains("\"total_would_delete\":1480"));
+        assertTrue(json.contains("\"pinned_would_skip\":3"));
+        assertTrue(json.contains("\"warnings\":[\"pinned count (503) exceeds max_count (500) for sessions"));
+    }
+
+    @Test
+    public void testStreamRoundTrip() throws IOException {
+        MemoryRetentionDryRunResult original = sampleResult();
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MemoryRetentionDryRunResult parsed = new MemoryRetentionDryRunResult(in);
+
+        assertEquals("agent-customer-support-abc123", parsed.getContainerId());
+        assertEquals(1752634800000L, parsed.getEvaluatedAt());
+        assertEquals("stored", parsed.getPolicySource());
+        assertEquals(Integer.valueOf(7), parsed.getWorkingMemoryTtlDays());
+        assertEquals(47, parsed.getSessions().getTotal());
+        assertEquals(Long.valueOf(35L), parsed.getSessions().getByReason().get("retention_days"));
+        assertEquals(Long.valueOf(12L), parsed.getSessions().getByReason().get("max_count"));
+        assertEquals(1420, parsed.getWorkingMemory().getTotal());
+        assertEquals(Long.valueOf(6L), parsed.getWorkingMemory().getByReason().get("orphan"));
+        assertEquals(1480, parsed.getTotalWouldDelete());
+        assertEquals(3, parsed.getPinnedWouldSkip());
+        assertEquals(1, parsed.getWarnings().size());
+        assertEquals(3, parsed.getEffectivePolicy().size());
+        assertEquals(Integer.valueOf(500), parsed.getEffectivePolicy().get(MemoryType.SESSIONS).getMaxCount());
+        assertEquals(Integer.valueOf(5000), parsed.getEffectivePolicy().get(MemoryType.HISTORY).getMaxCount());
+    }
+
+    @Test
+    public void testNonePolicyRendersEmptyEffectivePolicyAndNoTtl() throws IOException {
+        MemoryRetentionDryRunResult result = MemoryRetentionDryRunResult
+            .builder()
+            .containerId("c-none")
+            .evaluatedAt(1000L)
+            .policySource(MemoryRetentionDryRunResult.POLICY_SOURCE_NONE)
+            .effectivePolicy(null)
+            .workingMemoryTtlDays(-1)
+            .sessions(new MemoryRetentionDryRunResult.TypeDeletion(0, new LinkedHashMap<>()))
+            .longTerm(new MemoryRetentionDryRunResult.TypeDeletion(0, new LinkedHashMap<>()))
+            .history(new MemoryRetentionDryRunResult.TypeDeletion(0, new LinkedHashMap<>()))
+            .workingMemory(new MemoryRetentionDryRunResult.TypeDeletion(0, new LinkedHashMap<>()))
+            .totalWouldDelete(0)
+            .pinnedWouldSkip(0)
+            .warnings(List.of("container has no retention policy and no cluster defaults apply; nothing would be deleted"))
+            .build();
+
+        String json = toJson(result);
+        assertTrue(json.contains("\"policy_source\":\"none\""));
+        assertTrue(json.contains("\"effective_policy\":{}"));
+        // ttl <= 0 is not rendered
+        assertTrue(!json.contains("working_memory_ttl_days"));
+        assertTrue(json.contains("\"total_would_delete\":0"));
+    }
+
+    @Test
+    public void testResponseSingleRendersObject() throws IOException {
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false);
+        String json = toJson(response);
+        // Single container: bare object, not an array
+        assertTrue(json.startsWith("{"));
+        assertTrue(json.contains("\"container_id\":\"agent-customer-support-abc123\""));
+    }
+
+    @Test
+    public void testResponseClusterWideRendersArray() throws IOException {
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), true);
+        String json = toJson(response);
+        // Cluster-wide: array even with a single element
+        assertTrue(json.startsWith("["));
+        assertTrue(json.endsWith("]"));
+    }
+
+    @Test
+    public void testResponseStreamRoundTrip() throws IOException {
+        MLMemoryRetentionDryRunResponse original = new MLMemoryRetentionDryRunResponse(List.of(sampleResult(), sampleResult()), true);
+        BytesStreamOutput out = new BytesStreamOutput();
+        original.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        MLMemoryRetentionDryRunResponse parsed = new MLMemoryRetentionDryRunResponse(in);
+        assertEquals(2, parsed.getResults().size());
+        assertTrue(parsed.isClusterWide());
+        assertEquals("agent-customer-support-abc123", parsed.getResults().get(0).getContainerId());
+    }
+
+    @Test
+    public void testResponseFromActionResponseSame() {
+        MLMemoryRetentionDryRunResponse response = new MLMemoryRetentionDryRunResponse(List.of(sampleResult()), false);
+        assertEquals(response, MLMemoryRetentionDryRunResponse.fromActionResponse(response));
+    }
+
+    @Test
+    public void testXContentTypeParsableJson() throws IOException {
+        // Ensure the emitted document is well-formed JSON (parseable end to end).
+        String json = toJson(sampleResult());
+        Map<String, Object> parsed = XContentType.JSON
+            .xContent()
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE,
+                json
+            )
+            .map();
+        assertEquals("agent-customer-support-abc123", parsed.get("container_id"));
+        assertEquals(1480, ((Number) parsed.get("total_would_delete")).intValue());
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer;
+
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
+import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.ORPHAN_SWEEP_BASELINE_TIME_FIELD;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.get.GetRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.authuser.User;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.ml.common.memorycontainer.MLMemoryContainer;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunResponse;
+import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.ml.utils.RestActionUtils;
+import org.opensearch.ml.utils.TenantAwareHelper;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Transport action for the retention dry-run: loads the target container(s), enforces access control, then
+ * delegates the read-only "what would be deleted" computation to {@link MemoryRetentionJobProcessor}. Performs
+ * no deletions.
+ */
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TransportMemoryRetentionDryRunAction extends HandledTransportAction<ActionRequest, MLMemoryRetentionDryRunResponse> {
+
+    private static final int CONTAINER_PAGE_SIZE = 100;
+
+    final Client client;
+    final ClusterService clusterService;
+    final ThreadPool threadPool;
+    final NamedXContentRegistry xContentRegistry;
+    final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    final MemoryContainerHelper memoryContainerHelper;
+
+    @Inject
+    public TransportMemoryRetentionDryRunAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        NamedXContentRegistry xContentRegistry,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        MemoryContainerHelper memoryContainerHelper
+    ) {
+        super(MLMemoryRetentionDryRunAction.NAME, transportService, actionFilters, MLMemoryRetentionDryRunRequest::new);
+        this.client = client;
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.xContentRegistry = xContentRegistry;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.memoryContainerHelper = memoryContainerHelper;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLMemoryRetentionDryRunResponse> actionListener) {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            actionListener.onFailure(new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN));
+            return;
+        }
+
+        MLMemoryRetentionDryRunRequest dryRunRequest = MLMemoryRetentionDryRunRequest.fromActionRequest(request);
+        String tenantId = dryRunRequest.getTenantId();
+        if (!TenantAwareHelper.validateTenantId(mlFeatureEnabledSetting, tenantId, actionListener)) {
+            return;
+        }
+
+        User user = RestActionUtils.getUserContext(client);
+        MemoryRetentionJobProcessor processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+
+        if (dryRunRequest.isClusterWide()) {
+            executeClusterWide(processor, user, tenantId, actionListener);
+        } else {
+            executeSingle(processor, user, dryRunRequest.getMemoryContainerId(), tenantId, actionListener);
+        }
+    }
+
+    private void executeSingle(
+        MemoryRetentionJobProcessor processor,
+        User user,
+        String containerId,
+        String tenantId,
+        ActionListener<MLMemoryRetentionDryRunResponse> actionListener
+    ) {
+        GetRequest getRequest = new GetRequest(ML_MEMORY_CONTAINER_INDEX, containerId);
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLMemoryRetentionDryRunResponse> wrapped = ActionListener.runBefore(actionListener, context::restore);
+            client.get(getRequest, ActionListener.wrap(getResponse -> {
+                if (getResponse == null || !getResponse.isExists()) {
+                    wrapped
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "Failed to find memory container with the provided memory container id: " + containerId,
+                                RestStatus.NOT_FOUND
+                            )
+                        );
+                    return;
+                }
+                MLMemoryContainer container = parseContainer(getResponse.getSourceAsString());
+                if (!TenantAwareHelper.validateTenantResource(mlFeatureEnabledSetting, tenantId, container.getTenantId(), wrapped)) {
+                    return;
+                }
+                if (!memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
+                    wrapped
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "User doesn't have privilege to perform this operation on this memory container",
+                                RestStatus.FORBIDDEN
+                            )
+                        );
+                    return;
+                }
+                Long baseline = extractOrphanBaseline(getResponse.getSourceAsMap());
+                processor
+                    .dryRunContainer(
+                        container.getConfiguration(),
+                        containerId,
+                        baseline,
+                        ActionListener
+                            .wrap(
+                                result -> wrapped.onResponse(new MLMemoryRetentionDryRunResponse(List.of(result), false)),
+                                wrapped::onFailure
+                            )
+                    );
+            }, e -> {
+                if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
+                    wrapped.onFailure(new OpenSearchStatusException("Failed to find memory container index", RestStatus.NOT_FOUND));
+                } else {
+                    log.error("Failed to get memory container {} for retention dry-run", containerId, e);
+                    wrapped.onFailure(RestActionUtils.wrapAsStatusException(e));
+                }
+            }));
+        } catch (Exception e) {
+            log.error("Failed to run retention dry-run for container {}", containerId, e);
+            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void executeClusterWide(
+        MemoryRetentionJobProcessor processor,
+        User user,
+        String tenantId,
+        ActionListener<MLMemoryRetentionDryRunResponse> actionListener
+    ) {
+        List<MemoryRetentionDryRunResult> results = new ArrayList<>();
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            ActionListener<MLMemoryRetentionDryRunResponse> wrapped = ActionListener.runBefore(actionListener, context::restore);
+            searchContainerPage(processor, user, tenantId, null, results, wrapped);
+        } catch (Exception e) {
+            log.error("Failed to run cluster-wide retention dry-run", e);
+            actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void searchContainerPage(
+        MemoryRetentionJobProcessor processor,
+        User user,
+        String tenantId,
+        Object[] searchAfter,
+        List<MemoryRetentionDryRunResult> results,
+        ActionListener<MLMemoryRetentionDryRunResponse> listener
+    ) {
+        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .query(QueryBuilders.matchAllQuery())
+            .size(CONTAINER_PAGE_SIZE)
+            .sort("_id", SortOrder.ASC)
+            .fetchSource(true);
+        if (searchAfter != null) {
+            source.searchAfter(searchAfter);
+        }
+        request.source(source);
+
+        client.search(request, ActionListener.wrap(response -> {
+            SearchHit[] hits = response.getHits().getHits();
+            if (hits.length == 0) {
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+                return;
+            }
+            Object[] nextPageSort = hits.length == CONTAINER_PAGE_SIZE ? hits[hits.length - 1].getSortValues() : null;
+            processHitChain(processor, user, tenantId, hits, 0, nextPageSort, results, listener);
+        }, e -> {
+            if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
+                // No container index yet: nothing to evaluate, return an empty array rather than an error.
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+            } else {
+                log.error("Failed to search memory containers for cluster-wide retention dry-run", e);
+                listener.onFailure(RestActionUtils.wrapAsStatusException(e));
+            }
+        }));
+    }
+
+    private void processHitChain(
+        MemoryRetentionJobProcessor processor,
+        User user,
+        String tenantId,
+        SearchHit[] hits,
+        int index,
+        Object[] nextPageSort,
+        List<MemoryRetentionDryRunResult> results,
+        ActionListener<MLMemoryRetentionDryRunResponse> listener
+    ) {
+        if (index >= hits.length) {
+            if (nextPageSort != null) {
+                searchContainerPage(processor, user, tenantId, nextPageSort, results, listener);
+            } else {
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+            }
+            return;
+        }
+
+        SearchHit hit = hits[index];
+        String containerId = hit.getId();
+        final MLMemoryContainer container;
+        try {
+            container = parseContainer(hit.getSourceAsString());
+        } catch (Exception e) {
+            log.warn("Skipping container {} in retention dry-run: failed to parse", containerId, e);
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            return;
+        }
+
+        // Tenant + access filtering: silently skip containers the caller cannot see, mirroring the job's own
+        // per-container isolation. A mismatched tenant or denied access simply excludes the container.
+        boolean tenantOk = tenantId == null || container.getTenantId() == null || tenantId.equals(container.getTenantId());
+        if (!tenantOk || !memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            return;
+        }
+
+        Long baseline = extractOrphanBaseline(hit.getSourceAsMap());
+        processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
+            results.add(result);
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+        }, e -> {
+            log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+        }));
+    }
+
+    private MLMemoryContainer parseContainer(String sourceJson) throws java.io.IOException {
+        try (
+            XContentParser parser = jsonXContent
+                .createParser(xContentRegistry, org.opensearch.common.xcontent.LoggingDeprecationHandler.INSTANCE, sourceJson)
+        ) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            return MLMemoryContainer.parse(parser);
+        }
+    }
+
+    /**
+     * Reads the stored orphan-sweep baseline timestamp from a container source map so the dry-run can honor the
+     * same first-observation grace window the real orphan sweep applies. Returns {@code null} when not stamped.
+     */
+    private Long extractOrphanBaseline(Map<String, Object> source) {
+        if (source == null) {
+            return null;
+        }
+        Object value = source.get(ORPHAN_SWEEP_BASELINE_TIME_FIELD);
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
@@ -14,6 +14,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGE
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
@@ -65,6 +66,11 @@ import lombok.extern.log4j.Log4j2;
 public class TransportMemoryRetentionDryRunAction extends HandledTransportAction<ActionRequest, MLMemoryRetentionDryRunResponse> {
 
     private static final int CONTAINER_PAGE_SIZE = 100;
+    // Upper bound on containers evaluated in a single cluster-wide dry-run. Each evaluated container triggers a
+    // dozen-plus counting searches, so an unbounded scan over thousands of containers would balloon both the heap
+    // response and the number of unthrottled searches. When the cap is hit the response is flagged truncated with a
+    // warning rather than silently dropping the remaining containers.
+    static final int MAX_CONTAINERS_PER_DRY_RUN = 1000;
 
     final Client client;
     final ClusterService clusterService;
@@ -187,13 +193,31 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         // Mutable skipped-container counter threaded through the page/hit chain alongside 'results'. Incremented
         // whenever a container is dropped from the results (parse failure or evaluation failure).
         int[] skipped = new int[] { 0 };
+        // Set once the MAX_CONTAINERS_PER_DRY_RUN cap is hit while containers still remain, so the response can flag
+        // the truncation instead of silently dropping the unevaluated containers.
+        boolean[] truncated = new boolean[] { false };
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<MLMemoryRetentionDryRunResponse> wrapped = ActionListener.runBefore(actionListener, context::restore);
-            searchContainerPage(processor, user, tenantId, null, results, skipped, wrapped);
+            searchContainerPage(processor, user, tenantId, null, results, skipped, truncated, wrapped);
         } catch (Exception e) {
             log.error("Failed to run cluster-wide retention dry-run", e);
             actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
         }
+    }
+
+    /** Builds the terminal cluster-wide response, attaching a truncation warning when the container cap was hit. */
+    private void respondClusterWide(
+        List<MemoryRetentionDryRunResult> results,
+        int[] skipped,
+        boolean[] truncated,
+        ActionListener<MLMemoryRetentionDryRunResponse> listener
+    ) {
+        String warning = truncated[0]
+            ? "Cluster-wide retention dry-run evaluated the first "
+                + MAX_CONTAINERS_PER_DRY_RUN
+                + " memory containers; additional containers were not evaluated. Narrow the scope or run per-container dry-runs."
+            : null;
+        listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0], truncated[0], warning));
     }
 
     private void searchContainerPage(
@@ -203,6 +227,7 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         Object[] searchAfter,
         List<MemoryRetentionDryRunResult> results,
         int[] skipped,
+        boolean[] truncated,
         ActionListener<MLMemoryRetentionDryRunResponse> listener
     ) {
         SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
@@ -220,15 +245,17 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         client.search(request, ActionListener.wrap(response -> {
             SearchHit[] hits = response.getHits().getHits();
             if (hits.length == 0) {
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
+                respondClusterWide(results, skipped, truncated, listener);
                 return;
             }
             Object[] nextPageSort = hits.length == CONTAINER_PAGE_SIZE ? hits[hits.length - 1].getSortValues() : null;
-            processHitChain(processor, user, tenantId, hits, 0, nextPageSort, results, skipped, listener);
+            // Iterative drain over the page's hits (see drainPage): O(1) added stack depth per page even when the
+            // client completes synchronously, replacing the former per-container callback recursion.
+            drainPage(processor, user, tenantId, hits, new int[] { 0 }, nextPageSort, results, skipped, truncated, listener);
         }, e -> {
             if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
                 // No container index yet: nothing to evaluate, return an empty array rather than an error.
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
+                respondClusterWide(results, skipped, truncated, listener);
             } else {
                 log.error("Failed to search memory containers for cluster-wide retention dry-run", e);
                 listener.onFailure(RestActionUtils.wrapAsStatusException(e));
@@ -236,55 +263,100 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         }));
     }
 
-    private void processHitChain(
+    /**
+     * Iteratively drains one page of container hits. Each container's evaluation is asynchronous, but rather than
+     * recursing into the next container from inside the callback (which grows the stack to the container count under
+     * a synchronous/mocked client), a per-container {@link AtomicBoolean} handoff converts synchronous completions
+     * back into loop iterations: whichever of {the loop returning} / {the callback firing} arrives second continues
+     * the drain. Stack depth is therefore O(1) per page regardless of client behavior. Behavior is otherwise
+     * preserved: per-container evaluate -> collect result or increment skipped, tenant/access filtering (skips), and
+     * parse/eval skip counting. Paging stops once {@code results.size()} reaches {@link #MAX_CONTAINERS_PER_DRY_RUN},
+     * flagging the response truncated when containers still remain.
+     */
+    private void drainPage(
         MemoryRetentionJobProcessor processor,
         User user,
         String tenantId,
         SearchHit[] hits,
-        int index,
+        int[] index,
         Object[] nextPageSort,
         List<MemoryRetentionDryRunResult> results,
         int[] skipped,
+        boolean[] truncated,
         ActionListener<MLMemoryRetentionDryRunResponse> listener
     ) {
-        if (index >= hits.length) {
-            if (nextPageSort != null) {
-                searchContainerPage(processor, user, tenantId, nextPageSort, results, skipped, listener);
-            } else {
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
+        while (true) {
+            boolean capReached = results.size() >= MAX_CONTAINERS_PER_DRY_RUN;
+            if (index[0] >= hits.length) {
+                // Page exhausted. Fetch the next page only if the cap has not been reached; otherwise stop and, if
+                // more pages existed, flag truncation.
+                if (nextPageSort != null && !capReached) {
+                    searchContainerPage(processor, user, tenantId, nextPageSort, results, skipped, truncated, listener);
+                } else {
+                    if (nextPageSort != null) {
+                        truncated[0] = true;
+                    }
+                    respondClusterWide(results, skipped, truncated, listener);
+                }
+                return;
             }
-            return;
-        }
+            // There is at least one more hit in this page; if the cap is reached, containers genuinely remain.
+            if (capReached) {
+                truncated[0] = true;
+                respondClusterWide(results, skipped, truncated, listener);
+                return;
+            }
 
-        SearchHit hit = hits[index];
-        String containerId = hit.getId();
-        final MLMemoryContainer container;
-        try {
-            container = parseContainer(hit.getSourceAsString());
-        } catch (Exception e) {
-            log.warn("Skipping container {} in retention dry-run: failed to parse", containerId, e);
-            skipped[0]++;
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
-            return;
-        }
+            SearchHit hit = hits[index[0]];
+            String containerId = hit.getId();
+            final MLMemoryContainer container;
+            try {
+                container = parseContainer(hit.getSourceAsString());
+            } catch (Exception e) {
+                log.warn("Skipping container {} in retention dry-run: failed to parse", containerId, e);
+                skipped[0]++;
+                index[0]++;
+                continue;
+            }
 
-        // Tenant + access filtering: silently skip containers the caller cannot see, mirroring the job's own
-        // per-container isolation. A mismatched tenant or denied access simply excludes the container.
-        boolean tenantOk = tenantId == null || container.getTenantId() == null || tenantId.equals(container.getTenantId());
-        if (!tenantOk || !memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
-            return;
-        }
+            // Tenant + access filtering: silently skip containers the caller cannot see, mirroring the job's own
+            // per-container isolation. A mismatched tenant or denied access simply excludes the container. Matches
+            // the single-container path's TenantAwareHelper.validateTenantResource semantics: when multi-tenancy is
+            // off the tenant is irrelevant (allow); when it is on, require an exact match via Objects.equals so a
+            // null container tenant (pre-multi-tenancy stamp) only matches a null request tenant instead of leaking
+            // to every tenant.
+            boolean tenantOk = !mlFeatureEnabledSetting.isMultiTenancyEnabled() || Objects.equals(tenantId, container.getTenantId());
+            if (!tenantOk || !memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
+                index[0]++;
+                continue;
+            }
 
-        Long baseline = extractOrphanBaseline(hit.getSourceAsMap());
-        processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
-            results.add(result);
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
-        }, e -> {
-            log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
-            skipped[0]++;
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
-        }));
+            Long baseline = extractOrphanBaseline(hit.getSourceAsMap());
+            // handoff arbitrates the race between this loop yielding and the callback firing. The second arriver
+            // resumes the drain; whichever arrives first simply hands off. A synchronous callback (mocked client)
+            // arrives first, so the loop below observes handoff already set and continues iteratively (no recursion).
+            final java.util.concurrent.atomic.AtomicBoolean handoff = new java.util.concurrent.atomic.AtomicBoolean(false);
+            processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
+                results.add(result);
+                index[0]++;
+                if (!handoff.compareAndSet(false, true)) {
+                    // Loop already yielded (async completion): this callback is the second arriver, resume draining.
+                    drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
+                }
+            }, e -> {
+                log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
+                skipped[0]++;
+                index[0]++;
+                if (!handoff.compareAndSet(false, true)) {
+                    drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
+                }
+            }));
+            if (handoff.compareAndSet(false, true)) {
+                // Callback has not fired yet (async): yield; the callback will resume the drain when it arrives.
+                return;
+            }
+            // Callback already completed synchronously; continue iterating without adding a stack frame.
+        }
     }
 
     private MLMemoryContainer parseContainer(String sourceJson) throws java.io.IOException {

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
@@ -159,7 +159,7 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
                         baseline,
                         ActionListener
                             .wrap(
-                                result -> wrapped.onResponse(new MLMemoryRetentionDryRunResponse(List.of(result), false)),
+                                result -> wrapped.onResponse(new MLMemoryRetentionDryRunResponse(List.of(result), false, 0)),
                                 wrapped::onFailure
                             )
                     );
@@ -184,9 +184,12 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         ActionListener<MLMemoryRetentionDryRunResponse> actionListener
     ) {
         List<MemoryRetentionDryRunResult> results = new ArrayList<>();
+        // Mutable skipped-container counter threaded through the page/hit chain alongside 'results'. Incremented
+        // whenever a container is dropped from the results (parse failure or evaluation failure).
+        int[] skipped = new int[] { 0 };
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<MLMemoryRetentionDryRunResponse> wrapped = ActionListener.runBefore(actionListener, context::restore);
-            searchContainerPage(processor, user, tenantId, null, results, wrapped);
+            searchContainerPage(processor, user, tenantId, null, results, skipped, wrapped);
         } catch (Exception e) {
             log.error("Failed to run cluster-wide retention dry-run", e);
             actionListener.onFailure(new OpenSearchStatusException("Internal server error", RestStatus.INTERNAL_SERVER_ERROR));
@@ -199,6 +202,7 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         String tenantId,
         Object[] searchAfter,
         List<MemoryRetentionDryRunResult> results,
+        int[] skipped,
         ActionListener<MLMemoryRetentionDryRunResponse> listener
     ) {
         SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
@@ -216,15 +220,15 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         client.search(request, ActionListener.wrap(response -> {
             SearchHit[] hits = response.getHits().getHits();
             if (hits.length == 0) {
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
                 return;
             }
             Object[] nextPageSort = hits.length == CONTAINER_PAGE_SIZE ? hits[hits.length - 1].getSortValues() : null;
-            processHitChain(processor, user, tenantId, hits, 0, nextPageSort, results, listener);
+            processHitChain(processor, user, tenantId, hits, 0, nextPageSort, results, skipped, listener);
         }, e -> {
             if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
                 // No container index yet: nothing to evaluate, return an empty array rather than an error.
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
             } else {
                 log.error("Failed to search memory containers for cluster-wide retention dry-run", e);
                 listener.onFailure(RestActionUtils.wrapAsStatusException(e));
@@ -240,13 +244,14 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         int index,
         Object[] nextPageSort,
         List<MemoryRetentionDryRunResult> results,
+        int[] skipped,
         ActionListener<MLMemoryRetentionDryRunResponse> listener
     ) {
         if (index >= hits.length) {
             if (nextPageSort != null) {
-                searchContainerPage(processor, user, tenantId, nextPageSort, results, listener);
+                searchContainerPage(processor, user, tenantId, nextPageSort, results, skipped, listener);
             } else {
-                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true));
+                listener.onResponse(new MLMemoryRetentionDryRunResponse(results, true, skipped[0]));
             }
             return;
         }
@@ -258,7 +263,8 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
             container = parseContainer(hit.getSourceAsString());
         } catch (Exception e) {
             log.warn("Skipping container {} in retention dry-run: failed to parse", containerId, e);
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            skipped[0]++;
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
             return;
         }
 
@@ -266,17 +272,18 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
         // per-container isolation. A mismatched tenant or denied access simply excludes the container.
         boolean tenantOk = tenantId == null || container.getTenantId() == null || tenantId.equals(container.getTenantId());
         if (!tenantOk || !memoryContainerHelper.checkMemoryContainerAccess(user, container)) {
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
             return;
         }
 
         Long baseline = extractOrphanBaseline(hit.getSourceAsMap());
         processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
             results.add(result);
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
         }, e -> {
             log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
-            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, listener);
+            skipped[0]++;
+            processHitChain(processor, user, tenantId, hits, index + 1, nextPageSort, results, skipped, listener);
         }));
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -150,7 +150,14 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
                 && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                 && !this.startedMemoryRetentionJob) {
-                int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                // Read the effective interval, honoring OpenSearch precedence (transient > persistent > opensearch.yml
+                // > default). clusterService.getSettings() holds only node bootstrap settings (opensearch.yml / CLI),
+                // frozen at construction; state.getMetadata().settings() holds the persistent/transient values set via
+                // PUT _cluster/settings. Overlaying metadata on the node settings lets dynamic cluster settings win
+                // while still honoring an opensearch.yml value. Reading only one source would drop the other and make
+                // reconcile (which actively upserts on mismatch) revert an operator's chosen interval on restart.
+                Settings effectiveSettings = Settings.builder().put(clusterService.getSettings()).put(settings).build();
+                int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(effectiveSettings);
                 // CREATE (conflict-swallowing) seeds the job doc; safe to run on any node.
                 mlTaskManager.indexMemoryRetentionJob(intervalHours);
                 // Reconcile a settings.yml / restart value onto the already-existing (write-once) doc. This upserts

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -76,29 +76,32 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
 
     /**
      * Single-writer gate for memory-retention job writes that mutate the shared, fixed-id job document. Exactly one
-     * node (the elected cluster manager) should ever upsert/reconcile, and only when agentic memory is enabled and
-     * multi-tenancy is disabled (mirroring the startup scheduling path). The 3.1+ data-node check mirrors the startup
-     * loop's rolling-upgrade guard so a live setting change during a mixed-version upgrade does not create the new
-     * {@code .plugins-ml-jobs} index before the cluster is ready for it.
+     * node (the elected cluster manager) should ever upsert/reconcile, and only when agentic memory AND memory
+     * retention are enabled and multi-tenancy is disabled (mirroring the startup scheduling path exactly). The
+     * {@link #jobsIndexReadyForWrite()} check mirrors the startup loop's rolling-upgrade guard so a live setting
+     * change during a mixed-version upgrade does not create the new {@code .plugins-ml-jobs} index before the
+     * cluster is ready for it.
      */
     private boolean shouldManageMemoryRetentionJob() {
         return clusterService.state().nodes().isLocalNodeElectedClusterManager()
-            && hasDataNodeOnOrAfterV31()
+            && jobsIndexReadyForWrite()
             && mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+            && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
             && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings());
     }
 
     /**
-     * Whether the cluster contains at least one data node running 3.1 or later. The new {@code .plugins-ml-jobs} index
-     * and its jobs must not be written until this holds, to avoid issues during blue/green and rolling upgrades.
+     * Rolling-upgrade guard shared by the startup scheduling path and the live interval-change consumer. It is safe to
+     * write the {@code .plugins-ml-jobs} job document only when:
+     *   - the index already exists (writing a document to an existing index cannot strand a replica), or
+     *   - every node in the cluster is on at least this node's version, so a newly created index's replicas are
+     *     allocatable anywhere.
+     * While a rolling upgrade is in flight neither holds, so the write is deferred rather than creating the index
+     * with stranded replicas (which leaves the cluster yellow until enough nodes are upgraded).
      */
-    private boolean hasDataNodeOnOrAfterV31() {
-        for (DiscoveryNode node : clusterService.state().nodes()) {
-            if (node.isDataNode() && node.getVersion().onOrAfter(Version.V_3_1_0)) {
-                return true;
-            }
-        }
-        return false;
+    private boolean jobsIndexReadyForWrite() {
+        ClusterState state = clusterService.state();
+        return state.getMetadata().hasIndex(ML_JOBS_INDEX) || state.nodes().getMinNodeVersion().onOrAfter(Version.CURRENT);
     }
 
     @Override
@@ -152,8 +155,7 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
          * old node leaves, the resulting cluster state change re-runs this listener and the jobs are created then.
          */
         boolean jobsIndexExists = state.getMetadata().hasIndex(ML_JOBS_INDEX);
-        boolean noOlderNodes = state.nodes().getMinNodeVersion().onOrAfter(Version.CURRENT);
-        if (jobsIndexExists || noOlderNodes) {
+        if (jobsIndexReadyForWrite()) {
             if (mlFeatureEnabledSetting.isMetricCollectionEnabled()
                 && mlFeatureEnabledSetting.isStaticMetricCollectionEnabled()
                 && !jobsIndexExists

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -60,6 +60,44 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
         this.mlModelAutoReDeployer = mlModelAutoReDeployer;
         this.client = client;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+
+        // Apply live changes to the retention job interval (dynamic PUT _cluster/settings) by upserting the persisted
+        // job document. The version bump is observed by JobScheduler's JobSweeper, which reschedules with no restart.
+        // The consumer runs on every node, so gate the write on the elected cluster manager to avoid multi-node churn.
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS, newIntervalHours -> {
+                if (shouldManageMemoryRetentionJob()) {
+                    mlTaskManager.upsertMemoryRetentionJob(newIntervalHours);
+                }
+            });
+    }
+
+    /**
+     * Single-writer gate for memory-retention job writes that mutate the shared, fixed-id job document. Exactly one
+     * node (the elected cluster manager) should ever upsert/reconcile, and only when agentic memory is enabled and
+     * multi-tenancy is disabled (mirroring the startup scheduling path). The 3.1+ data-node check mirrors the startup
+     * loop's rolling-upgrade guard so a live setting change during a mixed-version upgrade does not create the new
+     * {@code .plugins-ml-jobs} index before the cluster is ready for it.
+     */
+    private boolean shouldManageMemoryRetentionJob() {
+        return clusterService.state().nodes().isLocalNodeElectedClusterManager()
+            && hasDataNodeOnOrAfterV31()
+            && mlFeatureEnabledSetting.isAgenticMemoryEnabled()
+            && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings());
+    }
+
+    /**
+     * Whether the cluster contains at least one data node running 3.1 or later. The new {@code .plugins-ml-jobs} index
+     * and its jobs must not be written until this holds, to avoid issues during blue/green and rolling upgrades.
+     */
+    private boolean hasDataNodeOnOrAfterV31() {
+        for (DiscoveryNode node : clusterService.state().nodes()) {
+            if (node.isDataNode() && node.getVersion().onOrAfter(Version.V_3_1_0)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -113,7 +151,14 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                 && !this.startedMemoryRetentionJob) {
                 int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(clusterService.getSettings());
+                // CREATE (conflict-swallowing) seeds the job doc; safe to run on any node.
                 mlTaskManager.indexMemoryRetentionJob(intervalHours);
+                // Reconcile a settings.yml / restart value onto the already-existing (write-once) doc. This upserts
+                // only when the persisted interval differs, so restart doesn't keep resetting the next-run anchor.
+                // Gate on the elected cluster manager so exactly one node ever writes the shared doc.
+                if (clusterService.state().nodes().isLocalNodeElectedClusterManager()) {
+                    mlTaskManager.reconcileMemoryRetentionJob(intervalHours);
+                }
                 this.startedMemoryRetentionJob = true;
             }
         }

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -20,6 +20,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.gateway.GatewayService;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
@@ -118,6 +119,22 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
         } else if (delta.added()) {
             List<String> addedNodesIds = delta.addedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toList());
             mlModelAutoReDeployer.buildAutoReloadArrangement(addedNodesIds, state.getNodes().getClusterManagerNodeId());
+        }
+
+        // The job-starting logic below reads and writes the .plugins-ml-jobs index. On a cluster restart this listener
+        // fires before the state is usable, so those reads/writes would fail and leave the one-shot
+        // startedMemoryRetentionJob / startedStatsJob flags stuck true with no retry until the next restart. Defer until
+        // the state is ready; clusterChanged fires again as startup progresses, with the flags still unset. Two gates:
+        // 1. cluster state not yet recovered -> a GET/index hits a "state not recovered" global block.
+        // 2. the jobs index exists (restart) but its primary shard is not yet allocated -> a GET hits
+        // NoShardAvailableActionException. (On a fresh cluster the index does not exist yet; the CREATE path seeds
+        // it, so we only wait when it already exists.)
+        if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+        if (state.getMetadata().hasIndex(ML_JOBS_INDEX)
+            && (state.routingTable().index(ML_JOBS_INDEX) == null || !state.routingTable().index(ML_JOBS_INDEX).allPrimaryShardsActive())) {
+            return;
         }
 
         /*

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -2018,13 +2018,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             EffectivePolicy effective = resolveEffectivePolicyForDryRun(config);
             String policySource = effective.source;
             int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
-            DryRunContext ctx = new DryRunContext(
-                containerId,
-                policySource,
-                System.currentTimeMillis(),
-                effective.policy,
-                ttlDays
-            );
+            DryRunContext ctx = new DryRunContext(containerId, policySource, System.currentTimeMillis(), effective.policy, ttlDays);
 
             if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
                 ctx.warnings.add("multi-tenancy is enabled; the scheduled retention job does not run, so nothing would be deleted");

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -380,11 +380,6 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
-        int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
-        int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
-        int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
-        int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
-
         Map<MemoryType, RetentionRule> defaultPolicy = computeDefaultRetentionPolicy();
         if (defaultPolicy == null) {
             log
@@ -398,14 +393,19 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         config.setRetentionPolicy(defaultPolicy);
 
+        // Derive the logged interval/counts from the computed policy rather than re-reading cluster settings
+        // (computeDefaultRetentionPolicy already read them). A null rule/value means that type has no default.
+        RetentionRule sessionsRule = defaultPolicy.get(MemoryType.SESSIONS);
+        RetentionRule longTermRule = defaultPolicy.get(MemoryType.LONG_TERM);
+        RetentionRule historyRule = defaultPolicy.get(MemoryType.HISTORY);
         log
             .info(
                 "[MemoryRetentionJob] container={} auto-applying default retention policy: sessions={}/{}d, long-term={}, history={}",
                 containerId,
-                sessionMaxCount,
-                sessionRetentionDays,
-                longTermMaxCount,
-                historyMaxCount
+                sessionsRule != null ? sessionsRule.getMaxCount() : null,
+                sessionsRule != null ? sessionsRule.getRetentionDays() : null,
+                longTermRule != null ? longTermRule.getMaxCount() : null,
+                historyRule != null ? historyRule.getMaxCount() : null
             );
 
         try {
@@ -1929,26 +1929,40 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     // =====================================================================================================
 
     /**
-     * Resolves the effective retention policy for a dry-run and reports its source. Mutates {@code config}'s
-     * retention policy to the effective one (backfilling cluster defaults in-memory for the "default" case,
-     * exactly as the real job would persist before evaluating). Returns one of the
-     * {@code MemoryRetentionDryRunResult.POLICY_SOURCE_*} constants.
+     * The effective retention policy for a dry-run: the policy map that would actually be evaluated plus the
+     * {@code MemoryRetentionDryRunResult.POLICY_SOURCE_*} constant describing where it came from. The dry-run is
+     * read-only, so this is computed locally and never written back onto the caller-owned {@link MemoryConfiguration}.
+     */
+    static final class EffectivePolicy {
+        final String source;
+        final Map<MemoryType, RetentionRule> policy;
+
+        EffectivePolicy(String source, Map<MemoryType, RetentionRule> policy) {
+            this.source = source;
+            this.policy = policy;
+        }
+    }
+
+    /**
+     * Resolves the effective retention policy for a dry-run and reports its source. Does NOT mutate {@code config}:
+     * for the "default" case it backfills cluster defaults into a LOCAL map (exactly the policy the real job would
+     * persist before evaluating) and returns it, leaving the caller's configuration untouched. The returned
+     * {@link EffectivePolicy#source} is one of the {@code MemoryRetentionDryRunResult.POLICY_SOURCE_*} constants.
      */
     @VisibleForTesting
-    String resolveEffectivePolicyForDryRun(MemoryConfiguration config) {
+    EffectivePolicy resolveEffectivePolicyForDryRun(MemoryConfiguration config) {
         Map<MemoryType, RetentionRule> stored = config.getRetentionPolicy();
         if (stored != null && !stored.isEmpty()) {
-            return MemoryRetentionDryRunResult.POLICY_SOURCE_STORED;
+            return new EffectivePolicy(MemoryRetentionDryRunResult.POLICY_SOURCE_STORED, stored);
         }
         if (config.isRetentionPolicyExplicitlyNull()) {
-            return MemoryRetentionDryRunResult.POLICY_SOURCE_NONE;
+            return new EffectivePolicy(MemoryRetentionDryRunResult.POLICY_SOURCE_NONE, stored);
         }
         Map<MemoryType, RetentionRule> defaults = computeDefaultRetentionPolicy();
         if (defaults == null) {
-            return MemoryRetentionDryRunResult.POLICY_SOURCE_NONE;
+            return new EffectivePolicy(MemoryRetentionDryRunResult.POLICY_SOURCE_NONE, stored);
         }
-        config.setRetentionPolicy(defaults);
-        return MemoryRetentionDryRunResult.POLICY_SOURCE_DEFAULT;
+        return new EffectivePolicy(MemoryRetentionDryRunResult.POLICY_SOURCE_DEFAULT, defaults);
     }
 
     /** Mutable accumulator threaded through the dry-run pass chain. */
@@ -2001,13 +2015,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         ActionListener<MemoryRetentionDryRunResult> listener
     ) {
         try {
-            String policySource = resolveEffectivePolicyForDryRun(config);
+            EffectivePolicy effective = resolveEffectivePolicyForDryRun(config);
+            String policySource = effective.source;
             int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
             DryRunContext ctx = new DryRunContext(
                 containerId,
                 policySource,
                 System.currentTimeMillis(),
-                config.getRetentionPolicy(),
+                effective.policy,
                 ttlDays
             );
 
@@ -2087,7 +2102,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private void dryRunSessions(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
         String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
-        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        Map<MemoryType, RetentionRule> policy = ctx.effectivePolicy;
         RetentionRule rule = policy == null ? null : policy.get(MemoryType.SESSIONS);
         if (sessionIndex == null || rule == null) {
             listener.onResponse(null);
@@ -2137,7 +2152,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private void dryRunLongTerm(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
         String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
-        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        Map<MemoryType, RetentionRule> policy = ctx.effectivePolicy;
         RetentionRule rule = policy == null ? null : policy.get(MemoryType.LONG_TERM);
         if (longTermIndex == null || rule == null) {
             listener.onResponse(null);
@@ -2179,7 +2194,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     private void dryRunHistory(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
         String historyIndex = config.getIndexName(MemoryType.HISTORY);
-        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        Map<MemoryType, RetentionRule> policy = ctx.effectivePolicy;
         RetentionRule rule = policy == null ? null : policy.get(MemoryType.HISTORY);
         // History supports max_count only; retention_days is rejected by validation.
         if (historyIndex == null || rule == null || rule.getMaxCount() == null) {
@@ -2269,7 +2284,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         ActionListener<Void> listener
     ) {
         String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
-        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        Map<MemoryType, RetentionRule> policy = ctx.effectivePolicy;
         boolean hasPolicy = policy != null && !policy.isEmpty();
         // Orphan sweep only runs for session-backed containers that have a retention policy, and only after the
         // sweep's first-observation grace window has elapsed (mirrors resolveOrphanSweepContainers + baseline gate).

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -2020,15 +2020,26 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
             DryRunContext ctx = new DryRunContext(containerId, policySource, System.currentTimeMillis(), effective.policy, ttlDays);
 
+            // Multi-tenancy hard-gates the scheduled job off - run() returns before any deletion when MT is
+            // enabled - so nothing would ever be deleted in this deployment mode. Skip the read-only passes and
+            // report an honest zero rather than scanning indices for counts the job can't act on.
+            // NOTE(PR-B): retention runs under multi-tenancy in PR-B; this becomes an isRemoteMetadataStore()
+            // gate there, but the skip-to-zero behavior is unchanged.
             if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
                 ctx.warnings.add("multi-tenancy is enabled; the scheduled retention job does not run, so nothing would be deleted");
+                listener.onResponse(buildDryRunResult(ctx));
+                return;
             }
+            // Retention is disabled cluster-wide, so run() would not execute and nothing would be deleted. Skip the
+            // read-only passes and report an honest zero - the whole feature stays gated behind this flag.
             if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
                 ctx.warnings
                     .add(
                         "retention is disabled cluster-wide (plugins.ml_commons.memory.retention_enabled=false);"
-                            + " the scheduled job will not run until it is re-enabled"
+                            + " the scheduled job will not run, so nothing would be deleted"
                     );
+                listener.onResponse(buildDryRunResult(ctx));
+                return;
             }
             if (MemoryRetentionDryRunResult.POLICY_SOURCE_NONE.equals(policySource)) {
                 ctx.warnings.add("container has no retention policy and no cluster defaults apply; nothing would be deleted");

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -64,6 +65,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
@@ -71,6 +73,7 @@ import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
@@ -341,7 +344,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      * never happen under a policy the user cannot see. Only settings explicitly configured by the
      * admin (value &gt; 0; the settings default to -1, an unset sentinel) contribute to the policy.
      */
-    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
+    /**
+     * Computes the cluster-default retention policy from admin settings, or {@code null} when no admin
+     * defaults are configured (all settings at the -1 unset sentinel). Only settings with a value &gt; 0
+     * contribute a rule. This is the single source of truth for the default policy, shared by the real
+     * backfill path ({@link #applyDefaultRetentionPolicy}) and the dry-run so the two can never diverge.
+     */
+    @VisibleForTesting
+    Map<MemoryType, RetentionRule> computeDefaultRetentionPolicy() {
         int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
         int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
         int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
@@ -349,13 +359,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
         boolean anyConfigured = sessionRetentionDays > 0 || sessionMaxCount > 0 || longTermMaxCount > 0 || historyMaxCount > 0;
         if (!anyConfigured) {
-            log
-                .debug(
-                    "Container [{}] has no retention policy and no admin default retention settings are configured; skipping",
-                    containerId
-                );
-            listener.onResponse(false);
-            return;
+            return null;
         }
 
         Map<MemoryType, RetentionRule> defaultPolicy = new EnumMap<>(MemoryType.class);
@@ -371,6 +375,25 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
         if (historyMaxCount > 0) {
             defaultPolicy.put(MemoryType.HISTORY, new RetentionRule(null, historyMaxCount));
+        }
+        return defaultPolicy;
+    }
+
+    private void applyDefaultRetentionPolicy(MemoryConfiguration config, String containerId, ActionListener<Boolean> listener) {
+        int sessionRetentionDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS);
+        int sessionMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT);
+        int longTermMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT);
+        int historyMaxCount = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT);
+
+        Map<MemoryType, RetentionRule> defaultPolicy = computeDefaultRetentionPolicy();
+        if (defaultPolicy == null) {
+            log
+                .debug(
+                    "Container [{}] has no retention policy and no admin default retention settings are configured; skipping",
+                    containerId
+                );
+            listener.onResponse(false);
+            return;
         }
 
         config.setRetentionPolicy(defaultPolicy);
@@ -1882,6 +1905,686 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             client.execute(DeleteByQueryAction.INSTANCE, dbq, ActionListener.wrap((BulkByScrollResponse response) -> {
                 listener.onResponse(response.getDeleted());
             }, listener::onFailure));
+        }
+    }
+
+    // =====================================================================================================
+    // DRY-RUN: preview exactly what the scheduled retention job WOULD delete, performing zero deletions.
+    //
+    // These methods reuse the same read-only identify/count/enumerate logic the real job uses to decide
+    // what to evict (identifyTimeBasedExpiredSessions, identifyCountBasedExpiredSessions, checkOrphanBatch,
+    // enumerate*SessionIds*, buildEpochAwareCutoffQuery, buildSessionIdMatchQuery, computeDefaultRetentionPolicy).
+    // No DeleteRequest / DeleteByQuery / bulk delete is ever issued from this path. Because the counting reuses
+    // the job's own predicates, the reported numbers track the job's behavior and cannot silently drift.
+    //
+    // Per-pass attribution mirrors each pass's real algorithm:
+    // - sessions: the job computes the UNION of the time-expired and count-expired id sets, then deletes it
+    // in one pass. We reuse both identify methods and attribute retention_days = |timeSet|,
+    // max_count = |countSet \ timeSet| (disjoint, sums to |union|).
+    // - long_term: the job deletes time-expired docs FIRST, then evicts by count on the REMAINDER. We compute
+    // the count-based excess against the post-time-deletion population analytically so time and
+    // count reasons stay disjoint, matching what the next run would delete.
+    // - history: count-only (retention_days is rejected by validation for history), so retention_days = 0.
+    // - working: cascade (sessions that expire), ttl (session-less containers only), and orphan sweep.
+    // =====================================================================================================
+
+    /**
+     * Resolves the effective retention policy for a dry-run and reports its source. Mutates {@code config}'s
+     * retention policy to the effective one (backfilling cluster defaults in-memory for the "default" case,
+     * exactly as the real job would persist before evaluating). Returns one of the
+     * {@code MemoryRetentionDryRunResult.POLICY_SOURCE_*} constants.
+     */
+    @VisibleForTesting
+    String resolveEffectivePolicyForDryRun(MemoryConfiguration config) {
+        Map<MemoryType, RetentionRule> stored = config.getRetentionPolicy();
+        if (stored != null && !stored.isEmpty()) {
+            return MemoryRetentionDryRunResult.POLICY_SOURCE_STORED;
+        }
+        if (config.isRetentionPolicyExplicitlyNull()) {
+            return MemoryRetentionDryRunResult.POLICY_SOURCE_NONE;
+        }
+        Map<MemoryType, RetentionRule> defaults = computeDefaultRetentionPolicy();
+        if (defaults == null) {
+            return MemoryRetentionDryRunResult.POLICY_SOURCE_NONE;
+        }
+        config.setRetentionPolicy(defaults);
+        return MemoryRetentionDryRunResult.POLICY_SOURCE_DEFAULT;
+    }
+
+    /** Mutable accumulator threaded through the dry-run pass chain. */
+    private static final class DryRunContext {
+        final String containerId;
+        final String policySource;
+        final long evaluatedAt;
+        final Map<MemoryType, RetentionRule> effectivePolicy;
+        final Integer workingMemoryTtlDays;
+        final List<String> warnings = new ArrayList<>();
+
+        MemoryRetentionDryRunResult.TypeDeletion sessions = zero();
+        MemoryRetentionDryRunResult.TypeDeletion longTerm = zero();
+        MemoryRetentionDryRunResult.TypeDeletion history = zero();
+        long cascade = 0;
+        long ttl = 0;
+        long orphan = 0;
+        long pinnedWouldSkip = 0;
+        Set<String> expiredSessionUnion = new HashSet<>();
+
+        DryRunContext(
+            String containerId,
+            String policySource,
+            long evaluatedAt,
+            Map<MemoryType, RetentionRule> effectivePolicy,
+            Integer workingMemoryTtlDays
+        ) {
+            this.containerId = containerId;
+            this.policySource = policySource;
+            this.evaluatedAt = evaluatedAt;
+            this.effectivePolicy = effectivePolicy;
+            this.workingMemoryTtlDays = workingMemoryTtlDays;
+        }
+
+        static MemoryRetentionDryRunResult.TypeDeletion zero() {
+            return new MemoryRetentionDryRunResult.TypeDeletion(0, new LinkedHashMap<>());
+        }
+    }
+
+    /**
+     * Entry point for a single-container dry-run. Resolves the effective policy, then evaluates every retention
+     * pass read-only and assembles a {@link MemoryRetentionDryRunResult}. {@code orphanBaselineMillis} is the
+     * container's stored orphan-sweep baseline (or {@code null} if never stamped), used to honor the same
+     * first-observation grace window the real orphan sweep applies.
+     */
+    public void dryRunContainer(
+        MemoryConfiguration config,
+        String containerId,
+        Long orphanBaselineMillis,
+        ActionListener<MemoryRetentionDryRunResult> listener
+    ) {
+        try {
+            String policySource = resolveEffectivePolicyForDryRun(config);
+            int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
+            DryRunContext ctx = new DryRunContext(
+                containerId,
+                policySource,
+                System.currentTimeMillis(),
+                config.getRetentionPolicy(),
+                ttlDays
+            );
+
+            if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
+                ctx.warnings.add("multi-tenancy is enabled; the scheduled retention job does not run, so nothing would be deleted");
+            }
+            if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
+                ctx.warnings
+                    .add(
+                        "retention is disabled cluster-wide (plugins.ml_commons.memory.retention_enabled=false);"
+                            + " the scheduled job will not run until it is re-enabled"
+                    );
+            }
+            if (MemoryRetentionDryRunResult.POLICY_SOURCE_NONE.equals(policySource)) {
+                ctx.warnings.add("container has no retention policy and no cluster defaults apply; nothing would be deleted");
+            }
+
+            // sessions -> long-term -> history -> working -> finalize
+            dryRunSessions(
+                config,
+                ctx,
+                ActionListener
+                    .wrap(
+                        v1 -> dryRunLongTerm(
+                            config,
+                            ctx,
+                            ActionListener
+                                .wrap(
+                                    v2 -> dryRunHistory(
+                                        config,
+                                        ctx,
+                                        ActionListener
+                                            .wrap(v3 -> dryRunWorking(config, ctx, orphanBaselineMillis, ActionListener.wrap(v4 -> {
+                                                listener.onResponse(buildDryRunResult(ctx));
+                                            }, listener::onFailure)), listener::onFailure)
+                                    ),
+                                    listener::onFailure
+                                )
+                        ),
+                        listener::onFailure
+                    )
+            );
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private MemoryRetentionDryRunResult buildDryRunResult(DryRunContext ctx) {
+        LinkedHashMap<String, Long> workingByReason = new LinkedHashMap<>();
+        workingByReason.put(MemoryRetentionDryRunResult.REASON_CASCADE, ctx.cascade);
+        workingByReason.put(MemoryRetentionDryRunResult.REASON_TTL, ctx.ttl);
+        workingByReason.put(MemoryRetentionDryRunResult.REASON_ORPHAN, ctx.orphan);
+        long workingTotal = ctx.cascade + ctx.ttl + ctx.orphan;
+        MemoryRetentionDryRunResult.TypeDeletion workingMemory = new MemoryRetentionDryRunResult.TypeDeletion(
+            workingTotal,
+            workingByReason
+        );
+
+        long total = ctx.sessions.getTotal() + ctx.longTerm.getTotal() + ctx.history.getTotal() + workingTotal;
+
+        return MemoryRetentionDryRunResult
+            .builder()
+            .containerId(ctx.containerId)
+            .evaluatedAt(ctx.evaluatedAt)
+            .policySource(ctx.policySource)
+            .effectivePolicy(ctx.effectivePolicy)
+            .workingMemoryTtlDays(ctx.workingMemoryTtlDays)
+            .sessions(ctx.sessions)
+            .longTerm(ctx.longTerm)
+            .history(ctx.history)
+            .workingMemory(workingMemory)
+            .totalWouldDelete(total)
+            .pinnedWouldSkip(ctx.pinnedWouldSkip)
+            .warnings(ctx.warnings)
+            .build();
+    }
+
+    private void dryRunSessions(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
+        String sessionIndex = config.getIndexName(MemoryType.SESSIONS);
+        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        RetentionRule rule = policy == null ? null : policy.get(MemoryType.SESSIONS);
+        if (sessionIndex == null || rule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        Set<String> timeSet = new HashSet<>();
+        ActionListener<Set<String>> afterCount = ActionListener.wrap(countSet -> {
+            // Attribute reasons disjointly: retention_days owns the time set; max_count owns only the
+            // count-expired ids NOT already covered by time expiry. Sum equals |union| (what the job deletes).
+            long timeCount = timeSet.size();
+            long countOnly = countSet.stream().filter(id -> !timeSet.contains(id)).count();
+            long unionTotal = timeCount + countOnly;
+
+            ctx.expiredSessionUnion = new HashSet<>(timeSet);
+            ctx.expiredSessionUnion.addAll(countSet);
+
+            LinkedHashMap<String, Long> byReason = new LinkedHashMap<>();
+            byReason.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, timeCount);
+            byReason.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, countOnly);
+            ctx.sessions = new MemoryRetentionDryRunResult.TypeDeletion(unionTotal, byReason);
+
+            if (rule.getMaxCount() != null && countSet.size() >= COUNT_BASED_ID_CAP) {
+                addCapWarning(ctx, "sessions");
+            }
+
+            // pinned_would_skip: pinned sessions that fall inside the time-expiry window (would be deleted but
+            // for the pin). Count-based eviction never considers pinned docs, so only the time window contributes.
+            addPinnedWarningsAndSkip(sessionIndex, ctx, "sessions", rule, LAST_UPDATED_TIME_FIELD, listener);
+        }, listener::onFailure);
+
+        ActionListener<Set<String>> afterTime = ActionListener.wrap(t -> {
+            timeSet.addAll(t);
+            if (rule.getMaxCount() != null) {
+                identifyCountBasedExpiredSessions(config, ctx.containerId, sessionIndex, rule.getMaxCount(), afterCount);
+            } else {
+                afterCount.onResponse(new HashSet<>());
+            }
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            identifyTimeBasedExpiredSessions(config, ctx.containerId, sessionIndex, rule.getRetentionDays(), afterTime);
+        } else {
+            afterTime.onResponse(new HashSet<>());
+        }
+    }
+
+    private void dryRunLongTerm(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
+        String longTermIndex = config.getIndexName(MemoryType.LONG_TERM);
+        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        RetentionRule rule = policy == null ? null : policy.get(MemoryType.LONG_TERM);
+        if (longTermIndex == null || rule == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        ActionListener<Long> afterTime = ActionListener.wrap(timeCount -> {
+            if (rule.getMaxCount() == null) {
+                setSequentialTypeDeletion(ctx, MemoryType.LONG_TERM, timeCount, 0L);
+                addPinnedWarningsAndSkip(longTermIndex, ctx, "long_term", rule, LAST_UPDATED_TIME_FIELD, listener);
+                return;
+            }
+            int maxCount = rule.getMaxCount();
+            // Count-based eviction runs on the population that REMAINS after time-based deletion.
+            countNonPinned(longTermIndex, ctx.containerId, ActionListener.wrap(totalNonPinned -> {
+                long remaining = Math.max(0, totalNonPinned - timeCount);
+                long rawExcess = Math.max(0, remaining - maxCount);
+                long cappedExcess = Math.min(rawExcess, COUNT_BASED_ID_CAP);
+                if (rawExcess > COUNT_BASED_ID_CAP) {
+                    addCapWarning(ctx, "long_term");
+                }
+                setSequentialTypeDeletion(ctx, MemoryType.LONG_TERM, timeCount, cappedExcess);
+                addPinnedWarningsAndSkip(longTermIndex, ctx, "long_term", rule, LAST_UPDATED_TIME_FIELD, listener);
+            }, listener::onFailure));
+        }, listener::onFailure);
+
+        if (rule.getRetentionDays() != null) {
+            long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(rule.getRetentionDays());
+            BoolQueryBuilder query = QueryBuilders
+                .boolQuery()
+                .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, ctx.containerId))
+                .must(buildEpochAwareCutoffQuery(LAST_UPDATED_TIME_FIELD, cutoffMillis))
+                .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+            countMatching(longTermIndex, query, afterTime);
+        } else {
+            afterTime.onResponse(0L);
+        }
+    }
+
+    private void dryRunHistory(MemoryConfiguration config, DryRunContext ctx, ActionListener<Void> listener) {
+        String historyIndex = config.getIndexName(MemoryType.HISTORY);
+        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        RetentionRule rule = policy == null ? null : policy.get(MemoryType.HISTORY);
+        // History supports max_count only; retention_days is rejected by validation.
+        if (historyIndex == null || rule == null || rule.getMaxCount() == null) {
+            listener.onResponse(null);
+            return;
+        }
+        int maxCount = rule.getMaxCount();
+        countNonPinned(historyIndex, ctx.containerId, ActionListener.wrap(totalNonPinned -> {
+            long rawExcess = Math.max(0, totalNonPinned - maxCount);
+            long cappedExcess = Math.min(rawExcess, COUNT_BASED_ID_CAP);
+            if (rawExcess > COUNT_BASED_ID_CAP) {
+                addCapWarning(ctx, "history");
+            }
+            LinkedHashMap<String, Long> byReason = new LinkedHashMap<>();
+            byReason.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, 0L);
+            byReason.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, cappedExcess);
+            ctx.history = new MemoryRetentionDryRunResult.TypeDeletion(cappedExcess, byReason);
+            // History count-based eviction excludes pinned; add the pinned>max_count warning (no time window,
+            // so no pinned_would_skip contribution).
+            checkPinnedExceedsMaxCountForDryRun(
+                historyIndex,
+                ctx,
+                "history",
+                maxCount,
+                ActionListener.wrap(v -> listener.onResponse(null), listener::onFailure)
+            );
+        }, listener::onFailure));
+    }
+
+    private void dryRunWorking(MemoryConfiguration config, DryRunContext ctx, Long orphanBaselineMillis, ActionListener<Void> listener) {
+        String workingIndex = config.getIndexName(MemoryType.WORKING);
+        if (workingIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+
+        // cascade: working memory belonging to sessions that would expire this run.
+        ActionListener<Void> afterCascade = ActionListener.wrap(v -> {
+            // ttl: only session-less (disable_session) containers age out working memory by TTL.
+            dryRunWorkingTtl(config, ctx, workingIndex, ActionListener.wrap(v2 -> {
+                // orphan: only runs for session-backed containers (mirrors resolveOrphanSweepContainers).
+                dryRunOrphanSweep(config, ctx, workingIndex, orphanBaselineMillis, listener);
+            }, listener::onFailure));
+        }, listener::onFailure);
+
+        if (ctx.expiredSessionUnion.isEmpty()) {
+            afterCascade.onResponse(null);
+        } else {
+            countWorkingForSessions(
+                workingIndex,
+                ctx.containerId,
+                new ArrayList<>(ctx.expiredSessionUnion),
+                ActionListener.wrap(cascadeCount -> {
+                    ctx.cascade = cascadeCount;
+                    afterCascade.onResponse(null);
+                }, listener::onFailure)
+            );
+        }
+    }
+
+    private void dryRunWorkingTtl(MemoryConfiguration config, DryRunContext ctx, String workingIndex, ActionListener<Void> listener) {
+        if (!config.isDisableSession()) {
+            listener.onResponse(null);
+            return;
+        }
+        int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
+        if (ttlDays <= 0) {
+            listener.onResponse(null);
+            return;
+        }
+        long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(ttlDays);
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, ctx.containerId))
+            .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis));
+        countMatching(workingIndex, query, ActionListener.wrap(c -> {
+            ctx.ttl = c;
+            listener.onResponse(null);
+        }, listener::onFailure));
+    }
+
+    private void dryRunOrphanSweep(
+        MemoryConfiguration config,
+        DryRunContext ctx,
+        String workingIndex,
+        Long orphanBaselineMillis,
+        ActionListener<Void> listener
+    ) {
+        String sessionsIndex = config.getIndexName(MemoryType.SESSIONS);
+        Map<MemoryType, RetentionRule> policy = config.getRetentionPolicy();
+        boolean hasPolicy = policy != null && !policy.isEmpty();
+        // Orphan sweep only runs for session-backed containers that have a retention policy, and only after the
+        // sweep's first-observation grace window has elapsed (mirrors resolveOrphanSweepContainers + baseline gate).
+        if (!hasPolicy || config.isDisableSession() || sessionsIndex == null) {
+            listener.onResponse(null);
+            return;
+        }
+        // Mirror the real sweep's index-existence safety check (processOrphanSweepContainerChain): if the working
+        // index doesn't exist there is nothing to sweep, and if the sessions index doesn't exist the sweep would
+        // classify ALL working memory as orphaned. Skip (report 0) in either case so the dry-run matches the job.
+        if (!clusterService.state().metadata().hasIndex(workingIndex) || !clusterService.state().metadata().hasIndex(sessionsIndex)) {
+            listener.onResponse(null);
+            return;
+        }
+        int orphanTtlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS);
+        long now = System.currentTimeMillis();
+        if (orphanBaselineMillis == null) {
+            ctx.warnings
+                .add(
+                    "orphan sweep has not yet observed this container (no baseline); orphaned working memory would be"
+                        + " deferred one orphan_ttl_days window before any deletion"
+                );
+            listener.onResponse(null);
+            return;
+        }
+        long normalizedBaseline = normalizeTimestamp(orphanBaselineMillis);
+        long graceUntil = normalizedBaseline + TimeUnit.DAYS.toMillis(orphanTtlDays);
+        if (now < graceUntil) {
+            ctx.warnings
+                .add(
+                    "orphan sweep is within its first-observation grace window for this container;"
+                        + " orphaned working memory would not be deleted until the window elapses"
+                );
+            listener.onResponse(null);
+            return;
+        }
+
+        long orphanCutoffMillis = now - TimeUnit.DAYS.toMillis(orphanTtlDays);
+
+        // Enumerate session ids referenced by working memory (top-level field + legacy namespace subpath),
+        // reusing the exact enumeration the real sweep uses.
+        Set<String> sessionIds = new HashSet<>();
+        String startKey = randomEnumerationStartKey();
+        enumerateSessionIdsFromWorkingMemory(
+            workingIndex,
+            ctx.containerId,
+            sessionIds,
+            Map.of(SESSION_ID_FIELD, startKey),
+            startKey,
+            false,
+            ActionListener
+                .wrap(
+                    aggIds -> enumerateLegacySessionIdsFromWorkingMemory(
+                        workingIndex,
+                        ctx.containerId,
+                        aggIds,
+                        new Object[] { startKey },
+                        startKey,
+                        false,
+                        ActionListener.wrap(collectedIds -> {
+                            ActionListener<Long> afterOrphanDocs = ActionListener.wrap(orphanDocs -> {
+                                // Plus session-less/empty-namespace working memory older than the cutoff.
+                                countEmptyNamespaceWorking(
+                                    ctx.containerId,
+                                    workingIndex,
+                                    orphanCutoffMillis,
+                                    ActionListener.wrap(emptyDocs -> {
+                                        ctx.orphan = orphanDocs + emptyDocs;
+                                        listener.onResponse(null);
+                                    }, listener::onFailure)
+                                );
+                            }, listener::onFailure);
+
+                            if (collectedIds.isEmpty()) {
+                                afterOrphanDocs.onResponse(0L);
+                            } else {
+                                List<List<String>> batches = partition(new ArrayList<>(collectedIds), ORPHAN_SESSION_BATCH_SIZE);
+                                Set<String> allOrphanIds = new HashSet<>();
+                                checkOrphanBatch(
+                                    ctx.containerId,
+                                    sessionsIndex,
+                                    batches,
+                                    0,
+                                    allOrphanIds,
+                                    ActionListener.wrap(orphanIds -> {
+                                        if (orphanIds.isEmpty()) {
+                                            afterOrphanDocs.onResponse(0L);
+                                        } else {
+                                            countWorkingForOrphanSessions(
+                                                ctx.containerId,
+                                                workingIndex,
+                                                new ArrayList<>(orphanIds),
+                                                orphanCutoffMillis,
+                                                afterOrphanDocs
+                                            );
+                                        }
+                                    }, listener::onFailure)
+                                );
+                            }
+                        }, listener::onFailure)
+                    ),
+                    listener::onFailure
+                )
+        );
+    }
+
+    // ---- dry-run count helpers (read-only) ----
+
+    private void setSequentialTypeDeletion(DryRunContext ctx, MemoryType type, long timeCount, long countExcess) {
+        LinkedHashMap<String, Long> byReason = new LinkedHashMap<>();
+        byReason.put(MemoryRetentionDryRunResult.REASON_RETENTION_DAYS, timeCount);
+        byReason.put(MemoryRetentionDryRunResult.REASON_MAX_COUNT, countExcess);
+        MemoryRetentionDryRunResult.TypeDeletion td = new MemoryRetentionDryRunResult.TypeDeletion(timeCount + countExcess, byReason);
+        if (type == MemoryType.LONG_TERM) {
+            ctx.longTerm = td;
+        } else if (type == MemoryType.HISTORY) {
+            ctx.history = td;
+        } else {
+            ctx.sessions = td;
+        }
+    }
+
+    private void addCapWarning(DryRunContext ctx, String type) {
+        ctx.warnings
+            .add(
+                "count-based eviction for "
+                    + type
+                    + " exceeds the per-run cap of "
+                    + COUNT_BASED_ID_CAP
+                    + "; the dry-run reports the single-run amount and the remainder would be removed over subsequent runs"
+            );
+    }
+
+    /**
+     * Adds the "pinned exceeds max_count" warning (when a max_count rule is set) and accumulates
+     * pinned_would_skip (pinned docs inside the time-expiry window, when a retention_days rule is set), then
+     * signals completion. Two independent read-only counts; both are best-effort in the sense that failures
+     * propagate via the listener.
+     */
+    private void addPinnedWarningsAndSkip(
+        String index,
+        DryRunContext ctx,
+        String type,
+        RetentionRule rule,
+        String timeField,
+        ActionListener<Void> listener
+    ) {
+        ActionListener<Void> afterPinnedExceed = ActionListener.wrap(v -> {
+            if (rule.getRetentionDays() != null) {
+                long cutoffMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(rule.getRetentionDays());
+                BoolQueryBuilder query = QueryBuilders
+                    .boolQuery()
+                    .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, ctx.containerId))
+                    .must(QueryBuilders.termQuery(PINNED_FIELD, true))
+                    .must(buildEpochAwareCutoffQuery(timeField, cutoffMillis));
+                countMatching(index, query, ActionListener.wrap(pinnedExpired -> {
+                    ctx.pinnedWouldSkip += pinnedExpired;
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            } else {
+                listener.onResponse(null);
+            }
+        }, listener::onFailure);
+
+        if (rule.getMaxCount() != null) {
+            checkPinnedExceedsMaxCountForDryRun(index, ctx, type, rule.getMaxCount(), afterPinnedExceed);
+        } else {
+            afterPinnedExceed.onResponse(null);
+        }
+    }
+
+    /**
+     * Read-only mirror of {@link #checkPinnedExceedsMaxCount}: adds a warning when pinned docs alone exceed
+     * max_count (the container will grow unbounded), then signals completion.
+     */
+    private void checkPinnedExceedsMaxCountForDryRun(
+        String index,
+        DryRunContext ctx,
+        String type,
+        int maxCount,
+        ActionListener<Void> listener
+    ) {
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, ctx.containerId))
+            .must(QueryBuilders.termQuery(PINNED_FIELD, true));
+        countMatching(index, query, ActionListener.wrap(pinnedCount -> {
+            if (pinnedCount > maxCount) {
+                ctx.warnings
+                    .add(
+                        "pinned count ("
+                            + pinnedCount
+                            + ") exceeds max_count ("
+                            + maxCount
+                            + ") for "
+                            + type
+                            + " — container will grow unbounded"
+                    );
+            }
+            listener.onResponse(null);
+        }, listener::onFailure));
+    }
+
+    private void countNonPinned(String index, String containerId, ActionListener<Long> listener) {
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.termQuery(PINNED_FIELD, true));
+        countMatching(index, query, listener);
+    }
+
+    private void countWorkingForSessions(String workingIndex, String containerId, List<String> sessionIds, ActionListener<Long> listener) {
+        List<List<String>> batches = partition(sessionIds, DELETE_BY_QUERY_BATCH_SIZE);
+        countWorkingForSessionsBatch(workingIndex, containerId, batches, 0, 0L, listener);
+    }
+
+    private void countWorkingForSessionsBatch(
+        String workingIndex,
+        String containerId,
+        List<List<String>> batches,
+        int batchIndex,
+        long total,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(total);
+            return;
+        }
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(buildSessionIdMatchQuery(batches.get(batchIndex)));
+        countMatching(
+            workingIndex,
+            query,
+            ActionListener
+                .wrap(
+                    c -> countWorkingForSessionsBatch(workingIndex, containerId, batches, batchIndex + 1, total + c, listener),
+                    listener::onFailure
+                )
+        );
+    }
+
+    private void countWorkingForOrphanSessions(
+        String containerId,
+        String workingIndex,
+        List<String> orphanSessionIds,
+        long orphanCutoffMillis,
+        ActionListener<Long> listener
+    ) {
+        List<List<String>> batches = partition(orphanSessionIds, DELETE_BY_QUERY_BATCH_SIZE);
+        countWorkingForOrphanBatch(containerId, workingIndex, batches, 0, orphanCutoffMillis, 0L, listener);
+    }
+
+    private void countWorkingForOrphanBatch(
+        String containerId,
+        String workingIndex,
+        List<List<String>> batches,
+        int batchIndex,
+        long orphanCutoffMillis,
+        long total,
+        ActionListener<Long> listener
+    ) {
+        if (batchIndex >= batches.size()) {
+            listener.onResponse(total);
+            return;
+        }
+        // Mirrors deleteOrphanBatch's query exactly (session-id match + epoch-aware created_time cutoff).
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .must(buildSessionIdMatchQuery(batches.get(batchIndex)))
+            .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, orphanCutoffMillis));
+        countMatching(
+            workingIndex,
+            query,
+            ActionListener
+                .wrap(
+                    c -> countWorkingForOrphanBatch(
+                        containerId,
+                        workingIndex,
+                        batches,
+                        batchIndex + 1,
+                        orphanCutoffMillis,
+                        total + c,
+                        listener
+                    ),
+                    listener::onFailure
+                )
+        );
+    }
+
+    private void countEmptyNamespaceWorking(String containerId, String workingIndex, long cutoffMillis, ActionListener<Long> listener) {
+        // Mirrors deleteEmptyNamespaceWorkingMemory's query exactly.
+        BoolQueryBuilder query = QueryBuilders
+            .boolQuery()
+            .must(QueryBuilders.termQuery(MEMORY_CONTAINER_ID_FIELD, containerId))
+            .mustNot(QueryBuilders.existsQuery(SESSION_ID_FIELD))
+            .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + SESSION_ID_FIELD))
+            .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + USER_ID_FIELD))
+            .mustNot(QueryBuilders.existsQuery(NAMESPACE_FIELD + "." + AGENT_ID_FIELD))
+            .must(buildEpochAwareCutoffQuery(CREATED_TIME_FIELD, cutoffMillis));
+        countMatching(workingIndex, query, listener);
+    }
+
+    private void countMatching(String index, QueryBuilder query, ActionListener<Long> listener) {
+        SearchRequest request = new SearchRequest(index);
+        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        request.source(new SearchSourceBuilder().query(query).size(0).trackTotalHits(true));
+        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+            client
+                .search(
+                    request,
+                    ActionListener.wrap(response -> listener.onResponse(response.getHits().getTotalHits().value()), listener::onFailure)
+                );
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -104,6 +104,7 @@ import org.opensearch.ml.action.mcpserver.TransportMcpToolsUpdateAction;
 import org.opensearch.ml.action.memorycontainer.TransportCreateMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.TransportDeleteMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.TransportGetMemoryContainerAction;
+import org.opensearch.ml.action.memorycontainer.TransportMemoryRetentionDryRunAction;
 import org.opensearch.ml.action.memorycontainer.TransportSearchMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.TransportUpdateMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction;
@@ -212,6 +213,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContaine
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerDeleteAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerGetAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerSearchAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLAddMemoriesAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoriesByQueryAction;
 import org.opensearch.ml.common.transport.memorycontainer.memory.MLDeleteMemoryAction;
@@ -359,6 +361,7 @@ import org.opensearch.ml.rest.RestMLGetToolAction;
 import org.opensearch.ml.rest.RestMLHybridSearchMemoriesAction;
 import org.opensearch.ml.rest.RestMLListContextManagementTemplatesAction;
 import org.opensearch.ml.rest.RestMLListToolsAction;
+import org.opensearch.ml.rest.RestMLMemoryRetentionDryRunAction;
 import org.opensearch.ml.rest.RestMLPredictionAction;
 import org.opensearch.ml.rest.RestMLPredictionStreamAction;
 import org.opensearch.ml.rest.RestMLProfileAction;
@@ -590,6 +593,7 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(MLCreateSessionAction.INSTANCE, TransportCreateSessionAction.class),
                 new ActionHandler<>(MLUpdateMemoryContainerAction.INSTANCE, TransportUpdateMemoryContainerAction.class),
                 new ActionHandler<>(MLMemoryContainerGetAction.INSTANCE, TransportGetMemoryContainerAction.class),
+                new ActionHandler<>(MLMemoryRetentionDryRunAction.INSTANCE, TransportMemoryRetentionDryRunAction.class),
                 new ActionHandler<>(MLMemoryContainerSearchAction.INSTANCE, TransportSearchMemoryContainerAction.class),
                 new ActionHandler<>(MLMemoryContainerDeleteAction.INSTANCE, TransportDeleteMemoryContainerAction.class),
                 new ActionHandler<>(MLAddMemoriesAction.INSTANCE, TransportAddMemoriesAction.class),
@@ -1080,6 +1084,9 @@ public class MachineLearningPlugin extends Plugin
             mlFeatureEnabledSetting
         );
         RestMLGetMemoryContainerAction restMLGetMemoryContainerAction = new RestMLGetMemoryContainerAction(mlFeatureEnabledSetting);
+        RestMLMemoryRetentionDryRunAction restMLMemoryRetentionDryRunAction = new RestMLMemoryRetentionDryRunAction(
+            mlFeatureEnabledSetting
+        );
         RestMLSearchMemoryContainerAction restMLSearchMemoryContainerAction = new RestMLSearchMemoryContainerAction(
             mlFeatureEnabledSetting
         );
@@ -1183,6 +1190,7 @@ public class MachineLearningPlugin extends Plugin
                 restMLCreateSessionAction,
                 restMLUpdateMemoryContainerAction,
                 restMLGetMemoryContainerAction,
+                restMLMemoryRetentionDryRunAction,
                 restMLSearchMemoryContainerAction,
                 restMLDeleteMemoryContainerAction,
                 restMLAddMemoriesAction,

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunAction.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableList;
  * REST handler for the retention dry-run. Two routes:
  * <ul>
  *   <li>POST {@code /_plugins/_ml/memory_containers/{memory_container_id}/_retention/_dry_run} — one container</li>
- *   <li>POST {@code /_plugins/_ml/memory/_retention/_dry_run} — all containers (cluster-wide array)</li>
+ *   <li>POST {@code /_plugins/_ml/memory_containers/_retention/_dry_run} — all containers (cluster-wide array)</li>
  * </ul>
  */
 public class RestMLMemoryRetentionDryRunAction extends BaseRestHandler {

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunAction.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.PARAMETER_MEMORY_CONTAINER_ID;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_DRY_RUN_ALL_PATH;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.RETENTION_DRY_RUN_PATH;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+import static org.opensearch.ml.utils.RestActionUtils.getParameterId;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * REST handler for the retention dry-run. Two routes:
+ * <ul>
+ *   <li>POST {@code /_plugins/_ml/memory_containers/{memory_container_id}/_retention/_dry_run} — one container</li>
+ *   <li>POST {@code /_plugins/_ml/memory/_retention/_dry_run} — all containers (cluster-wide array)</li>
+ * </ul>
+ */
+public class RestMLMemoryRetentionDryRunAction extends BaseRestHandler {
+    private static final String ML_MEMORY_RETENTION_DRY_RUN_ACTION = "ml_memory_retention_dry_run_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLMemoryRetentionDryRunAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    @Override
+    public String getName() {
+        return ML_MEMORY_RETENTION_DRY_RUN_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList
+            .of(new Route(RestRequest.Method.POST, RETENTION_DRY_RUN_PATH), new Route(RestRequest.Method.POST, RETENTION_DRY_RUN_ALL_PATH));
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            throw new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN);
+        }
+        MLMemoryRetentionDryRunRequest dryRunRequest = getRequest(request);
+        return channel -> client.execute(MLMemoryRetentionDryRunAction.INSTANCE, dryRunRequest, new RestToXContentListener<>(channel));
+    }
+
+    @VisibleForTesting
+    MLMemoryRetentionDryRunRequest getRequest(RestRequest request) throws IOException {
+        // memory_container_id is present only on the single-container route; null selects cluster-wide.
+        String memoryContainerId = request.hasParam(PARAMETER_MEMORY_CONTAINER_ID)
+            ? getParameterId(request, PARAMETER_MEMORY_CONTAINER_ID)
+            : null;
+        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
+        return new MLMemoryRetentionDryRunRequest(memoryContainerId, tenantId);
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
+++ b/plugin/src/main/java/org/opensearch/ml/task/MLTaskManager.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
@@ -43,10 +44,14 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.jobscheduler.spi.schedule.Schedule;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
@@ -58,6 +63,7 @@ import org.opensearch.ml.common.settings.SettingsChangeListener;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
 import org.opensearch.ml.jobs.MLJobParameter;
 import org.opensearch.ml.jobs.MLJobType;
+import org.opensearch.ml.utils.MLNodeUtils;
 import org.opensearch.remote.metadata.client.PutDataObjectRequest;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.UpdateDataObjectRequest;
@@ -603,6 +609,97 @@ public class MLTaskManager implements SettingsChangeListener {
             });
         } catch (IOException e) {
             log.error("Failed to index memory retention job", e);
+        }
+    }
+
+    /**
+     * Upsert the memory retention job document with a new interval.
+     *
+     * <p>Unlike {@link #indexMemoryRetentionJob(int)}, this method uses {@link DocWriteRequest.OpType#INDEX} (a
+     * version-bumping upsert) rather than {@code CREATE}, and is intentionally NOT guarded by the
+     * {@code memoryRetentionJobStarted} latch. Overwriting the existing document bumps its version, which the
+     * JobScheduler {@code JobSweeper.postIndex} hook observes and uses to deschedule the stale job and reschedule
+     * it from the fresh {@link IntervalSchedule} — with no cluster restart.
+     *
+     * <p>No {@code setIfSeqNo}/{@code setIfPrimaryTerm} guard is set on purpose: adding one would reintroduce
+     * version conflicts, defeating the point of the upsert. Callers MUST ensure only a single node (the elected
+     * cluster manager) invokes this to avoid multi-node reschedule churn, since the job document has a fixed id.
+     *
+     * @param intervalHours the new interval, in hours, for the retention job schedule
+     */
+    public void upsertMemoryRetentionJob(int intervalHours) {
+        try {
+            MLJobParameter jobParameter = new MLJobParameter(
+                MLJobType.MEMORY_RETENTION.name(),
+                new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+                120L,
+                null,
+                MLJobType.MEMORY_RETENTION,
+                true
+            );
+
+            IndexRequest indexRequest = new IndexRequest()
+                .index(CommonValue.ML_JOBS_INDEX)
+                .id(MLJobType.MEMORY_RETENTION.name())
+                .source(jobParameter.toXContent(JsonXContent.contentBuilder(), null))
+                .opType(DocWriteRequest.OpType.INDEX)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            indexJob(indexRequest, MLJobType.MEMORY_RETENTION, () -> {
+                this.memoryRetentionJobStarted = true;
+                log.info("Memory retention job upserted with interval {} hour(s)", intervalHours);
+            });
+        } catch (IOException e) {
+            log.error("Failed to upsert memory retention job", e);
+        }
+    }
+
+    /**
+     * Reconcile the persisted memory retention job schedule with the current interval setting, upserting only if
+     * they differ. Used on the startup path so a value supplied via {@code settings.yml} or a cluster restart is
+     * applied to the already-existing (write-once) job document.
+     *
+     * <p>Reconcile-<em>if-different</em> (rather than an unconditional upsert) matters: a fresh
+     * {@link IntervalSchedule} resets the next-run anchor to {@code now + interval}, so upserting on every startup
+     * could keep pushing the anchor forward and starve the job. If the document is absent, unparseable, or already
+     * carries the desired interval, this is a no-op. Callers MUST gate this on the elected cluster manager.
+     *
+     * @param intervalHours the desired interval, in hours, from the current setting value
+     */
+    public void reconcileMemoryRetentionJob(int intervalHours) {
+        GetRequest getRequest = new GetRequest(CommonValue.ML_JOBS_INDEX, MLJobType.MEMORY_RETENTION.name());
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.get(getRequest, ActionListener.runBefore(ActionListener.wrap(getResponse -> {
+                if (getResponse == null || !getResponse.isExists()) {
+                    // No persisted job yet; the CREATE path will seed it with the current interval.
+                    return;
+                }
+                try (
+                    XContentParser parser = MLNodeUtils
+                        .createXContentParserFromRegistry(NamedXContentRegistry.EMPTY, getResponse.getSourceAsBytesRef())
+                ) {
+                    MLJobParameter jobParameter = MLJobParameter.parse(parser);
+                    Schedule schedule = jobParameter.getSchedule();
+                    if (schedule instanceof IntervalSchedule) {
+                        IntervalSchedule intervalSchedule = (IntervalSchedule) schedule;
+                        if (intervalSchedule.getUnit() == ChronoUnit.HOURS && intervalSchedule.getInterval() == intervalHours) {
+                            log.debug("Memory retention job interval already {} hour(s); nothing to reconcile", intervalHours);
+                            return;
+                        }
+                    }
+                    log.info("Reconciling memory retention job interval to {} hour(s)", intervalHours);
+                    upsertMemoryRetentionJob(intervalHours);
+                } catch (Exception e) {
+                    log.error("Failed to parse persisted memory retention job during reconcile", e);
+                }
+            }, e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof IndexNotFoundException) {
+                    // Jobs index not created yet; the CREATE path will seed it.
+                    log.debug("ML jobs index not found during memory retention reconcile");
+                } else {
+                    log.error("Failed to get memory retention job during reconcile", e);
+                }
+            }), context::restore));
         }
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -22,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterState;
@@ -41,6 +44,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRu
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunResponse;
 import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.tasks.Task;
@@ -276,6 +280,80 @@ public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCas
         verify(listener).onResponse(responseCaptor.capture());
         assertTrue(responseCaptor.getValue().isClusterWide());
         assertEquals(0, responseCaptor.getValue().getResults().size());
+    }
+
+    public void testClusterWideTruncatesAtContainerCap() {
+        // Finding #2: the cluster-wide scan is bounded at MAX_CONTAINERS_PER_DRY_RUN. Simulate an effectively unbounded
+        // supply of containers by having every container-index page return a full page (CONTAINER_PAGE_SIZE hits) with
+        // distinct search-after sort values. The drain must stop after exactly the cap and flag the response truncated
+        // with a warning, rather than silently dropping the remaining containers or scanning them all.
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+        AtomicInteger nextContainerOffset = new AtomicInteger(0);
+        doAnswer(inv -> {
+            SearchRequest req = inv.getArgument(0);
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            if (req.indices().length > 0 && ".plugins-ml-am-memory-container".equals(req.indices()[0])) {
+                // Container listing page: always a full page so nextPageSort is non-null (more pages remain).
+                int base = nextContainerOffset.getAndAdd(100);
+                SearchHit[] pageHits = new SearchHit[100];
+                for (int i = 0; i < 100; i++) {
+                    String id = "container-" + (base + i);
+                    SearchHit hit = new SearchHit(base + i, id, null, null);
+                    hit.sourceRef(new org.opensearch.core.common.bytes.BytesArray(CONTAINER_JSON));
+                    hit.sortValues(new Object[] { id }, new DocValueFormat[] { DocValueFormat.RAW });
+                    pageHits[i] = hit;
+                }
+                SearchResponse resp = mock(SearchResponse.class);
+                SearchHits hits = new SearchHits(pageHits, new TotalHits(100000, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO), Float.NaN);
+                when(resp.getHits()).thenReturn(hits);
+                l.onResponse(resp);
+            } else {
+                // Per-container counting search: no matches.
+                l.onResponse(emptyCount());
+            }
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        MLMemoryRetentionDryRunResponse response = responseCaptor.getValue();
+        assertTrue(response.isClusterWide());
+        assertEquals(TransportMemoryRetentionDryRunAction.MAX_CONTAINERS_PER_DRY_RUN, response.getResults().size());
+        assertTrue("response should be flagged truncated when the container cap is hit", response.isTruncated());
+        assertNotNull("a truncation warning must be surfaced", response.getWarning());
+        assertTrue(response.getWarning().contains(String.valueOf(TransportMemoryRetentionDryRunAction.MAX_CONTAINERS_PER_DRY_RUN)));
+    }
+
+    public void testClusterWideMultiTenancyDoesNotLeakNullTenantContainer() {
+        // Finding #4: with multi-tenancy enabled, a container whose stored tenantId is null (pre-multi-tenancy stamp)
+        // must NOT be returned to a caller scoped to a concrete tenant. Objects.equals(tenantId, null) is false, so the
+        // container is silently skipped (not evaluated, not returned) — matching the single-container isolation path.
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+        // CONTAINER_JSON carries no tenant_id -> container.getTenantId() == null.
+        SearchHit hit = new SearchHit(0, "null-tenant-container", null, null);
+        hit.sourceRef(new org.opensearch.core.common.bytes.BytesArray(CONTAINER_JSON));
+        hit.sortValues(new Object[] { "null-tenant-container" }, new DocValueFormat[] { DocValueFormat.RAW });
+        SearchResponse page = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(page.getHits()).thenReturn(hits);
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(page);
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().tenantId("tenant-1").build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        MLMemoryRetentionDryRunResponse response = responseCaptor.getValue();
+        assertTrue(response.isClusterWide());
+        assertEquals("null-tenant container must not leak to a concrete-tenant caller", 0, response.getResults().size());
+        // Tenant filtering is a silent skip, not a parse/eval failure, so it is not counted in skipped_count.
+        assertEquals(0, response.getSkippedCount());
     }
 
     private SearchResponse emptyCount() {

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
@@ -240,6 +240,29 @@ public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCas
         assertEquals(0, responseCaptor.getValue().getResults().size());
     }
 
+    public void testClusterWideSkipsUnparseableContainerReportsSkippedCount() {
+        // A container whose stored source cannot be parsed is dropped from the results and counted in skipped_count.
+        SearchHit badHit = new SearchHit(0, "bad-container", null, null);
+        badHit.sourceRef(new org.opensearch.core.common.bytes.BytesArray("not-json"));
+        SearchResponse r = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[] { badHit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(r.getHits()).thenReturn(hits);
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(r);
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        MLMemoryRetentionDryRunResponse response = responseCaptor.getValue();
+        assertTrue(response.isClusterWide());
+        assertEquals(0, response.getResults().size());
+        assertEquals(1, response.getSkippedCount());
+    }
+
     public void testClusterWideIndexNotFoundReturnsEmptyArray() {
         doAnswer(inv -> {
             ActionListener<SearchResponse> l = inv.getArgument(1);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunResponse;
+import org.opensearch.ml.helper.MemoryContainerHelper;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCase {
+
+    private TransportMemoryRetentionDryRunAction action;
+
+    @Mock
+    private Client client;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private NamedXContentRegistry xContentRegistry;
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    @Mock
+    private MemoryContainerHelper memoryContainerHelper;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private Task task;
+    @Mock
+    private ActionListener<MLMemoryRetentionDryRunResponse> listener;
+
+    @Captor
+    private ArgumentCaptor<MLMemoryRetentionDryRunResponse> responseCaptor;
+    @Captor
+    private ArgumentCaptor<Exception> exceptionCaptor;
+
+    private ThreadContext threadContext;
+
+    private static final String CONTAINER_JSON = "{\"name\":\"c\",\"configuration\":{\"index_prefix\":\"p\",\"use_system_index\":false}}";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        MemoryRetentionJobProcessor.reset();
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        lenient().when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", -1)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        java.util.Set<Setting<?>> set = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        lenient().when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, set));
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        lenient().when(clusterService.state()).thenReturn(clusterState);
+        lenient().when(clusterState.metadata()).thenReturn(metadata);
+        lenient().when(metadata.hasIndex(anyString())).thenReturn(true);
+
+        action = new TransportMemoryRetentionDryRunAction(
+            transportService,
+            actionFilters,
+            client,
+            clusterService,
+            threadPool,
+            xContentRegistry,
+            mlFeatureEnabledSetting,
+            memoryContainerHelper
+        );
+    }
+
+    private GetResponse existsGet(boolean exists, String json) {
+        GetResponse gr = mock(GetResponse.class);
+        when(gr.isExists()).thenReturn(exists);
+        if (exists) {
+            lenient().when(gr.getSourceAsString()).thenReturn(json);
+            lenient().when(gr.getSourceAsMap()).thenReturn(java.util.Map.of());
+        }
+        return gr;
+    }
+
+    public void testForbiddenWhenAgenticMemoryDisabled() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testSingleContainerNotFound() {
+        doAnswer(inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onResponse(existsGet(false, null));
+            return null;
+        }).when(client).get(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("missing").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertEquals(RestStatus.NOT_FOUND, ((OpenSearchStatusException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testSingleContainerIndexNotFound() {
+        doAnswer(inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onFailure(new IndexNotFoundException("no index"));
+            return null;
+        }).when(client).get(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertEquals(RestStatus.NOT_FOUND, ((OpenSearchStatusException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testSingleContainerAccessDenied() {
+        doAnswer(inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onResponse(existsGet(true, CONTAINER_JSON));
+            return null;
+        }).when(client).get(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(false);
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testSingleContainerSuccessNoPolicy() {
+        // Container has no retention policy and no cluster defaults -> policy_source none, no deletes, single result.
+        doAnswer(inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onResponse(existsGet(true, CONTAINER_JSON));
+            return null;
+        }).when(client).get(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+        // Any incidental search returns empty counts.
+        lenient().doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(emptyCount());
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        MLMemoryRetentionDryRunResponse response = responseCaptor.getValue();
+        assertFalse(response.isClusterWide());
+        assertEquals(1, response.getResults().size());
+        assertEquals("none", response.getResults().get(0).getPolicySource());
+        assertEquals(0, response.getResults().get(0).getTotalWouldDelete());
+    }
+
+    public void testClusterWideEmpty() {
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(emptyHits());
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().isClusterWide());
+        assertEquals(0, responseCaptor.getValue().getResults().size());
+    }
+
+    public void testClusterWideIndexNotFoundReturnsEmptyArray() {
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onFailure(new IndexNotFoundException("no container index"));
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().isClusterWide());
+        assertEquals(0, responseCaptor.getValue().getResults().size());
+    }
+
+    private SearchResponse emptyCount() {
+        SearchResponse r = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(r.getHits()).thenReturn(hits);
+        return r;
+    }
+
+    private SearchResponse emptyHits() {
+        return emptyCount();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -320,17 +320,13 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testSettingsUpdateConsumer_UpsertsOnElectedClusterManager() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
-        DiscoveryNodes nodes = DiscoveryNodes
-            .builder()
-            .add(dataNode)
-            .localNodeId(dataNode.getId())
-            .clusterManagerNodeId(dataNode.getId())
-            .build();
-        when(clusterState.nodes()).thenReturn(nodes);
-        when(clusterService.state()).thenReturn(clusterState);
+        // All nodes on CURRENT (no mixed-version upgrade in flight), elected cluster manager, agentic memory AND
+        // retention enabled, multi-tenancy off -> the live interval change upserts the persisted job document.
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
+        setupElectedClusterManagerConsumerState(dataNode);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
 
         clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
 
@@ -349,7 +345,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testSettingsUpdateConsumer_SkippedWhenAgenticMemoryDisabled() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerConsumerState(dataNode);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
@@ -360,23 +356,41 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testSettingsUpdateConsumer_SkippedWhenMultiTenancyEnabled() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerConsumerState(dataNode);
         when(clusterService.getSettings()).thenReturn(Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
 
         clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
 
         verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
     }
 
-    public void testSettingsUpdateConsumer_SkippedWhenNoDataNodeOnOrAfterV31() {
-        // Elected cluster manager, agentic memory on, multi-tenancy off, but the only data node is pre-3.1 (mixed-version
-        // rolling upgrade). The consumer must not write the new jobs index yet, mirroring the startup path's guard.
-        DiscoveryNode preV31DataNode = createDataNode("dataNode", Version.V_3_0_0);
-        setupElectedClusterManagerConsumerState(preV31DataNode);
+    public void testSettingsUpdateConsumer_SkippedWhenMixedVersionCluster() {
+        // Elected cluster manager, agentic memory AND retention on, multi-tenancy off, jobs index absent, but a data
+        // node OLDER than current is present (mixed-version rolling upgrade). jobsIndexReadyForWrite() must be false so
+        // the consumer does not create the new jobs index yet, mirroring the startup path's rolling-upgrade guard.
+        // Retention is explicitly enabled so the version guard (not the feature flag) is what blocks the upsert.
+        DiscoveryNode olderDataNode = createDataNode("dataNode", Version.V_3_0_0);
+        setupElectedClusterManagerConsumerState(olderDataNode);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenRetentionDisabled() {
+        // Elected cluster manager, all nodes on CURRENT, agentic memory on, multi-tenancy off, but memory retention is
+        // DISABLED. The consumer gates on isMemoryRetentionEnabled() (matching the startup path), so no upsert fires.
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
+        setupElectedClusterManagerConsumerState(dataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(false);
 
         clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
 
@@ -387,6 +401,10 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).localNodeId(node.getId()).clusterManagerNodeId(node.getId()).build();
         when(clusterState.nodes()).thenReturn(nodes);
         when(clusterService.state()).thenReturn(clusterState);
+        // shouldManageMemoryRetentionJob() -> jobsIndexReadyForWrite() reads getMetadata().hasIndex(ML_JOBS_INDEX);
+        // stub it so the version-based rolling-upgrade guard governs (index absent -> falls back to minNodeVersion check).
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(false);
     }
 
     private DiscoveryNode createDataNode(String id, Version version) {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -227,6 +227,27 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager).reconcileMemoryRetentionJob(24);
     }
 
+    /**
+     * Regression guard: an interval set dynamically via {@code PUT _cluster/settings} lives in cluster-state metadata,
+     * NOT in the frozen node bootstrap settings returned by {@code clusterService.getSettings()}. The startup path must
+     * read the effective value (metadata overlaid on node settings); otherwise reconcile would upsert the default and
+     * silently revert the operator's persisted interval on restart.
+     */
+    public void testClusterChanged_MemoryRetentionReconcile_HonorsPersistedIntervalFromMetadata() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, true);
+        // Node bootstrap (opensearch.yml) has nothing; the interval was set via the cluster-settings API -> metadata.
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(metadata.settings()).thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(1);
+        verify(mlTaskManager).reconcileMemoryRetentionJob(1);
+    }
+
     public void testClusterChanged_MemoryRetentionReconcile_SkippedWhenNotElectedClusterManager() {
         DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
         setupElectedClusterManagerState(dataNode, false, false);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -210,7 +210,9 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testClusterChanged_MemoryRetentionJob_NonDefaultInterval() {
-        setupClusterState(false, createDataNode("dataNode", Version.V_3_1_0));
+        // Healthy, fully-upgraded cluster (all nodes on CURRENT): the startup deferral guard (noOlderNodes) is
+        // satisfied so the CREATE path runs. A pre-CURRENT node here would trip the rolling-upgrade deferral.
+        setupClusterState(false, createDataNode("dataNode", Version.CURRENT));
         when(clusterService.getSettings())
             .thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
 
@@ -223,7 +225,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testClusterChanged_MemoryRetentionReconcile_OnElectedClusterManager() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerState(dataNode, false, true);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
@@ -242,7 +244,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
      * silently revert the operator's persisted interval on restart.
      */
     public void testClusterChanged_MemoryRetentionReconcile_HonorsPersistedIntervalFromMetadata() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerState(dataNode, false, true);
         // Node bootstrap (opensearch.yml) has nothing; the interval was set via the cluster-settings API -> metadata.
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
@@ -257,7 +259,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     }
 
     public void testClusterChanged_MemoryRetentionReconcile_SkippedWhenNotElectedClusterManager() {
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerState(dataNode, false, false);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
@@ -305,7 +307,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
     public void testClusterChanged_ProceedsWhenJobsIndexAbsent() {
         // A fresh cluster has no jobs index yet; the shard-active gate must be skipped so the CREATE path can seed it.
-        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerState(dataNode, false, true);
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_JOBS_INDEX;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import org.junit.Before;
 import org.mockito.Mock;
@@ -26,7 +28,10 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.model.MLModelCacheHelper;
 import org.opensearch.ml.model.MLModelManager;
@@ -58,10 +63,16 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     private Metadata metadata;
 
     private MLCommonsClusterEventListener listener;
+    private ClusterSettings clusterSettings;
 
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        clusterSettings = new ClusterSettings(
+            Settings.EMPTY,
+            new HashSet<>(Arrays.asList(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         listener = new MLCommonsClusterEventListener(
             clusterService,
             mlModelManager,
@@ -190,6 +201,116 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
+    public void testClusterChanged_MemoryRetentionJob_NonDefaultInterval() {
+        setupClusterState(false, createDataNode("dataNode", Version.V_3_1_0));
+        when(clusterService.getSettings())
+            .thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(1);
+    }
+
+    public void testClusterChanged_MemoryRetentionReconcile_OnElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, true);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager).reconcileMemoryRetentionJob(24);
+    }
+
+    public void testClusterChanged_MemoryRetentionReconcile_SkippedWhenNotElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, false);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        // The conflict-safe CREATE still runs on any node, but reconcile (which upserts) must not.
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager, never()).reconcileMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_UpsertsOnElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNodes nodes = DiscoveryNodes
+            .builder()
+            .add(dataNode)
+            .localNodeId(dataNode.getId())
+            .clusterManagerNodeId(dataNode.getId())
+            .build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager).upsertMemoryRetentionJob(2);
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenNotElectedClusterManager() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(dataNode).localNodeId(dataNode.getId()).build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenAgenticMemoryDisabled() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerConsumerState(dataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenMultiTenancyEnabled() {
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerConsumerState(dataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    public void testSettingsUpdateConsumer_SkippedWhenNoDataNodeOnOrAfterV31() {
+        // Elected cluster manager, agentic memory on, multi-tenancy off, but the only data node is pre-3.1 (mixed-version
+        // rolling upgrade). The consumer must not write the new jobs index yet, mirroring the startup path's guard.
+        DiscoveryNode preV31DataNode = createDataNode("dataNode", Version.V_3_0_0);
+        setupElectedClusterManagerConsumerState(preV31DataNode);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
+
+        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+    }
+
+    private void setupElectedClusterManagerConsumerState(DiscoveryNode node) {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(node).localNodeId(node.getId()).clusterManagerNodeId(node.getId()).build();
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterService.state()).thenReturn(clusterState);
+    }
+
     private DiscoveryNode createDataNode(String id, Version version) {
         return new DiscoveryNode(
             id,
@@ -207,6 +328,23 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
             builder.add(node);
         }
         DiscoveryNodes nodes = builder.build();
+
+        when(event.state()).thenReturn(clusterState);
+        when(event.previousState()).thenReturn(clusterState);
+        when(event.nodesDelta()).thenReturn(mock(DiscoveryNodes.Delta.class));
+        when(clusterState.nodes()).thenReturn(nodes);
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
+        when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+    }
+
+    private void setupElectedClusterManagerState(DiscoveryNode node, boolean hasMLJobsIndex, boolean localNodeIsClusterManager) {
+        DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder().add(node).localNodeId(node.getId());
+        if (localNodeIsClusterManager) {
+            nodesBuilder.clusterManagerNodeId(node.getId());
+        }
+        DiscoveryNodes nodes = nodesBuilder.build();
 
         when(event.state()).thenReturn(clusterState);
         when(event.previousState()).thenReturn(clusterState);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -23,13 +23,17 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.IndexRoutingTable;
+import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.gateway.GatewayService;
 import org.opensearch.ml.autoredeploy.MLModelAutoReDeployer;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
@@ -61,6 +65,10 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     private ClusterState clusterState;
     @Mock
     private Metadata metadata;
+    @Mock
+    private ClusterBlocks clusterBlocks;
+    @Mock
+    private RoutingTable routingTable;
 
     private MLCommonsClusterEventListener listener;
     private ClusterSettings clusterSettings;
@@ -262,6 +270,53 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).reconcileMemoryRetentionJob(anyInt());
     }
 
+    public void testClusterChanged_SkippedWhenStateNotRecovered() {
+        // On a restart this listener fires before cluster state is recovered; the startup block must be deferred so a
+        // read/write against .plugins-ml-jobs does not hit the state-not-recovered block and wedge the one-shot flags.
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, true, true);
+        when(clusterBlocks.hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)).thenReturn(true);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMetricCollectionEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isStaticMetricCollectionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
+        verify(mlTaskManager, never()).reconcileMemoryRetentionJob(anyInt());
+        verify(mlTaskManager, never()).indexStatsCollectorJob(anyBoolean());
+    }
+
+    public void testClusterChanged_SkippedWhenJobsIndexPrimaryShardsNotActive() {
+        // State is recovered, but on a restart the existing jobs index's primary shard may not be allocated yet; a GET
+        // would throw NoShardAvailableActionException. The startup block must defer until the shards are active.
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, true, true);
+        IndexRoutingTable indexRoutingTable = mock(IndexRoutingTable.class);
+        when(routingTable.index(ML_JOBS_INDEX)).thenReturn(indexRoutingTable);
+        when(indexRoutingTable.allPrimaryShardsActive()).thenReturn(false);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
+        verify(mlTaskManager, never()).reconcileMemoryRetentionJob(anyInt());
+    }
+
+    public void testClusterChanged_ProceedsWhenJobsIndexAbsent() {
+        // A fresh cluster has no jobs index yet; the shard-active gate must be skipped so the CREATE path can seed it.
+        DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
+        setupElectedClusterManagerState(dataNode, false, true);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
+        verify(mlTaskManager).reconcileMemoryRetentionJob(24);
+    }
+
     public void testSettingsUpdateConsumer_UpsertsOnElectedClusterManager() {
         DiscoveryNode dataNode = createDataNode("dataNode", Version.V_3_1_0);
         DiscoveryNodes nodes = DiscoveryNodes
@@ -358,6 +413,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
         when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        setupStateReady();
     }
 
     private void setupElectedClusterManagerState(DiscoveryNode node, boolean hasMLJobsIndex, boolean localNodeIsClusterManager) {
@@ -375,5 +431,19 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
         when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        setupStateReady();
+    }
+
+    /**
+     * Default "state is ready" stubs for the startup guards: no state-not-recovered block, and (if the jobs index is
+     * present) its primary shards are active. Individual tests override these to exercise the deferral paths.
+     */
+    private void setupStateReady() {
+        when(clusterState.blocks()).thenReturn(clusterBlocks);
+        when(clusterBlocks.hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)).thenReturn(false);
+        when(clusterState.routingTable()).thenReturn(routingTable);
+        IndexRoutingTable indexRoutingTable = mock(IndexRoutingTable.class);
+        when(routingTable.index(ML_JOBS_INDEX)).thenReturn(indexRoutingTable);
+        when(indexRoutingTable.allPrimaryShardsActive()).thenReturn(true);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
@@ -609,7 +609,7 @@ public class MemoryRetentionDryRunTests {
     @Test
     public void testResolveEffectivePolicyStored() {
         MemoryConfiguration config = sessionConfig(7, 5);
-        assertEquals("stored", processor.resolveEffectivePolicyForDryRun(config));
+        assertEquals("stored", processor.resolveEffectivePolicyForDryRun(config).source);
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.jobs.processors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.index.reindex.DeleteByQueryAction;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
+import org.opensearch.ml.common.memorycontainer.MemoryStrategy;
+import org.opensearch.ml.common.memorycontainer.MemoryStrategyType;
+import org.opensearch.ml.common.memorycontainer.MemoryType;
+import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
+import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
+import org.opensearch.search.DocValueFormat;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
+
+/**
+ * Tests for the retention dry-run compute path on {@link MemoryRetentionJobProcessor}. Verifies the
+ * reported would_delete counts and by_reason attribution match the real job's identify/count logic, and
+ * that the dry-run performs ZERO deletions (no delete, bulk, delete-by-query, or update calls).
+ *
+ * Search responses are routed by target index and query shape so each pass's reuse of the real
+ * identify/count methods is exercised independently.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MemoryRetentionDryRunTests {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private Client client;
+
+    private ThreadContext threadContext;
+    private MemoryRetentionJobProcessor processor;
+
+    private static final String PREFIX = "test-memory-";
+
+    @Before
+    public void setUp() {
+        MemoryRetentionJobProcessor.reset();
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", -1)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        applySettings(settings);
+
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        lenient().when(clusterService.state()).thenReturn(clusterState);
+        lenient().when(clusterState.metadata()).thenReturn(metadata);
+        lenient().when(metadata.hasIndex(anyString())).thenReturn(true);
+
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    private void applySettings(Settings settings) {
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> set = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        lenient().when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, set));
+    }
+
+    // ---- config builders ----
+
+    private MemoryConfiguration sessionConfig(Integer retentionDays, Integer maxCount) {
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(retentionDays, maxCount));
+        return MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .useSystemIndex(false)
+            .disableSession(false)
+            .retentionPolicy(policy)
+            .build();
+    }
+
+    /** Config with LLM + strategies so long-term/history indices resolve. */
+    private MemoryConfiguration fullConfig(java.util.Map<MemoryType, RetentionRule> policy, boolean disableSession) {
+        MemoryStrategy strategy = MemoryStrategy
+            .builder()
+            .id("s1")
+            .type(MemoryStrategyType.SEMANTIC)
+            .namespace(List.of("user_id"))
+            .enabled(true)
+            .build();
+        return MemoryConfiguration
+            .builder()
+            .indexPrefix("test")
+            .useSystemIndex(false)
+            .disableSession(disableSession)
+            .llmId("llm-1")
+            .embeddingModelType(FunctionName.TEXT_EMBEDDING)
+            .embeddingModelId("emb-1")
+            .dimension(768)
+            .strategies(List.of(strategy))
+            .retentionPolicy(policy)
+            .build();
+    }
+
+    // ---- response helpers ----
+
+    private SearchResponse countResp(long total) {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(total, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(response.getHits()).thenReturn(hits);
+        return response;
+    }
+
+    private SearchResponse hitsResp(SearchHit[] hits) {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), Float.NaN);
+        when(response.getHits()).thenReturn(searchHits);
+        return response;
+    }
+
+    private SearchHit tsHit(String id, long lastUpdated) {
+        SearchHit hit = new SearchHit(id.hashCode(), id, null, null);
+        hit.sourceRef(new BytesArray("{\"last_updated_time\":" + lastUpdated + "}"));
+        return hit;
+    }
+
+    private SearchHit idHit(String id, long timeSort) {
+        SearchHit hit = new SearchHit(id.hashCode(), id, null, null);
+        hit.sortValues(new Object[] { timeSort, id }, new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW });
+        return hit;
+    }
+
+    private boolean isCount(SearchRequest r) {
+        return r.source().size() == 0;
+    }
+
+    private boolean isFetchSourceDisabled(SearchRequest r) {
+        return r.source().fetchSource() != null && !r.source().fetchSource().fetchSource();
+    }
+
+    private String q(SearchRequest r) {
+        return r.source().query() == null ? "" : r.source().query().toString();
+    }
+
+    private void assertNoDeletes() {
+        verify(client, never()).execute(isA(DeleteByQueryAction.class), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+        verify(client, never()).bulk(any(BulkRequest.class), isA(ActionListener.class));
+        verify(client, never()).delete(any(DeleteRequest.class), isA(ActionListener.class));
+        verify(client, never()).update(any(UpdateRequest.class), isA(ActionListener.class));
+    }
+
+    private MemoryRetentionDryRunResult run(MemoryConfiguration config, Long baseline) {
+        AtomicReference<MemoryRetentionDryRunResult> ref = new AtomicReference<>();
+        AtomicReference<Exception> err = new AtomicReference<>();
+        processor.dryRunContainer(config, "container-1", baseline, ActionListener.wrap(ref::set, err::set));
+        if (err.get() != null) {
+            fail("dryRunContainer failed: " + err.get());
+        }
+        assertNotNull("dry-run should complete synchronously with mocked client", ref.get());
+        return ref.get();
+    }
+
+    // =========================================================================================
+
+    @Test
+    public void testSessionsUnionTimeAndCount() {
+        long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+        MemoryConfiguration config = sessionConfig(7, 5);
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+
+            if (idx.endsWith("sessions")) {
+                if (!isCount(req)) {
+                    if (isFetchSourceDisabled(req)) {
+                        // collectOldestDocIds: countSet = {s2,s3,s4}; excess requested = 3
+                        listener.onResponse(hitsResp(new SearchHit[] { idHit("s2", 1), idHit("s3", 2), idHit("s4", 3) }));
+                    } else {
+                        // identifyTimeBasedExpiredSessions: timeSet = {s1,s2,s3}
+                        listener.onResponse(hitsResp(new SearchHit[] { tsHit("s1", old), tsHit("s2", old), tsHit("s3", old) }));
+                    }
+                } else if (query.contains("must_not")) {
+                    // count non-pinned sessions -> total 8, excess = 3
+                    listener.onResponse(countResp(8));
+                } else {
+                    // pinned count (checkPinnedExceedsMaxCount) or pinned-expiry count -> 0
+                    listener.onResponse(countResp(0));
+                }
+            } else if (idx.endsWith("working")) {
+                // cascade count for the expired session union
+                listener.onResponse(countResp(10));
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // baseline null -> orphan sweep skipped with a warning
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        assertEquals("stored", result.getPolicySource());
+        // union {s1,s2,s3,s4} = 4; retention_days owns {s1,s2,s3}=3; max_count owns only {s4}=1
+        assertEquals(4, result.getSessions().getTotal());
+        assertEquals(Long.valueOf(3L), result.getSessions().getByReason().get("retention_days"));
+        assertEquals(Long.valueOf(1L), result.getSessions().getByReason().get("max_count"));
+        // cascade working = 10, ttl 0 (session enabled), orphan 0 (baseline null)
+        assertEquals(10, result.getWorkingMemory().getTotal());
+        assertEquals(Long.valueOf(10L), result.getWorkingMemory().getByReason().get("cascade"));
+        assertEquals(Long.valueOf(0L), result.getWorkingMemory().getByReason().get("ttl"));
+        assertEquals(Long.valueOf(0L), result.getWorkingMemory().getByReason().get("orphan"));
+        // total = sessions 4 + working 10
+        assertEquals(14, result.getTotalWouldDelete());
+        assertEquals(0, result.getPinnedWouldSkip());
+        // orphan-baseline warning present
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("orphan sweep has not yet observed")));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testSessionsTimeOnlyWithPinnedSkip() {
+        long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+        MemoryConfiguration config = sessionConfig(7, null); // time-based only
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+            if (idx.endsWith("sessions")) {
+                if (!isCount(req)) {
+                    // time-based fetch: 2 expired
+                    listener.onResponse(hitsResp(new SearchHit[] { tsHit("s1", old), tsHit("s2", old) }));
+                } else if (query.contains("pinned") && query.contains("range")) {
+                    // pinned docs inside the time-expiry window -> pinned_would_skip
+                    listener.onResponse(countResp(3));
+                } else {
+                    listener.onResponse(countResp(0));
+                }
+            } else if (idx.endsWith("working")) {
+                listener.onResponse(countResp(4));
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        assertEquals(2, result.getSessions().getTotal());
+        assertEquals(Long.valueOf(2L), result.getSessions().getByReason().get("retention_days"));
+        assertEquals(Long.valueOf(0L), result.getSessions().getByReason().get("max_count"));
+        assertEquals(3, result.getPinnedWouldSkip());
+        assertEquals(4, result.getWorkingMemory().getByReason().get("cascade").longValue());
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testLongTermSequentialTimeThenCount() {
+        long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(200);
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.LONG_TERM, new RetentionRule(180, 100)); // days + max_count
+        MemoryConfiguration config = fullConfig(policy, false);
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+            if (idx.endsWith("long-term")) {
+                if (query.contains("range")) {
+                    // time-expired non-pinned count (only this query has an epoch-aware range clause)
+                    listener.onResponse(countResp(20));
+                } else if (query.contains("must_not")) {
+                    // total non-pinned count
+                    listener.onResponse(countResp(160));
+                } else {
+                    // checkPinnedExceedsMaxCount pinned count (pinned as must, no must_not, no range)
+                    listener.onResponse(countResp(0));
+                }
+            } else {
+                // sessions/history absent-or-empty, working cascade 0 (no expired sessions)
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        // time=20; remaining=160-20=140; count excess = 140-100 = 40; total=60
+        assertEquals("stored", result.getPolicySource());
+        assertEquals(60, result.getLongTerm().getTotal());
+        assertEquals(Long.valueOf(20L), result.getLongTerm().getByReason().get("retention_days"));
+        assertEquals(Long.valueOf(40L), result.getLongTerm().getByReason().get("max_count"));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testHistoryCountOnly() {
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 5000));
+        MemoryConfiguration config = fullConfig(policy, false);
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+            if (idx.endsWith("history")) {
+                if (query.contains("must_not")) {
+                    // total non-pinned history -> 5008, excess 8
+                    listener.onResponse(countResp(5008));
+                } else {
+                    // pinned count -> 0
+                    listener.onResponse(countResp(0));
+                }
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        assertEquals(8, result.getHistory().getTotal());
+        assertEquals(Long.valueOf(0L), result.getHistory().getByReason().get("retention_days"));
+        assertEquals(Long.valueOf(8L), result.getHistory().getByReason().get("max_count"));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testHistoryPinnedExceedsMaxCountWarning() {
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 500));
+        MemoryConfiguration config = fullConfig(policy, false);
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+            if (idx.endsWith("history")) {
+                if (query.contains("must_not")) {
+                    listener.onResponse(countResp(300)); // under max_count -> no count eviction
+                } else {
+                    listener.onResponse(countResp(600)); // pinned 600 > max_count 500 -> warning
+                }
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        assertEquals(0, result.getHistory().getTotal());
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("pinned count (600) exceeds max_count (500) for history")));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testWorkingTtlForSessionlessContainer() {
+        long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.HISTORY, new RetentionRule(null, 5000));
+        MemoryConfiguration config = fullConfig(policy, true); // disableSession -> TTL path active, sessions index null
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            String query = q(req);
+            if (idx.endsWith("working")) {
+                // TTL count (created_time cutoff, epoch-aware)
+                listener.onResponse(countResp(34));
+            } else if (idx.endsWith("history")) {
+                listener.onResponse(query.contains("must_not") ? countResp(5000) : countResp(0));
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+
+        assertEquals(34, result.getWorkingMemory().getByReason().get("ttl").longValue());
+        assertEquals(0, result.getWorkingMemory().getByReason().get("cascade").longValue());
+        // orphan sweep does not run for session-less containers
+        assertEquals(0, result.getWorkingMemory().getByReason().get("orphan").longValue());
+        assertEquals(34, result.getWorkingMemory().getTotal());
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testPolicySourceDefaultBackfill() {
+        // No stored policy, but admin defaults configured -> policy_source = default
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", 30)
+            .put("plugins.ml_commons.memory.default_session_max_count", 500)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        applySettings(settings);
+
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").useSystemIndex(false).disableSession(false).build(); // no
+                                                                                                                                            // retention
+                                                                                                                                            // policy
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            if (idx.endsWith("sessions")) {
+                if (!isCount(req)) {
+                    listener.onResponse(hitsResp(new SearchHit[0])); // no time-expired
+                } else {
+                    listener.onResponse(countResp(0)); // non-pinned under max_count, pinned 0
+                }
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+        assertEquals("default", result.getPolicySource());
+        assertNotNull(result.getEffectivePolicy());
+        assertEquals(Integer.valueOf(30), result.getEffectivePolicy().get(MemoryType.SESSIONS).getRetentionDays());
+        assertEquals(Integer.valueOf(500), result.getEffectivePolicy().get(MemoryType.SESSIONS).getMaxCount());
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testPolicySourceNoneWhenNoPolicyAndNoDefaults() {
+        MemoryConfiguration config = MemoryConfiguration.builder().indexPrefix("test").useSystemIndex(false).disableSession(false).build();
+
+        // No searches should be strictly required, but return empty for any that occur.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(countResp(0));
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+        assertEquals("none", result.getPolicySource());
+        assertEquals(0, result.getTotalWouldDelete());
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("no retention policy and no cluster defaults")));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testRetentionDisabledAndMultiTenancyWarnings() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", true)
+            .put("plugins.ml_commons.memory.retention_enabled", false)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .put("plugins.ml_commons.memory.default_session_retention_days", -1)
+            .put("plugins.ml_commons.memory.default_session_max_count", -1)
+            .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
+            .put("plugins.ml_commons.memory.default_history_max_count", -1)
+            .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
+            .build();
+        applySettings(settings);
+
+        MemoryConfiguration config = sessionConfig(7, null);
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            if (idx.endsWith("sessions") && req.source().size() > 0) {
+                listener.onResponse(hitsResp(new SearchHit[0]));
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, null);
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("multi-tenancy is enabled")));
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("retention is disabled cluster-wide")));
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testOrphanSweepSkippedWhenSessionsIndexMissing() {
+        // Regression: when the working index exists but the sessions index does not, the real orphan sweep skips
+        // (else it would classify ALL working memory as orphaned). The dry-run must report orphan=0 too.
+        java.util.Map<MemoryType, RetentionRule> policy = new java.util.EnumMap<>(MemoryType.class);
+        policy.put(MemoryType.SESSIONS, new RetentionRule(7, null));
+        MemoryConfiguration config = sessionConfig(7, null);
+
+        // sessions index does NOT exist; working index does
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        lenient().when(metadata.hasIndex(anyString())).thenAnswer(inv -> {
+            String name = inv.getArgument(0);
+            return !name.endsWith("sessions");
+        });
+
+        long veryOldBaseline = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(365);
+
+        doAnswer(invocation -> {
+            SearchRequest req = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            String idx = req.indices()[0];
+            if (idx.endsWith("sessions") && req.source().size() > 0) {
+                listener.onResponse(hitsResp(new SearchHit[0])); // no time-expired sessions
+            } else if (idx.endsWith("working")) {
+                // If the guard were missing, orphan enumeration would run and count these. It must NOT.
+                listener.onResponse(countResp(9999));
+            } else {
+                listener.onResponse(countResp(0));
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        MemoryRetentionDryRunResult result = run(config, veryOldBaseline);
+        assertEquals(
+            "orphan sweep must be skipped when sessions index is missing",
+            0,
+            result.getWorkingMemory().getByReason().get("orphan").longValue()
+        );
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testResolveEffectivePolicyStored() {
+        MemoryConfiguration config = sessionConfig(7, 5);
+        assertEquals("stored", processor.resolveEffectivePolicyForDryRun(config));
+    }
+
+    @Test
+    public void testComputeDefaultRetentionPolicyNullWhenUnset() {
+        // default settings are all -1 in setUp -> null
+        assertEquals(null, processor.computeDefaultRetentionPolicy());
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -527,38 +528,79 @@ public class MemoryRetentionDryRunTests {
         assertNoDeletes();
     }
 
-    @Test
-    public void testRetentionDisabledAndMultiTenancyWarnings() {
-        Settings settings = Settings
+    private Settings.Builder gateSettings(boolean multiTenancy, boolean retentionEnabled) {
+        return Settings
             .builder()
-            .put("plugins.ml_commons.multi_tenancy_enabled", true)
-            .put("plugins.ml_commons.memory.retention_enabled", false)
+            .put("plugins.ml_commons.multi_tenancy_enabled", multiTenancy)
+            .put("plugins.ml_commons.memory.retention_enabled", retentionEnabled)
             .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
             .put("plugins.ml_commons.memory.default_session_retention_days", -1)
             .put("plugins.ml_commons.memory.default_session_max_count", -1)
             .put("plugins.ml_commons.memory.default_long_term_max_count", -1)
             .put("plugins.ml_commons.memory.default_history_max_count", -1)
             .put("plugins.ml_commons.memory.orphan_ttl_days", 7)
-            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30)
-            .build();
-        applySettings(settings);
+            .put("plugins.ml_commons.memory.working_memory_ttl_days", 30);
+    }
 
-        MemoryConfiguration config = sessionConfig(7, null);
+    /** Same session-eviction mock as {@link #testSessionsUnionTimeAndCount()}: would count 4 sessions + 10 cascade if the passes ran. */
+    private void mockSessionsWouldEvict() {
+        long old = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
         doAnswer(invocation -> {
             SearchRequest req = invocation.getArgument(0);
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             String idx = req.indices()[0];
-            if (idx.endsWith("sessions") && req.source().size() > 0) {
-                listener.onResponse(hitsResp(new SearchHit[0]));
+            String query = q(req);
+            if (idx.endsWith("sessions")) {
+                if (!isCount(req)) {
+                    if (isFetchSourceDisabled(req)) {
+                        listener.onResponse(hitsResp(new SearchHit[] { idHit("s2", 1), idHit("s3", 2), idHit("s4", 3) }));
+                    } else {
+                        listener.onResponse(hitsResp(new SearchHit[] { tsHit("s1", old), tsHit("s2", old), tsHit("s3", old) }));
+                    }
+                } else if (query.contains("must_not")) {
+                    listener.onResponse(countResp(8));
+                } else {
+                    listener.onResponse(countResp(0));
+                }
+            } else if (idx.endsWith("working")) {
+                listener.onResponse(countResp(10));
             } else {
                 listener.onResponse(countResp(0));
             }
             return null;
         }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
 
-        MemoryRetentionDryRunResult result = run(config, null);
+    @Test
+    public void testDryRunShortCircuitsWhenMultiTenancyEnabled() {
+        // MT enabled hard-gates the scheduled job off, so the dry-run must short-circuit to total=0 even when the
+        // policy WOULD evict data. The mock returns evictable sessions; if the passes ran total would be > 0.
+        applySettings(gateSettings(true, true).build());
+        mockSessionsWouldEvict();
+
+        MemoryRetentionDryRunResult result = run(sessionConfig(7, 5), null);
+
+        assertEquals(0, result.getTotalWouldDelete());
         assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("multi-tenancy is enabled")));
+        assertFalse(result.getWarnings().stream().anyMatch(w -> w.contains("retention is disabled cluster-wide")));
+        assertNotNull(result.getEffectivePolicy());
+        assertNotNull(result.getPolicySource());
+        assertNoDeletes();
+    }
+
+    @Test
+    public void testDryRunShortCircuitsWhenRetentionDisabled() {
+        // retention_enabled=false gates the whole feature off, so the dry-run must short-circuit to total=0 even
+        // when the policy WOULD evict data. The mock returns evictable sessions; if the passes ran total would be > 0.
+        applySettings(gateSettings(false, false).build());
+        mockSessionsWouldEvict();
+
+        MemoryRetentionDryRunResult result = run(sessionConfig(7, 5), null);
+
+        assertEquals(0, result.getTotalWouldDelete());
         assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("retention is disabled cluster-wide")));
+        assertNotNull(result.getEffectivePolicy());
+        assertNotNull(result.getPolicySource());
         assertNoDeletes();
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunActionTests.java
@@ -85,7 +85,7 @@ public class RestMLMemoryRetentionDryRunActionTests extends OpenSearchTestCase {
         assertEquals(RestRequest.Method.POST, routes.get(0).getMethod());
         assertEquals("/_plugins/_ml/memory_containers/{memory_container_id}/_retention/_dry_run", routes.get(0).getPath());
         assertEquals(RestRequest.Method.POST, routes.get(1).getMethod());
-        assertEquals("/_plugins/_ml/memory/_retention/_dry_run", routes.get(1).getPath());
+        assertEquals("/_plugins/_ml/memory_containers/_retention/_dry_run", routes.get(1).getPath());
     }
 
     public void testGetRequestSingleContainer() throws IOException {
@@ -107,7 +107,7 @@ public class RestMLMemoryRetentionDryRunActionTests extends OpenSearchTestCase {
     public void testGetRequestClusterWide() throws IOException {
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(RestRequest.Method.POST)
-            .withPath("/_plugins/_ml/memory/_retention/_dry_run")
+            .withPath("/_plugins/_ml/memory_containers/_retention/_dry_run")
             .build();
 
         MLMemoryRetentionDryRunRequest dryRunRequest = action.getRequest(request);
@@ -154,7 +154,7 @@ public class RestMLMemoryRetentionDryRunActionTests extends OpenSearchTestCase {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(RestRequest.Method.POST)
-            .withPath("/_plugins/_ml/memory/_retention/_dry_run")
+            .withPath("/_plugins/_ml/memory_containers/_retention/_dry_run")
             .build();
 
         expectThrows(OpenSearchStatusException.class, () -> action.handleRequest(request, new FakeRestChannelHelper().channel(), client));

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLMemoryRetentionDryRunActionTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.input.Constants;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLMemoryRetentionDryRunResponse;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLMemoryRetentionDryRunActionTests extends OpenSearchTestCase {
+
+    private RestMLMemoryRetentionDryRunAction action;
+
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        action = new RestMLMemoryRetentionDryRunAction(mlFeatureEnabledSetting);
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryRetentionDryRunResponse> listener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLMemoryRetentionDryRunAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testGetName() {
+        assertFalse(Strings.isNullOrEmpty(action.getName()));
+        assertEquals("ml_memory_retention_dry_run_action", action.getName());
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = action.routes();
+        assertNotNull(routes);
+        assertEquals(2, routes.size());
+        assertEquals(RestRequest.Method.POST, routes.get(0).getMethod());
+        assertEquals("/_plugins/_ml/memory_containers/{memory_container_id}/_retention/_dry_run", routes.get(0).getPath());
+        assertEquals(RestRequest.Method.POST, routes.get(1).getMethod());
+        assertEquals("/_plugins/_ml/memory/_retention/_dry_run", routes.get(1).getPath());
+    }
+
+    public void testGetRequestSingleContainer() throws IOException {
+        Map<String, String> params = new HashMap<>();
+        params.put("memory_container_id", "container-abc");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory_containers/container-abc/_retention/_dry_run")
+            .withParams(params)
+            .build();
+
+        MLMemoryRetentionDryRunRequest dryRunRequest = action.getRequest(request);
+        assertNotNull(dryRunRequest);
+        assertEquals("container-abc", dryRunRequest.getMemoryContainerId());
+        assertFalse(dryRunRequest.isClusterWide());
+        assertNull(dryRunRequest.getTenantId());
+    }
+
+    public void testGetRequestClusterWide() throws IOException {
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory/_retention/_dry_run")
+            .build();
+
+        MLMemoryRetentionDryRunRequest dryRunRequest = action.getRequest(request);
+        assertNotNull(dryRunRequest);
+        assertNull(dryRunRequest.getMemoryContainerId());
+        assertTrue(dryRunRequest.isClusterWide());
+    }
+
+    public void testGetRequestWithMultiTenancy() throws IOException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        Map<String, String> params = new HashMap<>();
+        params.put("memory_container_id", "c1");
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put(Constants.TENANT_ID_HEADER, List.of("tenant-7"));
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory_containers/c1/_retention/_dry_run")
+            .withParams(params)
+            .withHeaders(headers)
+            .build();
+
+        MLMemoryRetentionDryRunRequest dryRunRequest = action.getRequest(request);
+        assertEquals("c1", dryRunRequest.getMemoryContainerId());
+        assertEquals("tenant-7", dryRunRequest.getTenantId());
+    }
+
+    public void testPrepareRequestDispatchesToTransport() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("memory_container_id", "container-xyz");
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory_containers/container-xyz/_retention/_dry_run")
+            .withParams(params)
+            .build();
+
+        action.handleRequest(request, new FakeRestChannelHelper().channel(), client);
+
+        ArgumentCaptor<MLMemoryRetentionDryRunRequest> captor = ArgumentCaptor.forClass(MLMemoryRetentionDryRunRequest.class);
+        verify(client, times(1)).execute(eq(MLMemoryRetentionDryRunAction.INSTANCE), captor.capture(), any());
+        assertEquals("container-xyz", captor.getValue().getMemoryContainerId());
+    }
+
+    public void testPrepareRequestForbiddenWhenAgenticMemoryDisabled() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory/_retention/_dry_run")
+            .build();
+
+        expectThrows(OpenSearchStatusException.class, () -> action.handleRequest(request, new FakeRestChannelHelper().channel(), client));
+    }
+
+    /** Minimal RestChannel that is never written to (transport call is mocked to no-op). */
+    private static class FakeRestChannelHelper {
+        org.opensearch.rest.RestChannel channel() {
+            return new org.opensearch.test.rest.FakeRestChannel(new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).build(), true, 1);
+        }
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
@@ -206,7 +206,7 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDryRunStillComputesButWarnsWhenRetentionDisabled() throws IOException {
+    public void testDryRunReportsZeroWhenRetentionDisabled() throws IOException {
         // Create the container WHILE retention is enabled (a stored policy is rejected when disabled), then disable.
         String containerId = createContainer(
             "{ \"name\": \"dryrun_retdisabled_it_"
@@ -216,12 +216,13 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
         try {
             updateClusterSettings("plugins.ml_commons.memory.retention_enabled", false);
 
-            // Dry-run still returns 200 and still computes; it warns that the scheduled job will not run.
+            // Dry-run returns 200 but short-circuits: the feature is gated off, so it reports total 0 and warns why.
             Map<String, Object> result = dryRunSingle(containerId);
             assertEquals("stored", result.get("policy_source"));
+            assertEquals(0, ((Number) result.get("total_would_delete")).intValue());
             List<String> warnings = (List<String>) result.get("warnings");
             assertTrue(
-                "a retention-disabled warning should be emitted while still computing",
+                "a retention-disabled warning should be emitted",
                 warnings.stream().anyMatch(w -> w.contains("retention is disabled cluster-wide"))
             );
         } finally {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.common.utils.StringUtils;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * Integration tests for the retention dry-run endpoints, which previously had zero IT coverage:
+ * <ul>
+ *   <li>{@code POST /_plugins/_ml/memory_containers/{id}/_retention/_dry_run} (single container)</li>
+ *   <li>{@code POST /_plugins/_ml/memory/_retention/_dry_run} (cluster-wide array)</li>
+ * </ul>
+ *
+ * <p>All tests use BARE containers ({@code "configuration": {}}) so sessions can be created without any
+ * external LLM/embedding credentials; the dry-run computation reuses the retention job's read-only
+ * count logic and never needs a model.
+ *
+ * <p>The critical safety assertion (see {@link #testDryRunPerformsNoDeletion()}) proves the dry-run
+ * deletes nothing: session documents created before the dry-run still exist afterward.
+ */
+public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
+
+    private static final String CREATE_PATH = "/_plugins/_ml/memory_containers/_create";
+    private static final String CONTAINER_PATH = "/_plugins/_ml/memory_containers/";
+    private static final String CLUSTER_WIDE_DRY_RUN_PATH = "/_plugins/_ml/memory/_retention/_dry_run";
+    private static final String DEFAULT_SESSION_MAX_COUNT_SETTING = "plugins.ml_commons.memory.default_session_max_count";
+
+    @Before
+    public void setup() throws IOException {
+        updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testSingleContainerDryRunShapeAndStoredPolicySource() throws IOException {
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_shape_it_"
+                + System.currentTimeMillis()
+                + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 5 } } } }"
+        );
+
+        Map<String, Object> result = dryRunSingle(containerId);
+
+        // Top-level documented shape.
+        assertEquals(containerId, result.get("container_id"));
+        assertTrue("evaluated_at should be a numeric epoch millis", result.get("evaluated_at") instanceof Number);
+        assertEquals("policy_source should be 'stored' when the container has its own policy", "stored", result.get("policy_source"));
+        assertTrue("effective_policy should be an object", result.get("effective_policy") instanceof Map);
+
+        // would_delete carries all four memory-type buckets, each an object with total + by_reason.
+        Map<String, Object> wouldDelete = (Map<String, Object>) result.get("would_delete");
+        assertNotNull("would_delete must be present", wouldDelete);
+        for (String key : List.of("sessions", "long_term", "history", "working_memory")) {
+            Map<String, Object> bucket = (Map<String, Object>) wouldDelete.get(key);
+            assertNotNull("would_delete." + key + " must be present", bucket);
+            assertTrue("would_delete." + key + ".total must be numeric", bucket.get("total") instanceof Number);
+            assertTrue("would_delete." + key + ".by_reason must be an object", bucket.get("by_reason") instanceof Map);
+        }
+
+        assertTrue("total_would_delete must be numeric", result.get("total_would_delete") instanceof Number);
+        assertTrue("pinned_would_skip must be numeric", result.get("pinned_would_skip") instanceof Number);
+        assertTrue("warnings must be a list", result.get("warnings") instanceof List);
+
+        // effective_policy should echo the stored sessions rule.
+        Map<String, Object> effectivePolicy = (Map<String, Object>) result.get("effective_policy");
+        Map<String, Object> sessions = (Map<String, Object>) effectivePolicy.get("sessions");
+        assertNotNull("effective_policy.sessions should reflect the stored rule", sessions);
+        assertEquals(5, ((Number) sessions.get("max_count")).intValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDryRunPolicySourceNoneWhenNoPolicyAndNoDefaults() throws IOException {
+        // Bare container with no retention_policy and no cluster defaults configured (all default to -1).
+        String containerId = createContainer("{ \"name\": \"dryrun_none_it_" + System.currentTimeMillis() + "\", \"configuration\": {} }");
+
+        Map<String, Object> result = dryRunSingle(containerId);
+
+        assertEquals("policy_source should be 'none' with no stored policy and no cluster defaults", "none", result.get("policy_source"));
+        assertEquals("nothing should be reported for deletion", 0, ((Number) result.get("total_would_delete")).intValue());
+        List<String> warnings = (List<String>) result.get("warnings");
+        assertTrue("a 'no retention policy' warning should be emitted", warnings.stream().anyMatch(w -> w.contains("no retention policy")));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDryRunPolicySourceDefaultWhenClusterDefaultsConfigured() throws IOException {
+        // Bare container with NO stored policy; a configured cluster default makes the effective source "default".
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_default_it_" + System.currentTimeMillis() + "\", \"configuration\": {} }"
+        );
+        try {
+            updateClusterSettings(DEFAULT_SESSION_MAX_COUNT_SETTING, 10);
+
+            Map<String, Object> result = dryRunSingle(containerId);
+            assertEquals("policy_source should be 'default' when cluster defaults apply", "default", result.get("policy_source"));
+            Map<String, Object> effectivePolicy = (Map<String, Object>) result.get("effective_policy");
+            Map<String, Object> sessions = (Map<String, Object>) effectivePolicy.get("sessions");
+            assertNotNull("effective_policy.sessions should be backfilled from the cluster default", sessions);
+            assertEquals(10, ((Number) sessions.get("max_count")).intValue());
+        } finally {
+            // Restore the unset sentinel so this default cannot leak into other tests via persistent settings.
+            updateClusterSettings(DEFAULT_SESSION_MAX_COUNT_SETTING, -1);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDryRunPerformsNoDeletion() throws IOException {
+        // Aggressive policy so the dry-run WOULD report deletions; the safety assertion is that it does not delete.
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_safety_it_"
+                + System.currentTimeMillis()
+                + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 1 } } } }"
+        );
+
+        createSession(containerId, "safety-1");
+        createSession(containerId, "safety-2");
+        createSession(containerId, "safety-3");
+        assertEquals("precondition: 3 sessions exist", 3L, countSessions(containerId));
+
+        Map<String, Object> result = dryRunSingle(containerId);
+        Map<String, Object> wouldDelete = (Map<String, Object>) result.get("would_delete");
+        Map<String, Object> sessions = (Map<String, Object>) wouldDelete.get("sessions");
+        // 3 non-pinned sessions, max_count 1 -> the job would delete the 2 oldest.
+        assertEquals("dry-run should report 2 sessions would be deleted", 2, ((Number) sessions.get("total")).intValue());
+
+        // CRITICAL: the dry-run must not have deleted anything.
+        assertEquals("dry-run must delete nothing; all 3 sessions must still exist", 3L, countSessions(containerId));
+    }
+
+    @Test
+    public void testClusterWideDryRunReturnsArrayIncludingCreatedContainer() throws IOException {
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_all_it_"
+                + System.currentTimeMillis()
+                + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 3 } } } }"
+        );
+
+        List<Map<String, Object>> results = dryRunClusterWide();
+        assertFalse("cluster-wide dry-run should return a non-empty array", results.isEmpty());
+        assertTrue(
+            "cluster-wide dry-run should include the created container",
+            results.stream().anyMatch(r -> containerId.equals(r.get("container_id")))
+        );
+    }
+
+    @Test
+    public void testDryRunNonExistentContainerReturns404() throws IOException {
+        // Ensure the container index exists first so this exercises the "container not found" path (404),
+        // not an index-not-found path.
+        createContainer("{ \"name\": \"dryrun_404_seed_" + System.currentTimeMillis() + "\", \"configuration\": {} }");
+
+        try {
+            TestHelper
+                .makeRequest(
+                    client(),
+                    "POST",
+                    CONTAINER_PATH + "does-not-exist-" + System.currentTimeMillis() + "/_retention/_dry_run",
+                    null,
+                    "",
+                    null
+                );
+            fail("dry-run against a non-existent container id should fail, not return 200");
+        } catch (ResponseException e) {
+            assertEquals("a missing container should yield 404, not 500", 404, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    @Test
+    public void testDryRunForbiddenWhenAgenticMemoryDisabled() throws IOException {
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_disabled_it_" + System.currentTimeMillis() + "\", \"configuration\": {} }"
+        );
+        try {
+            updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", false);
+            try {
+                TestHelper.makeRequest(client(), "POST", CONTAINER_PATH + containerId + "/_retention/_dry_run", null, "", null);
+                fail("dry-run should be rejected with 403 when agentic memory is disabled");
+            } catch (ResponseException e) {
+                assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+            }
+        } finally {
+            updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDryRunStillComputesButWarnsWhenRetentionDisabled() throws IOException {
+        // Create the container WHILE retention is enabled (a stored policy is rejected when disabled), then disable.
+        String containerId = createContainer(
+            "{ \"name\": \"dryrun_retdisabled_it_"
+                + System.currentTimeMillis()
+                + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 2 } } } }"
+        );
+        try {
+            updateClusterSettings("plugins.ml_commons.memory.retention_enabled", false);
+
+            // Dry-run still returns 200 and still computes; it warns that the scheduled job will not run.
+            Map<String, Object> result = dryRunSingle(containerId);
+            assertEquals("stored", result.get("policy_source"));
+            List<String> warnings = (List<String>) result.get("warnings");
+            assertTrue(
+                "a retention-disabled warning should be emitted while still computing",
+                warnings.stream().anyMatch(w -> w.contains("retention is disabled cluster-wide"))
+            );
+        } finally {
+            updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
+        }
+    }
+
+    // ---- helpers ----
+
+    private String createContainer(String body) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", CREATE_PATH, null, TestHelper.toHttpEntity(body), null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        String containerId = (String) parseResponseToMap(response).get("memory_container_id");
+        assertNotNull("create should return a memory_container_id", containerId);
+        return containerId;
+    }
+
+    private void createSession(String containerId, String sessionId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                CONTAINER_PATH + containerId + "/memories/sessions",
+                null,
+                TestHelper.toHttpEntity("{ \"session_id\": \"" + sessionId + "\" }"),
+                null
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> dryRunSingle(String containerId) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", CONTAINER_PATH + containerId + "/_retention/_dry_run", null, "", null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        return parseResponseToMap(response);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> dryRunClusterWide() throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", CLUSTER_WIDE_DRY_RUN_PATH, null, "", null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        String body = TestHelper.httpEntityToString(response.getEntity());
+        return StringUtils.gson.fromJson(body, List.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private long countSessions(String containerId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                CONTAINER_PATH + containerId + "/memories/sessions/_search",
+                null,
+                TestHelper.toHttpEntity("{ \"size\": 0, \"track_total_hits\": true, \"query\": { \"match_all\": {} } }"),
+                null
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> map = parseResponseToMap(response);
+        Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+        Map<String, Object> total = (Map<String, Object>) hits.get("total");
+        return ((Number) total.get("value")).longValue();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
@@ -143,6 +143,7 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testClusterWideDryRunReturnsArrayIncludingCreatedContainer() throws IOException {
         String containerId = createContainer(
             "{ \"name\": \"dryrun_all_it_"
@@ -150,12 +151,17 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
                 + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 3 } } } }"
         );
 
-        List<Map<String, Object>> results = dryRunClusterWide();
+        Map<String, Object> response = dryRunClusterWide();
+        List<Map<String, Object>> results = (List<Map<String, Object>>) response.get("results");
+        assertNotNull("cluster-wide dry-run should wrap results in a \"results\" array", results);
         assertFalse("cluster-wide dry-run should return a non-empty array", results.isEmpty());
         assertTrue(
             "cluster-wide dry-run should include the created container",
             results.stream().anyMatch(r -> containerId.equals(r.get("container_id")))
         );
+        // fix #3: the cluster-wide response surfaces a skipped_count for containers dropped during evaluation.
+        assertNotNull("cluster-wide dry-run should surface a skipped_count field", response.get("skipped_count"));
+        assertEquals("no containers should be skipped in this happy-path scenario", 0, ((Number) response.get("skipped_count")).intValue());
     }
 
     @Test
@@ -254,11 +260,11 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> dryRunClusterWide() throws IOException {
+    private Map<String, Object> dryRunClusterWide() throws IOException {
         Response response = TestHelper.makeRequest(client(), "POST", CLUSTER_WIDE_DRY_RUN_PATH, null, "", null);
         assertEquals(200, response.getStatusLine().getStatusCode());
         String body = TestHelper.httpEntityToString(response.getEntity());
-        return StringUtils.gson.fromJson(body, List.class);
+        return StringUtils.gson.fromJson(body, Map.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionDryRunIT.java
@@ -20,7 +20,7 @@ import org.opensearch.ml.utils.TestHelper;
  * Integration tests for the retention dry-run endpoints, which previously had zero IT coverage:
  * <ul>
  *   <li>{@code POST /_plugins/_ml/memory_containers/{id}/_retention/_dry_run} (single container)</li>
- *   <li>{@code POST /_plugins/_ml/memory/_retention/_dry_run} (cluster-wide array)</li>
+ *   <li>{@code POST /_plugins/_ml/memory_containers/_retention/_dry_run} (cluster-wide array)</li>
  * </ul>
  *
  * <p>All tests use BARE containers ({@code "configuration": {}}) so sessions can be created without any
@@ -34,7 +34,7 @@ public class RestMemoryRetentionDryRunIT extends MLCommonsRestTestCase {
 
     private static final String CREATE_PATH = "/_plugins/_ml/memory_containers/_create";
     private static final String CONTAINER_PATH = "/_plugins/_ml/memory_containers/";
-    private static final String CLUSTER_WIDE_DRY_RUN_PATH = "/_plugins/_ml/memory/_retention/_dry_run";
+    private static final String CLUSTER_WIDE_DRY_RUN_PATH = "/_plugins/_ml/memory_containers/_retention/_dry_run";
     private static final String DEFAULT_SESSION_MAX_COUNT_SETTING = "plugins.ml_commons.memory.default_session_max_count";
 
     @Before

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.jobs.MLJobType;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * Integration test proving that a live {@code PUT _cluster/settings} for
+ * {@code plugins.ml_commons.memory.retention_job_interval_hours} updates the persisted memory-retention job
+ * document's {@link org.opensearch.jobscheduler.spi.schedule.IntervalSchedule} — with no cluster restart.
+ *
+ * <p>The retention job is a write-once document in the {@code .plugins-ml-jobs} system index keyed by a fixed id.
+ * The fix upserts that document (version-bumping) on a dynamic setting change, which JobScheduler's
+ * {@code JobSweeper.postIndex} hook observes to deschedule + reschedule from the fresh interval.
+ */
+public class RestMemoryRetentionJobIntervalIT extends MLCommonsRestTestCase {
+
+    private static final String JOBS_INDEX = ".plugins-ml-jobs";
+    private static final String RETENTION_JOB_ID = MLJobType.MEMORY_RETENTION.name();
+    private static final String INTERVAL_SETTING = "plugins.ml_commons.memory.retention_job_interval_hours";
+
+    @Before
+    public void setup() throws IOException {
+        // Agentic memory must be enabled for the retention job to be scheduled.
+        updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+    }
+
+    @Test
+    public void testUpdateIntervalRescheduleReflectedInPersistedDoc() throws Exception {
+        // The retention job doc is created asynchronously when a 3.1+ data node is observed in the cluster state.
+        assertBusy(() -> assertEquals(24, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+
+        // Live dynamic change: shrink the interval to 1 hour.
+        updateClusterSettings(INTERVAL_SETTING, 1);
+
+        // The elected cluster manager upserts the job doc; the persisted schedule interval should follow.
+        assertBusy(() -> assertEquals(1, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Reads the persisted memory-retention job document from the {@code .plugins-ml-jobs} system index and returns
+     * its {@code schedule.interval} value (in hours). Returns -1 when the document is not yet present.
+     */
+    @SuppressWarnings("unchecked")
+    private int getPersistedIntervalHours() throws IOException {
+        Response response;
+        try {
+            response = TestHelper.makeRequest(client(), "GET", JOBS_INDEX + "/_doc/" + RETENTION_JOB_ID, null, (String) null, null);
+        } catch (ResponseException e) {
+            // The jobs index or the document may not exist yet; treat as not-yet-present so assertBusy keeps polling.
+            return -1;
+        }
+        Map<String, Object> responseMap = parseResponseToMap(response);
+        if (responseMap == null || !Boolean.TRUE.equals(responseMap.get("found"))) {
+            return -1;
+        }
+        Map<String, Object> source = (Map<String, Object>) responseMap.get("_source");
+        Map<String, Object> schedule = (Map<String, Object>) source.get("schedule");
+        Map<String, Object> interval = (Map<String, Object>) schedule.get("interval");
+        return ((Number) interval.get("period")).intValue();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
@@ -35,17 +35,25 @@ public class RestMemoryRetentionJobIntervalIT extends MLCommonsRestTestCase {
     public void setup() throws IOException {
         // Agentic memory must be enabled for the retention job to be scheduled.
         updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        // Start from a known state. The base-class @After only wipes indices, so a persistent interval left over from
+        // an aborted local rerun would survive; clearing it guarantees the first PUT below is a real change (see below).
+        updateClusterSettings(INTERVAL_SETTING, (Object) null);
     }
 
     @Test
     public void testUpdateIntervalRescheduleReflectedInPersistedDoc() throws Exception {
-        // The retention job doc is created asynchronously when a 3.1+ data node is observed in the cluster state.
-        assertBusy(() -> assertEquals(24, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
+        // Drive the assertion entirely through the dynamic settings-update consumer (the fix under test). That
+        // consumer upserts the job doc and is NOT gated by the one-shot startup latch (startedMemoryRetentionJob), so
+        // it is robust in the shared integ cluster: a prior memory test may have already tripped that node-level latch
+        // and then had .plugins-ml-jobs wiped by the base class @After, which would leave the latch-gated
+        // lazy-startup path unable to recreate the doc. The consumer fires on a change from the last-applied value;
+        // setup() cleared the setting to the default, so each PUT below is a distinct change that fires the consumer.
+        updateClusterSettings(INTERVAL_SETTING, 2);
+        // The elected cluster manager upserts the job doc (creating .plugins-ml-jobs if needed); interval follows.
+        assertBusy(() -> assertEquals(2, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
 
-        // Live dynamic change: shrink the interval to 1 hour.
+        // Live dynamic change: shrink the interval to 1 hour. The persisted schedule interval should follow.
         updateClusterSettings(INTERVAL_SETTING, 1);
-
-        // The elected cluster manager upserts the job doc; the persisted schedule interval should follow.
         assertBusy(() -> assertEquals(1, getPersistedIntervalHours()), 30, TimeUnit.SECONDS);
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionJobIntervalIT.java
@@ -35,6 +35,9 @@ public class RestMemoryRetentionJobIntervalIT extends MLCommonsRestTestCase {
     public void setup() throws IOException {
         // Agentic memory must be enabled for the retention job to be scheduled.
         updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        // Memory retention must also be enabled: the interval-change consumer (and the startup scheduling path) gate
+        // on isMemoryRetentionEnabled(), which defaults to false. Without this the consumer never upserts the job doc.
+        updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
         // Start from a known state. The base-class @After only wipes indices, so a persistent interval left over from
         // an aborted local rerun would survive; clearing it guarantees the first PUT below is a real change (see below).
         updateClusterSettings(INTERVAL_SETTING, (Object) null);

--- a/plugin/src/test/java/org/opensearch/ml/task/MLTaskManagerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/task/MLTaskManagerTests.java
@@ -20,6 +20,7 @@ import static org.opensearch.ml.common.CommonValue.ML_TASK_INDEX;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,7 +33,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest;
@@ -40,14 +43,20 @@ import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.engine.VersionConflictEngineException;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
 import org.opensearch.ml.common.MLTask;
 import org.opensearch.ml.common.MLTaskState;
 import org.opensearch.ml.common.MLTaskType;
 import org.opensearch.ml.engine.indices.MLIndicesHandler;
+import org.opensearch.ml.jobs.MLJobParameter;
 import org.opensearch.ml.jobs.MLJobType;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory;
@@ -432,6 +441,159 @@ public class MLTaskManagerTests extends OpenSearchTestCase {
         mlTaskManager.indexStatsCollectorJob(true);
 
         verify(client).index(any(), any());
+    }
+
+    public void testUpsertMemoryRetentionJob() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        mlTaskManager.upsertMemoryRetentionJob(1);
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client).index(indexRequestCaptor.capture(), any());
+
+        IndexRequest capturedRequest = indexRequestCaptor.getValue();
+        assertEquals(ML_JOBS_INDEX, capturedRequest.index());
+        assertEquals(MLJobType.MEMORY_RETENTION.name(), capturedRequest.id());
+        // The upsert path must use INDEX (version-bumping) rather than CREATE so JobScheduler reschedules.
+        assertEquals(DocWriteRequest.OpType.INDEX, capturedRequest.opType());
+        assertEquals(WriteRequest.RefreshPolicy.IMMEDIATE, capturedRequest.getRefreshPolicy());
+        // The caller's interval must actually be serialized into the persisted schedule (guards against a hardcoded value).
+        assertEquals(1, extractScheduleIntervalPeriod(capturedRequest));
+    }
+
+    @SuppressWarnings("unchecked")
+    private int extractScheduleIntervalPeriod(IndexRequest indexRequest) {
+        Map<String, Object> source = indexRequest.sourceAsMap();
+        Map<String, Object> schedule = (Map<String, Object>) source.get("schedule");
+        Map<String, Object> interval = (Map<String, Object>) schedule.get("interval");
+        return ((Number) interval.get("period")).intValue();
+    }
+
+    public void testUpsertMemoryRetentionJob_NotGatedByLatch() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        // Even after the memoryRetentionJobStarted latch is set by a first upsert, subsequent upserts must still write.
+        mlTaskManager.upsertMemoryRetentionJob(1);
+        mlTaskManager.upsertMemoryRetentionJob(2);
+
+        verify(client, times(2)).index(any(), any());
+    }
+
+    public void testUpsertMemoryRetentionJob_VersionConflictSwallowed() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener
+                .onFailure(
+                    new VersionConflictEngineException(new ShardId(ML_JOBS_INDEX, "_na_", 0), MLJobType.MEMORY_RETENTION.name(), "conflict")
+                );
+            return null;
+        }).when(client).index(any(), any());
+
+        // The swallow branch in indexJob treats a VersionConflictEngineException as success; no exception should escape.
+        mlTaskManager.upsertMemoryRetentionJob(1);
+
+        // Prove the swallow branch actually ran its success callback (not the error branch): the callback flips the
+        // memoryRetentionJobStarted latch, so a subsequent CREATE-path call must early-return without a second index.
+        // If the swallow logic were deleted/inverted, the latch would stay false and this CREATE would issue index #2.
+        mlTaskManager.indexMemoryRetentionJob(24);
+
+        verify(client, times(1)).index(any(), any());
+    }
+
+    public void testReconcileMemoryRetentionJob_UpsertsWhenIntervalDiffers() throws IOException {
+        int persistedInterval = 24;
+        int desiredInterval = 1;
+        GetResponse getResponse = buildMemoryRetentionJobGetResponse(persistedInterval);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        doAnswer(invocation -> {
+            ActionListener<Boolean> listener = invocation.getArgument(0);
+            listener.onResponse(true);
+            return null;
+        }).when(mlIndicesHandler).initMLJobsIndex(any());
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(client).index(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(desiredInterval);
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(client).index(indexRequestCaptor.capture(), any());
+        assertEquals(DocWriteRequest.OpType.INDEX, indexRequestCaptor.getValue().opType());
+    }
+
+    public void testReconcileMemoryRetentionJob_NoOpWhenIntervalSame() throws IOException {
+        int interval = 24;
+        GetResponse getResponse = buildMemoryRetentionJobGetResponse(interval);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(interval);
+
+        verify(client, never()).index(any(), any());
+    }
+
+    public void testReconcileMemoryRetentionJob_NoOpWhenDocAbsent() throws IOException {
+        GetResponse getResponse = mock(GetResponse.class);
+        when(getResponse.isExists()).thenReturn(false);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        mlTaskManager.reconcileMemoryRetentionJob(1);
+
+        verify(client, never()).index(any(), any());
+    }
+
+    private GetResponse buildMemoryRetentionJobGetResponse(int intervalHours) throws IOException {
+        MLJobParameter jobParameter = new MLJobParameter(
+            MLJobType.MEMORY_RETENTION.name(),
+            new IntervalSchedule(Instant.now(), intervalHours, ChronoUnit.HOURS),
+            120L,
+            null,
+            MLJobType.MEMORY_RETENTION,
+            true
+        );
+        BytesReference bytesReference = BytesReference.bytes(jobParameter.toXContent(XContentFactory.jsonBuilder(), null));
+        GetResult getResult = new GetResult(ML_JOBS_INDEX, MLJobType.MEMORY_RETENTION.name(), 1L, 1L, 1L, true, bytesReference, null, null);
+        return new GetResponse(getResult);
     }
 
     public void testUpdateMLTaskDirectly_NullTaskId() {


### PR DESCRIPTION
Title:
  [Memory] Retention job dynamic interval fix + dry-run API (RFC #4859)

  Description:
  ### Description
  
  Part 1 of 2 (stacked) for the agentic memory retention lifecycle, per RFC #4859.

  **Dynamic retention job interval**
  - Fixes the retention job interval setting (`plugins.ml_commons.memory.retention_job_interval_hours`) being effectively *write-once*: the scheduled job document was
  seeded on first startup and never reconciled, so changing the cluster setting (or `settings.yml` on restart) silently had no effect on the next run.
  - Reconciles on startup by reading the effective interval (cluster settings layered over node settings, honoring OpenSearch precedence) and upserting the persisted job
  doc only when it differs — gated on the elected cluster manager so exactly one node writes the shared doc.
  - Defers retention/stats job scheduling until cluster state is recovered and the jobs index primary shards are active, so a rolling upgrade does not leave the cluster
  yellow. Builds on and preserves the rolling-upgrade guard from #4937.
  
  **Dry-run API**
  - Adds `POST /_plugins/_ml/memory_containers/{memory_container_id}/_retention/_dry_run` (single container) and `POST /_plugins/_ml/memory/_retention/_dry_run`
  (cluster-wide) to preview exactly what the retention job *would* delete — without deleting anything.
  - The dry-run path reuses the real job's eviction-counting logic (shared `computeDefaultRetentionPolicy()`) and performs zero deletes. Response reports `effective_policy`, per-type `would_delete` with `by_reason` breakdowns, `total_would_delete`, `pinned_would_skip`, and `warnings`.
  - Cluster-wide response is an object { "skipped_count": N, "results": [ … ] }, where skipped_count is the number of containers that could not be evaluated (parse/eval error) and were omitted from results, so callers can tell "no deletions" from "not evaluated." The single-container response is a bare result object.


  The existing `agentic_memory_enabled` / `memory_retention_enabled` / multi-tenancy gates are retained unchanged. A follow-up stacked PR (on-demand execute +
  remote-metadata gating) builds on this branch.

  ### Related Issues
  Relates to RFC #4859
  
  ### Check List
  - [x] New functionality includes testing.
  - [x] New functionality has been documented.
  - [ ] API changes companion pull request created.
  - [x] Commits are signed per the DCO using `--signoff`.
  - [ ] Public documentation issue/PR created.

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.