### PR TITLE
[Backport 3.8] Fix TEXT_SIMILARITY ONNX inference for models without token_type_ids

### DIFF
--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityTranslator.java
@@ -34,10 +34,17 @@ import ai.djl.ndarray.NDArray;
 import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
+import ai.djl.ndarray.types.Shape;
 import ai.djl.translate.TranslatorContext;
+import ai.djl.util.PairList;
+import lombok.extern.log4j.Log4j2;
 
+@Log4j2
 public class TextSimilarityTranslator extends SentenceTransformerTranslator {
     public final String SIMILARITY_NAME = "similarity";
+    private static final String INPUT_IDS = "input_ids";
+    private static final String ATTENTION_MASK = "attention_mask";
+    private static final String TOKEN_TYPE_IDS = "token_type_ids";
 
     @Override
     public NDList processInput(TranslatorContext ctx, Input input) {
@@ -48,21 +55,38 @@ public class TextSimilarityTranslator extends SentenceTransformerTranslator {
         Encoding encodings = tokenizer.encode(sentence, context);
         long[] indices = encodings.getIds();
         long[] attentionMask = encodings.getAttentionMask();
-        long[] tokenTypes = encodings.getTypeIds();
 
         NDArray indicesArray = manager.create(indices);
-        indicesArray.setName("input_ids");
+        indicesArray.setName(INPUT_IDS);
 
         NDArray attentionMaskArray = manager.create(attentionMask);
-        attentionMaskArray.setName("attention_mask");
-
-        NDArray tokenTypeArray = manager.create(tokenTypes);
-        tokenTypeArray.setName("token_type_ids");
+        attentionMaskArray.setName(ATTENTION_MASK);
 
         ndList.add(indicesArray);
         ndList.add(attentionMaskArray);
-        ndList.add(tokenTypeArray);
+
+        if (requiresTokenTypeIds(ctx)) {
+            NDArray tokenTypeArray = manager.create(encodings.getTypeIds());
+            tokenTypeArray.setName(TOKEN_TYPE_IDS);
+            ndList.add(tokenTypeArray);
+        }
         return ndList;
+    }
+
+    /**
+     * Determines whether the loaded model expects a token_type_ids input.
+     */
+    private boolean requiresTokenTypeIds(TranslatorContext ctx) {
+        try {
+            PairList<String, Shape> describedInput = ctx.getModel().getBlock().describeInput();
+            if (describedInput == null || describedInput.isEmpty()) {
+                return true;
+            }
+            return describedInput.contains(TOKEN_TYPE_IDS);
+        } catch (Exception e) {
+            log.warn("Failed to inspect model input signature, sending {} by default", TOKEN_TYPE_IDS, e);
+            return true;
+        }
     }
 
     @Override

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityCrossEncoderModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/text_similarity/TextSimilarityCrossEncoderModelTest.java
@@ -66,7 +66,9 @@ import ai.djl.ndarray.NDList;
 import ai.djl.ndarray.NDManager;
 import ai.djl.ndarray.types.DataType;
 import ai.djl.ndarray.types.Shape;
+import ai.djl.nn.Block;
 import ai.djl.translate.TranslatorContext;
+import ai.djl.util.PairList;
 import lombok.extern.log4j.Log4j2;
 
 @Log4j2
@@ -187,6 +189,37 @@ public class TextSimilarityCrossEncoderModelTest {
             assertEquals(1, mlModelTensors.get(0).getData().length);
         }
         textSimilarityCrossEncoderModel.close();
+    }
+
+    @Test
+    public void test_TextSimilarity_Translator_ProcessInput_withoutTokenTypeIds() throws URISyntaxException, IOException {
+        TextSimilarityTranslator textSimilarityTranslator = new TextSimilarityTranslator();
+        TranslatorContext translatorContext = mock(TranslatorContext.class);
+        Model mlModel = mock(Model.class);
+        when(translatorContext.getModel()).thenReturn(mlModel);
+        when(mlModel.getModelPath()).thenReturn(Paths.get(getClass().getResource("../tokenize/tokenizer.json").toURI()).getParent());
+        textSimilarityTranslator.prepare(translatorContext);
+
+        // Model that declares only input_ids and attention_mask
+        Block block = mock(Block.class);
+        PairList<String, Shape> describedInput = new PairList<>();
+        describedInput.add("input_ids", new Shape(1));
+        describedInput.add("attention_mask", new Shape(1));
+        when(mlModel.getBlock()).thenReturn(block);
+        when(block.describeInput()).thenReturn(describedInput);
+
+        NDManager manager = mock(NDManager.class);
+        when(translatorContext.getNDManager()).thenReturn(manager);
+        Input input = mock(Input.class);
+        String testSentence = "hello world";
+        when(input.getAsString(0)).thenReturn(testSentence);
+        when(input.getAsString(1)).thenReturn(testSentence);
+        NDArray indiceNdArray = mock(NDArray.class);
+        when(indiceNdArray.toLongArray()).thenReturn(new long[] { 102l, 101l });
+        when(manager.create((long[]) any())).thenReturn(indiceNdArray);
+        doNothing().when(indiceNdArray).setName(any());
+        NDList outputList = textSimilarityTranslator.processInput(translatorContext, input);
+        assertEquals(2, outputList.size());
     }
 
     @Test


### PR DESCRIPTION
### Description
Backport https://github.com/opensearch-project/ml-commons/pull/4946 to 3.8 branch

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
