### PR TITLE
[Memory] On-demand retention execute + self-hosted multi-tenancy (RFC #4859)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -112,7 +112,7 @@ public class MemoryContainerConstants {
     public static final String BASE_MEMORY_CONTAINERS_PATH = "/_plugins/_ml/memory_containers";
     public static final String CREATE_MEMORY_CONTAINER_PATH = BASE_MEMORY_CONTAINERS_PATH + "/_create";
     // Cluster-wide on-demand trigger for the memory retention job (runs the real, per-policy delete pipeline).
-    public static final String EXECUTE_MEMORY_RETENTION_PATH = "/_plugins/_ml/memory/_retention/_execute";
+    public static final String EXECUTE_MEMORY_RETENTION_PATH = BASE_MEMORY_CONTAINERS_PATH + "/_retention/_execute";
     public static final String PARAMETER_MEMORY_CONTAINER_ID = "memory_container_id";
     public static final String PARAMETER_DELETE_ALL_MEMORIES = "delete_all_memories";
     public static final String PARAMETER_DELETE_MEMORIES = "delete_memories";

--- a/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/memorycontainer/MemoryContainerConstants.java
@@ -111,6 +111,8 @@ public class MemoryContainerConstants {
     // REST API paths
     public static final String BASE_MEMORY_CONTAINERS_PATH = "/_plugins/_ml/memory_containers";
     public static final String CREATE_MEMORY_CONTAINER_PATH = BASE_MEMORY_CONTAINERS_PATH + "/_create";
+    // Cluster-wide on-demand trigger for the memory retention job (runs the real, per-policy delete pipeline).
+    public static final String EXECUTE_MEMORY_RETENTION_PATH = "/_plugins/_ml/memory/_retention/_execute";
     public static final String PARAMETER_MEMORY_CONTAINER_ID = "memory_container_id";
     public static final String PARAMETER_DELETE_ALL_MEMORIES = "delete_all_memories";
     public static final String PARAMETER_DELETE_MEMORIES = "delete_memories";

--- a/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
+++ b/common/src/main/java/org/opensearch/ml/common/settings/MLCommonsSettings.java
@@ -5,12 +5,15 @@
 
 package org.opensearch.ml.common.settings;
 
+import static org.opensearch.remote.metadata.common.CommonValue.AWS_DYNAMO_DB;
+import static org.opensearch.remote.metadata.common.CommonValue.AWS_OPENSEARCH_SERVICE;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_TENANT_ID_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_REGION_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
+import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_OPENSEARCH;
 
 import java.util.List;
 import java.util.function.Function;
@@ -18,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeUnit;
 import org.opensearch.core.common.unit.ByteSizeValue;
 
@@ -526,6 +530,18 @@ public final class MLCommonsSettings {
     /** This setting sets the remote metadata service name */
     public static final Setting<String> REMOTE_METADATA_SERVICE_NAME = Setting
         .simpleString(ML_PLUGIN_SETTING_PREFIX + REMOTE_METADATA_SERVICE_NAME_KEY, Setting.Property.NodeScope, Setting.Property.Final);
+
+    /**
+     * Whether cluster metadata (including the memory container registry) is stored in a REMOTE metadata store rather
+     * than the local cluster. Mirrors {@code SdkClientFactory}: any of {@code RemoteOpenSearch}, {@code AWSDynamoDB},
+     * or {@code AWSOpenSearchService} routes metadata to a remote store; empty/unrecognized falls back to the local
+     * cluster. Background jobs that scan local system indices with the native client (e.g. memory retention) find no
+     * metadata when the store is remote, so they must gate on this. See RFC #4859.
+     */
+    public static boolean isRemoteMetadataStore(Settings settings) {
+        String type = REMOTE_METADATA_TYPE.get(settings);
+        return REMOTE_OPENSEARCH.equals(type) || AWS_DYNAMO_DB.equals(type) || AWS_OPENSEARCH_SERVICE.equals(type);
+    }
 
     // Feature flag for enabling telemetry metric collection via metrics framework
     public static final Setting<Boolean> ML_COMMONS_METRIC_COLLECTION_ENABLED = Setting

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionAction.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action to trigger the memory retention job on demand, instead of waiting for the scheduled
+ * interval. This runs the real retention pipeline (it deletes per policy), reusing the exact same
+ * code path as the scheduled run.
+ */
+public class MLExecuteMemoryRetentionAction extends ActionType<MLExecuteMemoryRetentionResponse> {
+    public static final MLExecuteMemoryRetentionAction INSTANCE = new MLExecuteMemoryRetentionAction();
+    public static final String NAME = "cluster:admin/opensearch/ml/memory_containers/retention/execute";
+
+    private MLExecuteMemoryRetentionAction() {
+        super(NAME, MLExecuteMemoryRetentionResponse::new);
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.InputStreamStreamInput;
+import org.opensearch.core.common.io.stream.OutputStreamStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Request to trigger the memory retention job on demand.
+ *
+ * <p>The retention pipeline is a singleton, cluster-wide operation that iterates every container.
+ * There is no per-container scoping today (see MLExecuteMemoryRetentionAction), so this request
+ * carries no target id. {@code tenantId} is captured from the request context by the REST layer for
+ * transport-serialization symmetry with the other memory-container requests; the multi-tenancy
+ * decision itself is made by the processor from the cluster setting (the scheduled job refuses to
+ * run under multi-tenancy), so {@code tenantId} is not used for gating and {@code validate()} has no
+ * required fields.
+ */
+@Getter
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@ToString
+public class MLExecuteMemoryRetentionRequest extends ActionRequest {
+
+    String tenantId;
+
+    @Builder
+    public MLExecuteMemoryRetentionRequest(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public MLExecuteMemoryRetentionRequest(StreamInput in) throws IOException {
+        super(in);
+        this.tenantId = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(tenantId);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public static MLExecuteMemoryRetentionRequest fromActionRequest(ActionRequest actionRequest) {
+        if (actionRequest instanceof MLExecuteMemoryRetentionRequest) {
+            return (MLExecuteMemoryRetentionRequest) actionRequest;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); OutputStreamStreamOutput osso = new OutputStreamStreamOutput(baos)) {
+            actionRequest.writeTo(osso);
+            try (StreamInput input = new InputStreamStreamInput(new ByteArrayInputStream(baos.toByteArray()))) {
+                return new MLExecuteMemoryRetentionRequest(input);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to parse ActionRequest into MLExecuteMemoryRetentionRequest", e);
+        }
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequest.java
@@ -28,33 +28,25 @@ import lombok.experimental.FieldDefaults;
  *
  * <p>The retention pipeline is a singleton, cluster-wide operation that iterates every container.
  * There is no per-container scoping today (see MLExecuteMemoryRetentionAction), so this request
- * carries no target id. {@code tenantId} is captured from the request context by the REST layer for
- * transport-serialization symmetry with the other memory-container requests; the multi-tenancy
- * decision itself is made by the processor from the cluster setting (the scheduled job refuses to
- * run under multi-tenancy), so {@code tenantId} is not used for gating and {@code validate()} has no
- * required fields.
+ * carries no target id and no fields. It always runs cluster-wide; under multi-tenancy the run is
+ * tenant-isolated by the processor via per-container {@code memory_container_id} filters, and it
+ * skips only when a remote metadata store is configured. {@code validate()} has no required fields.
  */
 @Getter
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @ToString
 public class MLExecuteMemoryRetentionRequest extends ActionRequest {
 
-    String tenantId;
-
     @Builder
-    public MLExecuteMemoryRetentionRequest(String tenantId) {
-        this.tenantId = tenantId;
-    }
+    public MLExecuteMemoryRetentionRequest() {}
 
     public MLExecuteMemoryRetentionRequest(StreamInput in) throws IOException {
         super(in);
-        this.tenantId = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(tenantId);
     }
 
     @Override

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponse.java
@@ -44,17 +44,6 @@ public class MLExecuteMemoryRetentionResponse extends ActionResponse implements 
         /** plugins.ml_commons.memory.retention_enabled=false. */
         RETENTION_DISABLED("retention_disabled", false),
         /**
-         * Multi-tenancy is enabled; the native retention job cannot route by tenant.
-         *
-         * @deprecated RFC #4859: multi-tenancy no longer gates the retention job (local-metadata multi-tenancy runs
-         *             tenant-isolated via per-container memory_container_id filters). The job now skips only when a
-         *             REMOTE metadata store is configured; see {@link #REMOTE_METADATA_STORE}. This constant is
-         *             retained (never emitted by current code) purely for wire-compatibility: writeEnum/readEnum
-         *             serialize by ordinal, so it must not be removed or reordered.
-         */
-        @Deprecated
-        MULTI_TENANCY_ENABLED("multi_tenancy_enabled", false),
-        /**
          * A remote metadata store (e.g. AWS OpenSearch Serverless / DynamoDB) is configured; the container registry
          * lives outside the local cluster, so the native-client retention job cannot enumerate containers. See RFC #4859.
          */
@@ -100,7 +89,7 @@ public class MLExecuteMemoryRetentionResponse extends ActionResponse implements 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("acknowledged", true);
+        builder.field("acknowledged", status.isTriggered());
         builder.field("triggered", status.isTriggered());
         builder.field("status", status.getValue());
         if (message != null) {

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponse.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import java.io.IOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Response for an on-demand memory retention trigger.
+ *
+ * <p>The trigger is an acknowledgement: it reports whether the retention pipeline was started
+ * ({@code triggered}) or why it was not, without blocking until the (fully async) delete pipeline
+ * finishes. Every job-level outcome returns HTTP 200; the {@code status} and {@code triggered}
+ * fields in the body communicate what happened so a benign "already running" or "disabled" state
+ * is never surfaced as an error the caller must special-case.
+ */
+@Getter
+@ToString
+public class MLExecuteMemoryRetentionResponse extends ActionResponse implements ToXContentObject {
+
+    /**
+     * Job-level outcome of an on-demand trigger. Mirrors the guards inside
+     * MemoryRetentionJobProcessor#triggerRun() one-to-one so the API surfaces exactly what the
+     * scheduled run would have done.
+     */
+    // Wire format note: writeEnum/readEnum serialize by ordinal. Constants are APPEND-ONLY —
+    // never reorder or remove existing values, or the stream format breaks across node versions.
+    public enum TriggerStatus {
+        /** Pipeline started on this invocation. */
+        TRIGGERED("triggered", true),
+        /** A scheduled or previous on-demand run is still in progress; not double-run. */
+        ALREADY_RUNNING("already_running", false),
+        /** plugins.ml_commons.memory.retention_enabled=false. */
+        RETENTION_DISABLED("retention_disabled", false),
+        /**
+         * Multi-tenancy is enabled; the native retention job cannot route by tenant.
+         *
+         * @deprecated RFC #4859: multi-tenancy no longer gates the retention job (local-metadata multi-tenancy runs
+         *             tenant-isolated via per-container memory_container_id filters). The job now skips only when a
+         *             REMOTE metadata store is configured; see {@link #REMOTE_METADATA_STORE}. This constant is
+         *             retained (never emitted by current code) purely for wire-compatibility: writeEnum/readEnum
+         *             serialize by ordinal, so it must not be removed or reordered.
+         */
+        @Deprecated
+        MULTI_TENANCY_ENABLED("multi_tenancy_enabled", false),
+        /**
+         * A remote metadata store (e.g. AWS OpenSearch Serverless / DynamoDB) is configured; the container registry
+         * lives outside the local cluster, so the native-client retention job cannot enumerate containers. See RFC #4859.
+         */
+        REMOTE_METADATA_STORE("remote_metadata_store", false);
+
+        private final String value;
+        private final boolean triggered;
+
+        TriggerStatus(String value, boolean triggered) {
+            this.value = value;
+            this.triggered = triggered;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public boolean isTriggered() {
+            return triggered;
+        }
+    }
+
+    private final TriggerStatus status;
+    private final String message;
+
+    public MLExecuteMemoryRetentionResponse(TriggerStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public MLExecuteMemoryRetentionResponse(StreamInput in) throws IOException {
+        super(in);
+        this.status = in.readEnum(TriggerStatus.class);
+        this.message = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeEnum(status);
+        out.writeOptionalString(message);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("acknowledged", true);
+        builder.field("triggered", status.isTriggered());
+        builder.field("status", status.getValue());
+        if (message != null) {
+            builder.field("message", message);
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/memorycontainer/MLMemoryRetentionDryRunResponse.java
@@ -95,7 +95,13 @@ public class MLMemoryRetentionDryRunResponse extends ActionResponse implements T
             builder.endObject();
             return builder;
         }
-        // Single-container dry-run: render the sole result as a bare object.
+        // Single-container dry-run: render the sole result as a bare object. Guard against an empty result list so a
+        // container that produced no evaluation renders "{}" instead of throwing IndexOutOfBoundsException.
+        if (results == null || results.isEmpty()) {
+            builder.startObject();
+            builder.endObject();
+            return builder;
+        }
         return results.get(0).toXContent(builder, params);
     }
 

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequestTests.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.ml.common.transport.memorycontainer;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -24,51 +23,31 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 public class MLExecuteMemoryRetentionRequestTests {
 
     @Test
-    public void testBuilderWithTenant() {
-        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-1").build();
-        assertNotNull(request);
-        assertEquals("tenant-1", request.getTenantId());
-    }
-
-    @Test
-    public void testBuilderWithoutTenant() {
+    public void testBuilder() {
         MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().build();
         assertNotNull(request);
-        assertNull(request.getTenantId());
     }
 
     @Test
     public void testValidateAlwaysNull() {
-        // The request carries no required fields; validation is always clean.
+        // The request carries no fields; validation is always clean.
         assertNull(MLExecuteMemoryRetentionRequest.builder().build().validate());
-        assertNull(MLExecuteMemoryRetentionRequest.builder().tenantId("t").build().validate());
     }
 
     @Test
-    public void testStreamRoundTripWithTenant() throws IOException {
-        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-x").build();
-        BytesStreamOutput out = new BytesStreamOutput();
-        request.writeTo(out);
-
-        StreamInput in = out.bytes().streamInput();
-        MLExecuteMemoryRetentionRequest parsed = new MLExecuteMemoryRetentionRequest(in);
-        assertEquals("tenant-x", parsed.getTenantId());
-    }
-
-    @Test
-    public void testStreamRoundTripWithoutTenant() throws IOException {
+    public void testStreamRoundTrip() throws IOException {
         MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().build();
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
 
         StreamInput in = out.bytes().streamInput();
         MLExecuteMemoryRetentionRequest parsed = new MLExecuteMemoryRetentionRequest(in);
-        assertNull(parsed.getTenantId());
+        assertNotNull(parsed);
     }
 
     @Test
     public void testFromActionRequestSameType() {
-        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("t").build();
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().build();
         assertSame(request, MLExecuteMemoryRetentionRequest.fromActionRequest(request));
     }
 
@@ -83,13 +62,11 @@ public class MLExecuteMemoryRetentionRequestTests {
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 super.writeTo(out);
-                out.writeOptionalString("converted-tenant");
             }
         };
 
         MLExecuteMemoryRetentionRequest result = MLExecuteMemoryRetentionRequest.fromActionRequest(other);
         assertNotNull(result);
-        assertEquals("converted-tenant", result.getTenantId());
     }
 
     @Test(expected = UncheckedIOException.class)
@@ -106,13 +83,6 @@ public class MLExecuteMemoryRetentionRequestTests {
             }
         };
         MLExecuteMemoryRetentionRequest.fromActionRequest(broken);
-    }
-
-    @Test
-    public void testToStringContainsTenant() {
-        String s = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-str").build().toString();
-        assertNotNull(s);
-        assertTrue(s.contains("tenant-str"));
     }
 
     @Test

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionRequestTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Test;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class MLExecuteMemoryRetentionRequestTests {
+
+    @Test
+    public void testBuilderWithTenant() {
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-1").build();
+        assertNotNull(request);
+        assertEquals("tenant-1", request.getTenantId());
+    }
+
+    @Test
+    public void testBuilderWithoutTenant() {
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().build();
+        assertNotNull(request);
+        assertNull(request.getTenantId());
+    }
+
+    @Test
+    public void testValidateAlwaysNull() {
+        // The request carries no required fields; validation is always clean.
+        assertNull(MLExecuteMemoryRetentionRequest.builder().build().validate());
+        assertNull(MLExecuteMemoryRetentionRequest.builder().tenantId("t").build().validate());
+    }
+
+    @Test
+    public void testStreamRoundTripWithTenant() throws IOException {
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-x").build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteMemoryRetentionRequest parsed = new MLExecuteMemoryRetentionRequest(in);
+        assertEquals("tenant-x", parsed.getTenantId());
+    }
+
+    @Test
+    public void testStreamRoundTripWithoutTenant() throws IOException {
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteMemoryRetentionRequest parsed = new MLExecuteMemoryRetentionRequest(in);
+        assertNull(parsed.getTenantId());
+    }
+
+    @Test
+    public void testFromActionRequestSameType() {
+        MLExecuteMemoryRetentionRequest request = MLExecuteMemoryRetentionRequest.builder().tenantId("t").build();
+        assertSame(request, MLExecuteMemoryRetentionRequest.fromActionRequest(request));
+    }
+
+    @Test
+    public void testFromActionRequestDifferentType() throws IOException {
+        ActionRequest other = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                super.writeTo(out);
+                out.writeOptionalString("converted-tenant");
+            }
+        };
+
+        MLExecuteMemoryRetentionRequest result = MLExecuteMemoryRetentionRequest.fromActionRequest(other);
+        assertNotNull(result);
+        assertEquals("converted-tenant", result.getTenantId());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void testFromActionRequestIOException() {
+        ActionRequest broken = new ActionRequest() {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                throw new IOException("boom");
+            }
+        };
+        MLExecuteMemoryRetentionRequest.fromActionRequest(broken);
+    }
+
+    @Test
+    public void testToStringContainsTenant() {
+        String s = MLExecuteMemoryRetentionRequest.builder().tenantId("tenant-str").build().toString();
+        assertNotNull(s);
+        assertTrue(s.contains("tenant-str"));
+    }
+
+    @Test
+    public void testInstanceOfActionRequest() {
+        assertTrue(MLExecuteMemoryRetentionRequest.builder().build() instanceof ActionRequest);
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponseTests.java
@@ -34,8 +34,8 @@ public class MLExecuteMemoryRetentionResponseTests {
         assertFalse(TriggerStatus.RETENTION_DISABLED.isTriggered());
         assertEquals("retention_disabled", TriggerStatus.RETENTION_DISABLED.getValue());
 
-        assertFalse(TriggerStatus.MULTI_TENANCY_ENABLED.isTriggered());
-        assertEquals("multi_tenancy_enabled", TriggerStatus.MULTI_TENANCY_ENABLED.getValue());
+        assertFalse(TriggerStatus.REMOTE_METADATA_STORE.isTriggered());
+        assertEquals("remote_metadata_store", TriggerStatus.REMOTE_METADATA_STORE.getValue());
     }
 
     @Test
@@ -78,6 +78,8 @@ public class MLExecuteMemoryRetentionResponseTests {
     public void testToXContentAlreadyRunning() throws IOException {
         MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.ALREADY_RUNNING, "busy");
         String json = toJson(response);
+        // acknowledged reflects whether a run was actually triggered; a benign "already running" was not.
+        assertTrue(json.contains("\"acknowledged\":false"));
         assertTrue(json.contains("\"triggered\":false"));
         assertTrue(json.contains("\"status\":\"already_running\""));
     }
@@ -86,6 +88,7 @@ public class MLExecuteMemoryRetentionResponseTests {
     public void testToXContentDisabled() throws IOException {
         MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.RETENTION_DISABLED, "off");
         String json = toJson(response);
+        assertTrue(json.contains("\"acknowledged\":false"));
         assertTrue(json.contains("\"triggered\":false"));
         assertTrue(json.contains("\"status\":\"retention_disabled\""));
     }

--- a/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/memorycontainer/MLExecuteMemoryRetentionResponseTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.transport.memorycontainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
+
+public class MLExecuteMemoryRetentionResponseTests {
+
+    @Test
+    public void testTriggeredStatusFlags() {
+        assertTrue(TriggerStatus.TRIGGERED.isTriggered());
+        assertEquals("triggered", TriggerStatus.TRIGGERED.getValue());
+
+        assertFalse(TriggerStatus.ALREADY_RUNNING.isTriggered());
+        assertEquals("already_running", TriggerStatus.ALREADY_RUNNING.getValue());
+
+        assertFalse(TriggerStatus.RETENTION_DISABLED.isTriggered());
+        assertEquals("retention_disabled", TriggerStatus.RETENTION_DISABLED.getValue());
+
+        assertFalse(TriggerStatus.MULTI_TENANCY_ENABLED.isTriggered());
+        assertEquals("multi_tenancy_enabled", TriggerStatus.MULTI_TENANCY_ENABLED.getValue());
+    }
+
+    @Test
+    public void testStreamRoundTripAllStatuses() throws IOException {
+        for (TriggerStatus status : TriggerStatus.values()) {
+            MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(status, "msg-" + status.getValue());
+            BytesStreamOutput out = new BytesStreamOutput();
+            response.writeTo(out);
+
+            StreamInput in = out.bytes().streamInput();
+            MLExecuteMemoryRetentionResponse parsed = new MLExecuteMemoryRetentionResponse(in);
+            assertEquals(status, parsed.getStatus());
+            assertEquals("msg-" + status.getValue(), parsed.getMessage());
+        }
+    }
+
+    @Test
+    public void testStreamRoundTripNullMessage() throws IOException {
+        MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.TRIGGERED, null);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        MLExecuteMemoryRetentionResponse parsed = new MLExecuteMemoryRetentionResponse(in);
+        assertEquals(TriggerStatus.TRIGGERED, parsed.getStatus());
+        assertNull(parsed.getMessage());
+    }
+
+    @Test
+    public void testToXContentTriggered() throws IOException {
+        MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.TRIGGERED, "started");
+        String json = toJson(response);
+        assertTrue(json.contains("\"acknowledged\":true"));
+        assertTrue(json.contains("\"triggered\":true"));
+        assertTrue(json.contains("\"status\":\"triggered\""));
+        assertTrue(json.contains("\"message\":\"started\""));
+    }
+
+    @Test
+    public void testToXContentAlreadyRunning() throws IOException {
+        MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.ALREADY_RUNNING, "busy");
+        String json = toJson(response);
+        assertTrue(json.contains("\"triggered\":false"));
+        assertTrue(json.contains("\"status\":\"already_running\""));
+    }
+
+    @Test
+    public void testToXContentDisabled() throws IOException {
+        MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.RETENTION_DISABLED, "off");
+        String json = toJson(response);
+        assertTrue(json.contains("\"triggered\":false"));
+        assertTrue(json.contains("\"status\":\"retention_disabled\""));
+    }
+
+    @Test
+    public void testToXContentOmitsNullMessage() throws IOException {
+        MLExecuteMemoryRetentionResponse response = new MLExecuteMemoryRetentionResponse(TriggerStatus.TRIGGERED, null);
+        String json = toJson(response);
+        assertFalse(json.contains("\"message\""));
+    }
+
+    private String toJson(MLExecuteMemoryRetentionResponse response) throws IOException {
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(XContentType.JSON);
+        response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return builder.toString();
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
@@ -21,6 +21,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetenti
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
+import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.tasks.Task;
@@ -47,6 +48,7 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
     final ClusterService clusterService;
     final ThreadPool threadPool;
     final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    final MemoryContainerHelper memoryContainerHelper;
 
     @Inject
     public TransportExecuteMemoryRetentionAction(
@@ -55,13 +57,15 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
         Client client,
         ClusterService clusterService,
         ThreadPool threadPool,
-        MLFeatureEnabledSetting mlFeatureEnabledSetting
+        MLFeatureEnabledSetting mlFeatureEnabledSetting,
+        MemoryContainerHelper memoryContainerHelper
     ) {
         super(MLExecuteMemoryRetentionAction.NAME, transportService, actionFilters, MLExecuteMemoryRetentionRequest::new);
         this.client = client;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+        this.memoryContainerHelper = memoryContainerHelper;
     }
 
     @Override
@@ -77,7 +81,7 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
         // lower-privilege caller from forcing early deletion of data they could not otherwise reach, while
         // still allowing the scheduled run (which uses the system context, no user) to proceed normally.
         User user = RestActionUtils.getUserContext(client);
-        if (user != null && (user.getRoles() == null || !user.getRoles().contains("all_access"))) {
+        if (user != null && !memoryContainerHelper.isAdminUser(user)) {
             actionListener
                 .onFailure(
                     new OpenSearchStatusException(
@@ -128,8 +132,6 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
             case REMOTE_METADATA_STORE:
                 return "Memory retention job cannot run while a remote metadata store is configured; "
                     + "the container registry is not in the local cluster.";
-            case MULTI_TENANCY_ENABLED:
-                return "Memory retention job cannot run while multi-tenancy is enabled; the native client lacks tenant routing.";
             default:
                 return null;
         }

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer;
+
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Triggers the memory retention job on demand. Delegates to the same
+ * {@link MemoryRetentionJobProcessor} singleton the scheduler uses and invokes its
+ * {@link MemoryRetentionJobProcessor#triggerRun()} guard-and-kickoff path, so behavior is identical
+ * to a scheduled run. The pipeline is fully async; this action acknowledges the trigger promptly and
+ * does not block until deletions complete.
+ */
+@Log4j2
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class TransportExecuteMemoryRetentionAction extends HandledTransportAction<ActionRequest, MLExecuteMemoryRetentionResponse> {
+
+    final Client client;
+    final ClusterService clusterService;
+    final ThreadPool threadPool;
+    final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Inject
+    public TransportExecuteMemoryRetentionAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        MLFeatureEnabledSetting mlFeatureEnabledSetting
+    ) {
+        super(MLExecuteMemoryRetentionAction.NAME, transportService, actionFilters, MLExecuteMemoryRetentionRequest::new);
+        this.client = client;
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    @Override
+    protected void doExecute(Task task, ActionRequest request, ActionListener<MLExecuteMemoryRetentionResponse> actionListener) {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            actionListener.onFailure(new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN));
+            return;
+        }
+
+        try {
+            // Reuse the scheduler's per-node singleton so the on-demand trigger and the scheduled run
+            // share the same in-progress guard ON THIS NODE. This dedupes the common cases (repeated
+            // triggers, or a trigger racing the scheduler, when both land on the same node). NOTE: the
+            // guard is a per-JVM AtomicBoolean and this action runs locally on the coordinating node
+            // WITHOUT the scheduler's cluster-wide LockService lock, so it does not prevent a trigger on
+            // one node from running concurrently with the scheduled run (or another trigger) on a
+            // different node. The pipeline tolerates this (deletes are idempotent, version conflicts are
+            // handled, orphan sweep is baseline-gated); cluster-wide mutual exclusion would require
+            // routing this path through LockService and is intentionally out of scope here.
+            MemoryRetentionJobProcessor processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+            TriggerStatus status = processor.triggerRun();
+            actionListener.onResponse(new MLExecuteMemoryRetentionResponse(status, messageFor(status)));
+        } catch (Exception e) {
+            log.error("Failed to trigger memory retention job on demand", e);
+            actionListener
+                .onFailure(new OpenSearchStatusException("Failed to trigger memory retention job", RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private static String messageFor(TriggerStatus status) {
+        switch (status) {
+            case TRIGGERED:
+                return "Memory retention job triggered. Deletions run asynchronously per configured retention policy.";
+            case ALREADY_RUNNING:
+                return "Memory retention job is already in progress; this invocation was skipped to avoid double-running.";
+            case RETENTION_DISABLED:
+                return "Memory retention is disabled (plugins.ml_commons.memory.retention_enabled=false); nothing was triggered.";
+            case MULTI_TENANCY_ENABLED:
+                return "Memory retention job cannot run while multi-tenancy is enabled; the native client lacks tenant routing.";
+            default:
+                return null;
+        }
+    }
+}

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
@@ -13,6 +13,7 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
@@ -21,6 +22,7 @@ import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetenti
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
 import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.ml.utils.RestActionUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -66,6 +68,23 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
     protected void doExecute(Task task, ActionRequest request, ActionListener<MLExecuteMemoryRetentionResponse> actionListener) {
         if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
             actionListener.onFailure(new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN));
+            return;
+        }
+
+        // Admin-only: this triggers a CLUSTER-WIDE retention run that evaluates every container's policy and
+        // deletes expired memories across the cluster. Unlike per-container operations, there is no single
+        // container whose access we can check, so we restrict it to admins (all_access). This prevents a
+        // lower-privilege caller from forcing early deletion of data they could not otherwise reach, while
+        // still allowing the scheduled run (which uses the system context, no user) to proceed normally.
+        User user = RestActionUtils.getUserContext(client);
+        if (user != null && (user.getRoles() == null || !user.getRoles().contains("all_access"))) {
+            actionListener
+                .onFailure(
+                    new OpenSearchStatusException(
+                        "Only administrators (all_access) may trigger the memory retention job on demand.",
+                        RestStatus.FORBIDDEN
+                    )
+                );
             return;
         }
 

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionAction.java
@@ -33,7 +33,7 @@ import lombok.extern.log4j.Log4j2;
 /**
  * Triggers the memory retention job on demand. Delegates to the same
  * {@link MemoryRetentionJobProcessor} singleton the scheduler uses and invokes its
- * {@link MemoryRetentionJobProcessor#triggerRun()} guard-and-kickoff path, so behavior is identical
+ * {@link MemoryRetentionJobProcessor#triggerRun(org.opensearch.core.action.ActionListener)} guard-and-kickoff path, so behavior is identical
  * to a scheduled run. The pipeline is fully async; this action acknowledges the trigger promptly and
  * does not block until deletions complete.
  */
@@ -70,18 +70,27 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
         }
 
         try {
-            // Reuse the scheduler's per-node singleton so the on-demand trigger and the scheduled run
-            // share the same in-progress guard ON THIS NODE. This dedupes the common cases (repeated
-            // triggers, or a trigger racing the scheduler, when both land on the same node). NOTE: the
-            // guard is a per-JVM AtomicBoolean and this action runs locally on the coordinating node
-            // WITHOUT the scheduler's cluster-wide LockService lock, so it does not prevent a trigger on
-            // one node from running concurrently with the scheduled run (or another trigger) on a
-            // different node. The pipeline tolerates this (deletes are idempotent, version conflicts are
-            // handled, orphan sweep is baseline-gated); cluster-wide mutual exclusion would require
-            // routing this path through LockService and is intentionally out of scope here.
+            // Reuse the scheduler's per-node singleton so the on-demand trigger and the scheduled run share
+            // the same in-progress guard ON THIS NODE and, crucially, the same cluster-wide JobScheduler
+            // LockService lock. triggerRun() acquires that lock (same lock index + doc id the scheduled run
+            // uses) and HOLDS it for the whole async delete pipeline, so an on-demand trigger on one node
+            // will report ALREADY_RUNNING rather than overlap a scheduled (or on-demand) run on another node.
+            // The call is async because lock acquisition is async; it reports the outcome via the listener.
             MemoryRetentionJobProcessor processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
-            TriggerStatus status = processor.triggerRun();
-            actionListener.onResponse(new MLExecuteMemoryRetentionResponse(status, messageFor(status)));
+            processor
+                .triggerRun(
+                    ActionListener
+                        .wrap(status -> actionListener.onResponse(new MLExecuteMemoryRetentionResponse(status, messageFor(status))), e -> {
+                            log.error("Failed to trigger memory retention job on demand", e);
+                            actionListener
+                                .onFailure(
+                                    new OpenSearchStatusException(
+                                        "Failed to trigger memory retention job",
+                                        RestStatus.INTERNAL_SERVER_ERROR
+                                    )
+                                );
+                        })
+                );
         } catch (Exception e) {
             log.error("Failed to trigger memory retention job on demand", e);
             actionListener
@@ -97,6 +106,9 @@ public class TransportExecuteMemoryRetentionAction extends HandledTransportActio
                 return "Memory retention job is already in progress; this invocation was skipped to avoid double-running.";
             case RETENTION_DISABLED:
                 return "Memory retention is disabled (plugins.ml_commons.memory.retention_enabled=false); nothing was triggered.";
+            case REMOTE_METADATA_STORE:
+                return "Memory retention job cannot run while a remote metadata store is configured; "
+                    + "the container registry is not in the local cluster.";
             case MULTI_TENANCY_ENABLED:
                 return "Memory retention job cannot run while multi-tenancy is enabled; the native client lacks tenant routing.";
             default:

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunAction.java
@@ -336,21 +336,33 @@ public class TransportMemoryRetentionDryRunAction extends HandledTransportAction
             // resumes the drain; whichever arrives first simply hands off. A synchronous callback (mocked client)
             // arrives first, so the loop below observes handoff already set and continues iteratively (no recursion).
             final java.util.concurrent.atomic.AtomicBoolean handoff = new java.util.concurrent.atomic.AtomicBoolean(false);
-            processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
-                results.add(result);
-                index[0]++;
-                if (!handoff.compareAndSet(false, true)) {
-                    // Loop already yielded (async completion): this callback is the second arriver, resume draining.
-                    drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
-                }
-            }, e -> {
-                log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
+            try {
+                processor.dryRunContainer(container.getConfiguration(), containerId, baseline, ActionListener.wrap(result -> {
+                    results.add(result);
+                    index[0]++;
+                    if (!handoff.compareAndSet(false, true)) {
+                        // Loop already yielded (async completion): this callback is the second arriver, resume draining.
+                        drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
+                    }
+                }, e -> {
+                    log.warn("Skipping container {} in retention dry-run: evaluation failed", containerId, e);
+                    skipped[0]++;
+                    index[0]++;
+                    if (!handoff.compareAndSet(false, true)) {
+                        drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
+                    }
+                }));
+            } catch (Exception e) {
+                // dryRunContainer threw synchronously before ever invoking the listener (e.g. a client that rejects
+                // the dispatch inline). Mirror the async onFailure handler so the container is skipped and the drain
+                // still advances, instead of leaking the exception up and aborting the whole page.
+                log.warn("Skipping container {} in retention dry-run: dispatch failed", containerId, e);
                 skipped[0]++;
                 index[0]++;
                 if (!handoff.compareAndSet(false, true)) {
                     drainPage(processor, user, tenantId, hits, index, nextPageSort, results, skipped, truncated, listener);
                 }
-            }));
+            }
             if (handoff.compareAndSet(false, true)) {
                 // Callback has not fired yet (async): yield; the callback will resume the drain when it arrives.
                 return;

--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -182,24 +182,19 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                 // TODO: use LLM to summarize first user message
                 ActionListener<String> summaryListener = ActionListener.wrap(summary -> {
                     Instant now = Instant.now();
-                    indexRequest
-                        .source(
-                            Map
-                                .of(
-                                    OWNER_ID_FIELD,
-                                    input.getOwnerId(),
-                                    MEMORY_CONTAINER_ID_FIELD,
-                                    input.getMemoryContainerId(),
-                                    SUMMARY_FIELD,
-                                    summary,
-                                    NAMESPACE_FIELD,
-                                    input.getNamespace(),
-                                    CREATED_TIME_FIELD,
-                                    now.toEpochMilli(),
-                                    LAST_UPDATED_TIME_FIELD,
-                                    now.toEpochMilli()
-                                )
-                        );
+                    // Build the source with a mutable map: owner_id is absent when the security plugin is
+                    // disabled (no authenticated user), and Map.of() rejects null values. This mirrors the
+                    // null-safe owner_id handling in processAndIndexMemory below.
+                    Map<String, Object> sessionSource = new HashMap<>();
+                    if (input.getOwnerId() != null) {
+                        sessionSource.put(OWNER_ID_FIELD, input.getOwnerId());
+                    }
+                    sessionSource.put(MEMORY_CONTAINER_ID_FIELD, input.getMemoryContainerId());
+                    sessionSource.put(SUMMARY_FIELD, summary);
+                    sessionSource.put(NAMESPACE_FIELD, input.getNamespace());
+                    sessionSource.put(CREATED_TIME_FIELD, now.toEpochMilli());
+                    sessionSource.put(LAST_UPDATED_TIME_FIELD, now.toEpochMilli());
+                    indexRequest.source(sessionSource);
                     indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     ActionListener<IndexResponse> responseActionListener = ActionListener.<IndexResponse>wrap(r -> {
                         input.getNamespace().put(SESSION_ID_FIELD, r.getId());

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -77,17 +77,18 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
     /**
      * Single-writer gate for memory-retention job writes that mutate the shared, fixed-id job document. Exactly one
      * node (the elected cluster manager) should ever upsert/reconcile, and only when agentic memory AND memory
-     * retention are enabled and multi-tenancy is disabled (mirroring the startup scheduling path exactly). The
-     * {@link #jobsIndexReadyForWrite()} check mirrors the startup loop's rolling-upgrade guard so a live setting
-     * change during a mixed-version upgrade does not create the new {@code .plugins-ml-jobs} index before the
-     * cluster is ready for it.
+     * retention are enabled (mirroring the startup scheduling path exactly). The {@link #jobsIndexReadyForWrite()}
+     * check mirrors the startup loop's rolling-upgrade guard so a live setting change during a mixed-version upgrade
+     * does not create the new {@code .plugins-ml-jobs} index before the cluster is ready for it. The retention job
+     * schedules and runs under multi-tenancy too: it is a single cluster-wide, system-context janitor that cleans
+     * every container across every tenant, with per-container memory_container_id filters providing tenant isolation.
+     * See RFC #4859.
      */
     private boolean shouldManageMemoryRetentionJob() {
         return clusterService.state().nodes().isLocalNodeElectedClusterManager()
             && jobsIndexReadyForWrite()
             && mlFeatureEnabledSetting.isAgenticMemoryEnabled()
-            && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
-            && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings());
+            && mlFeatureEnabledSetting.isMemoryRetentionEnabled();
     }
 
     /**
@@ -167,7 +168,6 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
 
             if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                 && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
-                && !MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED.get(clusterService.getSettings())
                 && !this.startedMemoryRetentionJob) {
                 // Read the effective interval, honoring OpenSearch precedence (transient > persistent > opensearch.yml
                 // > default). clusterService.getSettings() holds only node bootstrap settings (opensearch.yml / CLI),

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -82,13 +82,16 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
      * does not create the new {@code .plugins-ml-jobs} index before the cluster is ready for it. The retention job
      * schedules and runs under multi-tenancy too: it is a single cluster-wide, system-context janitor that cleans
      * every container across every tenant, with per-container memory_container_id filters providing tenant isolation.
-     * See RFC #4859.
+     * It is NOT scheduled when a remote metadata store is configured (e.g. AWS OpenSearch Serverless / DynamoDB),
+     * because the container registry then lives outside the local cluster and the native-client job cannot enumerate
+     * it; self-hosted (local metadata) multi-tenancy is fully supported. See RFC #4859.
      */
     private boolean shouldManageMemoryRetentionJob() {
         return clusterService.state().nodes().isLocalNodeElectedClusterManager()
             && jobsIndexReadyForWrite()
             && mlFeatureEnabledSetting.isAgenticMemoryEnabled()
-            && mlFeatureEnabledSetting.isMemoryRetentionEnabled();
+            && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
+            && !MLCommonsSettings.isRemoteMetadataStore(clusterService.getSettings());
     }
 
     /**
@@ -166,9 +169,13 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 this.startedStatsJob = true;
             }
 
+            // Skip when a remote metadata store is configured: the container registry lives outside the local
+            // cluster, so the native-client retention job cannot enumerate containers. Local-metadata
+            // multi-tenancy is fully supported. See RFC #4859.
             if (mlFeatureEnabledSetting.isAgenticMemoryEnabled()
                 && mlFeatureEnabledSetting.isMemoryRetentionEnabled()
-                && !this.startedMemoryRetentionJob) {
+                && !this.startedMemoryRetentionJob
+                && !MLCommonsSettings.isRemoteMetadataStore(clusterService.getSettings())) {
                 // Read the effective interval, honoring OpenSearch precedence (transient > persistent > opensearch.yml
                 // > default). clusterService.getSettings() holds only node bootstrap settings (opensearch.yml / CLI),
                 // frozen at construction; state.getMetadata().settings() holds the persistent/transient values set via

--- a/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
+++ b/plugin/src/main/java/org/opensearch/ml/cluster/MLCommonsClusterEventListener.java
@@ -178,11 +178,16 @@ public class MLCommonsClusterEventListener implements ClusterStateListener {
                 && !MLCommonsSettings.isRemoteMetadataStore(clusterService.getSettings())) {
                 // Read the effective interval, honoring OpenSearch precedence (transient > persistent > opensearch.yml
                 // > default). clusterService.getSettings() holds only node bootstrap settings (opensearch.yml / CLI),
-                // frozen at construction; state.getMetadata().settings() holds the persistent/transient values set via
-                // PUT _cluster/settings. Overlaying metadata on the node settings lets dynamic cluster settings win
-                // while still honoring an opensearch.yml value. Reading only one source would drop the other and make
-                // reconcile (which actively upserts on mismatch) revert an operator's chosen interval on restart.
-                Settings effectiveSettings = Settings.builder().put(clusterService.getSettings()).put(settings).build();
+                // frozen at construction; the cluster state's persistent/transient settings hold the values set via
+                // PUT _cluster/settings. Overlay them so dynamic cluster settings win while still honoring an
+                // opensearch.yml value. Reading only the node settings would drop dynamic values and make reconcile
+                // (which actively upserts on mismatch) revert an operator's chosen interval on restart.
+                Settings effectiveSettings = Settings
+                    .builder()
+                    .put(clusterService.getSettings())
+                    .put(state.getMetadata().persistentSettings())
+                    .put(state.getMetadata().transientSettings())
+                    .build();
                 int intervalHours = MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.get(effectiveSettings);
                 // CREATE (conflict-swallowing) seeds the job doc; safe to run on any node.
                 mlTaskManager.indexMemoryRetentionJob(intervalHours);

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
@@ -158,6 +159,29 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      */
     private static volatile LockService lockService;
 
+    /**
+     * How long the {@link #isRunning} guard may stay held before {@link #triggerRun(ActionListener)} treats it
+     * as leaked. The run is a fully asynchronous callback chain: an unhandled throw on a thread we do not wrap
+     * (e.g. a transport/listener thread deep in a continuation whose {@code onFailure} itself throws)
+     * can leave {@code isRunning} stuck {@code true}, after which every future invocation logs
+     * "already in progress, skipping" and retention silently stops until the node restarts. The
+     * watchdog in {@link #triggerRun(ActionListener)} recovers from that without a restart.
+     *
+     * <p>This bound is a heuristic, not a hard guarantee that a healthy run finishes within it. A
+     * run's wall-clock time is roughly (containers-with-deletions &times; per-container throttle,
+     * capped at 60s each) plus per-container I/O plus the orphan sweep, so on a very large cluster
+     * with an elevated throttle a legitimate run could in principle approach 24h. The watchdog is
+     * deliberately conservative about that: on a suspected leak it only tears the guard down (via
+     * {@link #finishRun()}, which also stops lock renewal and releases the cluster-wide lock) and
+     * skips the current invocation — it never aborts the in-flight run and never starts a second run
+     * itself. The worst case of a false positive is therefore that the next scheduled run overlaps a
+     * still-live one, doing duplicate but idempotent deletes (same tolerated outcome as the cross-node
+     * overlap noted in the 3.9 handoff §5.1). Recovery from a genuine leak costs at most one job
+     * interval. 24h comfortably exceeds any run on a normally-provisioned cluster while keeping the
+     * false-positive rate negligible.
+     */
+    static final long STUCK_GUARD_TIMEOUT_MILLIS = TimeUnit.HOURS.toMillis(24);
+
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     /**
@@ -172,6 +196,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     /** Cancellable handle for the periodic lock-renewal task of the in-progress run, or null when idle. */
     private final AtomicReference<Scheduler.Cancellable> lockRenewalTask = new AtomicReference<>();
+
+    /**
+     * Wall-clock time (epoch millis) at which the current run acquired {@link #isRunning}, or
+     * {@link Long#MIN_VALUE} when no run holds the guard. Read by the stuck-guard watchdog in
+     * {@link #triggerRun(ActionListener)} to decide whether a still-set guard has outlived
+     * {@link #STUCK_GUARD_TIMEOUT_MILLIS}. Set when the guard is claimed and cleared by {@link #finishRun()}.
+     */
+    private final AtomicLong runStartMillis = new AtomicLong(Long.MIN_VALUE);
 
     public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
         if (instance != null) {
@@ -281,10 +313,37 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // Per-node single-flight guard. Claimed here; released by finishRun() (success/terminal/error) or
         // immediately below if the cluster-wide lock is already held elsewhere / cannot be acquired.
         if (!isRunning.compareAndSet(false, true)) {
-            log.warn("Memory retention job already in progress on this node, skipping this invocation");
+            // The guard is held. Normally that means a prior run is genuinely still in flight, so we
+            // skip. But because the run is a fully async callback chain, an unhandled throw on a
+            // thread we cannot wrap can leave the guard stuck true forever, silently disabling
+            // retention until node restart. Detect that: if the holder acquired the guard longer ago
+            // than any run should plausibly last, assume it leaked and tear it down (finishRun() also
+            // stops lock renewal and releases the cluster-wide lock) so the NEXT invocation can start
+            // cleanly. We deliberately do NOT take over and start a run here: if this were a false
+            // positive (a genuinely long run), starting a second chain now — with no per-run ownership
+            // on the shared finishRun() teardown — could let the two runs race the guard and cascade
+            // into several concurrent runs. Clearing-and-skipping caps the worst case at one overlapping
+            // run of idempotent deletes on the following interval.
+            long heldSince = runStartMillis.get();
+            long heldForMillis = System.currentTimeMillis() - heldSince;
+            if (heldSince == Long.MIN_VALUE || heldForMillis < STUCK_GUARD_TIMEOUT_MILLIS) {
+                log.warn("Memory retention job already in progress on this node, skipping this invocation");
+                listener.onResponse(TriggerStatus.ALREADY_RUNNING);
+                return;
+            }
+            log
+                .error(
+                    "Memory retention job guard appears stuck (held for {} ms, exceeds {} ms); clearing it so the next "
+                        + "scheduled run can proceed. A prior run likely failed without releasing the guard.",
+                    heldForMillis,
+                    STUCK_GUARD_TIMEOUT_MILLIS
+                );
+            finishRun();
             listener.onResponse(TriggerStatus.ALREADY_RUNNING);
             return;
         }
+
+        runStartMillis.set(System.currentTimeMillis());
 
         LockService ls = lockService;
         if (ls == null) {
@@ -300,8 +359,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             ls.acquireLockWithId(ML_JOBS_INDEX, LOCK_DURATION_SECONDS, MLJobType.MEMORY_RETENTION.name(), ActionListener.wrap(lock -> {
                 if (lock == null) {
                     // A run is already in progress cluster-wide (another node, or the scheduler, holds
-                    // the lock). Release the per-node guard and report already-running.
-                    isRunning.set(false);
+                    // the lock). Release the per-node guard (and start-time stamp) and report already-running.
+                    finishRun();
                     log.info("Memory retention job already running cluster-wide (lock held); skipping this invocation");
                     listener.onResponse(TriggerStatus.ALREADY_RUNNING);
                     return;
@@ -310,12 +369,12 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 startLockRenewal();
                 kickOffPipeline(listener);
             }, e -> {
-                isRunning.set(false);
+                finishRun();
                 log.error("Failed to acquire cluster-wide lock for memory retention job", e);
                 listener.onFailure(e);
             }));
         } catch (Exception e) {
-            isRunning.set(false);
+            finishRun();
             log.error("Failed to acquire cluster-wide lock for memory retention job", e);
             listener.onFailure(e);
         }
@@ -429,6 +488,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 log.error("Failed to release cluster-wide memory retention lock; it will expire after its TTL", e);
             }
         }
+        // Clear the watchdog start-time stamp before releasing the guard so a subsequent invocation never sees a
+        // stale timestamp against a freshly-cleared guard.
+        runStartMillis.set(Long.MIN_VALUE);
         isRunning.set(false);
         log.info("Memory retention job completed");
     }
@@ -438,6 +500,16 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // or during node shutdown) must still tear the run down. Otherwise the escaped exception would leave
         // isRunning stuck true AND the lock-renewal task alive, renewing the cluster-wide lock forever and
         // wedging retention cluster-wide until node restart.
+        //
+        // Teardown vs. propagation depends on WHICH dispatch this is, distinguished by searchAfterValues:
+        // - Initial kickoff (searchAfterValues == null, called only from kickOffPipeline): after tearing down
+        // we RETHROW so kickOffPipeline reports the failure to the trigger listener and the on-demand
+        // transport surfaces HTTP 500 (the pipeline never actually started).
+        // - Pagination continuation (searchAfterValues != null, re-entered from processContainerChain inside a
+        // container's ActionListener): we must NOT rethrow. That callback's onFailure retries the chain, so a
+        // rethrow would loop; the run has genuinely started, so we simply tear down and stop. finishRun() is
+        // idempotent.
+        boolean initialKickoff = searchAfterValues == null;
         try {
             SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
             request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
@@ -477,6 +549,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         } catch (Exception e) {
             log.error("Unexpected error dispatching container search for memory retention", e);
             finishRun();
+            if (initialKickoff) {
+                throw e;
+            }
         }
     }
 
@@ -506,12 +581,16 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         int throttleSeconds = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS);
         try {
             threadPool.schedule(() -> {
-                // Guard the scheduled task body too: it re-enters the driver (which may synchronously dispatch
-                // the next search), and a throw here runs on a scheduler thread with no other teardown in scope.
+                // This runnable executes later on the GENERIC pool, outside any ActionListener that would route a
+                // throw to onFailure. It re-enters the driver (which may synchronously dispatch the next search),
+                // and if processContainerChain throws (e.g. client.search rejects work during node shutdown) the
+                // throw would be swallowed by the executor and the run's state would never reset, silently wedging
+                // retention AND leaving the lock-renewal task alive forever. Guarantee a full teardown on any
+                // unhandled failure.
                 try {
                     processContainerChain(hits, nextIndex, nextPageSortValues);
-                } catch (Exception e) {
-                    log.error("Unexpected error resuming container processing for memory retention", e);
+                } catch (Throwable t) {
+                    log.error("Unhandled error resuming container processing chain; releasing retention guard", t);
                     finishRun();
                 }
             }, TimeValue.timeValueSeconds(throttleSeconds), ThreadPool.Names.GENERIC);

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -262,6 +262,9 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     @VisibleForTesting
     public static synchronized void reset() {
         instance = null;
+        // Clear the static LockService too so a fresh getInstance() after reset() starts clean and does not
+        // inherit a stale lock service from a previous lifecycle. Tests re-inject via setLockService().
+        lockService = null;
     }
 
     /**
@@ -585,7 +588,6 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             }
         }
         releaseGuard();
-        log.info("Memory retention job completed");
     }
 
     /**
@@ -639,6 +641,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     SearchHit[] hitArray = hits.getHits();
 
                     if (hitArray.length == 0) {
+                        // No containers carry a retention policy: nothing to delete, the run is complete.
+                        log.info("Memory retention job completed");
                         finishRun();
                         return;
                     }
@@ -1785,6 +1789,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     SearchHit[] hitArray = hits.getHits();
 
                     if (hitArray.length == 0) {
+                        // No containers to orphan-sweep: the run has finished all its work.
+                        log.info("Memory retention job completed");
                         finishRun();
                         return;
                     }
@@ -1807,6 +1813,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             if (nextPageSortValues != null) {
                 resolveOrphanSweepContainers(nextPageSortValues);
             } else {
+                // Final page of the orphan sweep processed: the full retention run is complete.
+                log.info("Memory retention job completed");
                 finishRun();
             }
             return;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.ml.jobs.processors;
 
+import static org.opensearch.ml.common.CommonValue.ML_JOBS_INDEX;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.AGENT_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.CREATED_TIME_FIELD;
@@ -39,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -69,12 +71,17 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.jobscheduler.spi.JobExecutionContext;
+import org.opensearch.jobscheduler.spi.LockModel;
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
 import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
+import org.opensearch.ml.jobs.MLJobType;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
 import org.opensearch.search.SearchHit;
@@ -84,6 +91,7 @@ import org.opensearch.search.aggregations.bucket.composite.CompositeAggregationB
 import org.opensearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -121,9 +129,49 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      */
     private static final long EPOCH_SECOND_DETECTION_THRESHOLD = 10_000_000_000L;
 
+    /**
+     * Duration, in seconds, of the cluster-wide JobScheduler lock acquired for a run. Matches the
+     * {@code lockDurationSeconds} the scheduled job document is registered with (see
+     * {@code MLTaskManager#indexMemoryRetentionJob}) so the on-demand and scheduled paths request an
+     * identically-scoped lock. The retention pipeline is fully async and throttled and can outlive this
+     * TTL, so the lock is periodically renewed (see {@link #LOCK_RENEWAL_SECONDS}) for as long as the run
+     * is in progress; the TTL is the ceiling on how long a stale lock survives a node crash mid-run.
+     */
+    private static final long LOCK_DURATION_SECONDS = 120L;
+
+    /**
+     * How often (seconds) the held cluster-wide lock is renewed while a run is in progress. Set to a third of
+     * {@link #LOCK_DURATION_SECONDS} so at least two renewal attempts land before the lock could expire — one
+     * slow or failed renewal still leaves a retry with margin to spare, rather than racing the TTL.
+     */
+    private static final long LOCK_RENEWAL_SECONDS = 40L;
+
     private static volatile MemoryRetentionJobProcessor instance;
 
+    /**
+     * Process-wide handle to the JobScheduler {@link LockService}, injected once at node start via the
+     * plugin's Guice service holder (the impl lives in the job-scheduler plugin and is only reachable at
+     * runtime). It is the SAME instance the scheduled run receives through {@code JobExecutionContext}, so
+     * a lock acquired on the on-demand path and one acquired on the scheduled path are the same document in
+     * the same lock index. When null (e.g. job-scheduler not installed, or a unit test that does not wire
+     * it) the processor degrades to the per-node {@link #isRunning} guard only and logs a warning.
+     */
+    private static volatile LockService lockService;
+
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
+    /**
+     * The cluster-wide lock currently held by an in-progress run, or null when idle. Advanced on each
+     * successful {@code renewLock} (which returns a new {@link LockModel} carrying fresh seqNo/primaryTerm) so
+     * the NEXT renewal's seqNo-gated update targets the current version; teardown itself deletes by stable lock
+     * id (see {@link #finishRun()}) and so does not depend on this being the latest version. Guarded for
+     * visibility by being an {@link AtomicReference}; only one run is ever in flight at a time (enforced by
+     * {@link #isRunning}) so there is no contended mutation.
+     */
+    private final AtomicReference<LockModel> currentLock = new AtomicReference<>();
+
+    /** Cancellable handle for the periodic lock-renewal task of the in-progress run, or null when idle. */
+    private final AtomicReference<Scheduler.Cancellable> lockRenewalTask = new AtomicReference<>();
 
     public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
         if (instance != null) {
@@ -145,46 +193,63 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         instance = null;
     }
 
+    /**
+     * Injects the process-wide JobScheduler {@link LockService}. Called once at node start from the
+     * plugin's Guice service holder. Idempotent and null-tolerant: passing null (or never calling this)
+     * leaves the processor on the per-node guard only.
+     */
+    public static void setLockService(LockService lockService) {
+        MemoryRetentionJobProcessor.lockService = lockService;
+    }
+
+    @VisibleForTesting
+    static LockService getLockService() {
+        return lockService;
+    }
+
     public MemoryRetentionJobProcessor(ClusterService clusterService, Client client, ThreadPool threadPool) {
         super(clusterService, client, threadPool);
     }
 
+    /**
+     * Scheduled entry point (invoked from {@link #process(ScheduledJobParameter, JobExecutionContext)}).
+     * Fire-and-forget: kicks off the async pipeline via {@link #triggerRun(ActionListener)} and only logs
+     * the outcome, preserving the pre-refactor scheduled semantics where a run never propagates a failure
+     * back to the JobScheduler thread.
+     */
     @Override
     public void run() {
-        // The scheduled path ignores the returned status (it is only logged inside triggerRun);
-        // the on-demand API path calls triggerRun() directly to surface the status to the caller.
-        // Both share the exact same guards and pipeline kickoff so behavior is identical. The
-        // scheduled path additionally swallows a synchronous kickoff failure (already logged and the
-        // in-progress guard already released inside triggerRun) exactly as it did before this method
-        // was refactored, so a fire-and-forget scheduled run never propagates.
-        try {
-            triggerRun();
-        } catch (Exception e) {
-            // Swallowed on purpose: preserves pre-refactor fire-and-forget scheduled semantics.
-            // triggerRun() has already error-logged and reset the in-progress guard before rethrowing.
-            log.trace("Scheduled memory retention run kickoff failed (already handled by triggerRun)", e);
-        }
+        triggerRun(ActionListener.wrap(status -> {
+            if (status != TriggerStatus.TRIGGERED) {
+                log.info("Scheduled memory retention run not started: {}", status.getValue());
+            }
+        }, e -> log.error("Scheduled memory retention run failed to start", e)));
     }
 
     /**
-     * Applies the retention job's gating (remote-metadata-store skip, retention_enabled, single-flight in-progress
-     * guard) and, when all pass, kicks off the full async retention pipeline via
-     * {@link #resolveContainersWithPolicies(Object[])} exactly as the scheduled run does. Returns
-     * promptly with a {@link TriggerStatus} describing the outcome; it does NOT block until the
-     * (fully async) delete pipeline completes. When {@link TriggerStatus#TRIGGERED} is returned the
-     * in-progress guard has been claimed and will be released by {@link #onJobComplete()} (or on a
-     * synchronous kickoff failure below); for every other status no guard is held and no state is
-     * mutated, so a caller can safely retry.
+     * The single source of truth for both the scheduled {@link #run()} and the on-demand transport action:
+     * applies the retention job's gating (remote-metadata-store skip, retention_enabled), then acquires mutual
+     * exclusion and, when all pass, kicks off the full async retention pipeline. Reports the outcome via
+     * {@code listener} as a {@link TriggerStatus}; it does NOT block until the (fully async) delete pipeline completes.
      *
-     * <p>This is the single source of truth for both the scheduled {@link #run()} and the on-demand
-     * transport action, so the two can never diverge. The in-progress guard is a per-JVM
-     * {@link AtomicBoolean}: it serializes invocations on THIS node (the scheduler additionally holds a
-     * cluster-wide JobScheduler lock, but the on-demand path does not), so it does not by itself
-     * prevent a run on another node from overlapping.
+     * <p><b>Two layers of mutual exclusion.</b> A per-JVM {@link #isRunning} guard serializes invocations on
+     * THIS node, and the cluster-wide JobScheduler {@link LockService} lock (same lock index and doc id the
+     * scheduled run uses — keyed on {@link MLJobType#MEMORY_RETENTION} in {@link org.opensearch.ml.common.CommonValue#ML_JOBS_INDEX})
+     * serializes across nodes. Unlike the base {@link MLJobProcessor#process} — which releases its lock the
+     * instant {@code run()} returns, i.e. right after the pipeline is merely <em>dispatched</em> — this path
+     * HOLDS the lock for the entire pipeline lifetime and renews it periodically (see {@link #startLockRenewal()}),
+     * releasing only at every terminal/error exit via {@link #finishRun()}. That is what actually prevents an
+     * on-demand trigger on one node from overlapping a scheduled (or on-demand) run on another.
      *
-     * @return the job-level outcome of this invocation
+     * <p>When {@link TriggerStatus#TRIGGERED} is reported the guard is held and the lock is owned; both are
+     * released by {@link #finishRun()}. For every other status no guard is held and no lock is owned, so a
+     * caller can safely retry. If the JobScheduler {@link LockService} is unavailable (not installed, or not
+     * wired in a unit test) the run proceeds under the per-node guard only, logged as a warning.
+     *
+     * @param listener receives the job-level outcome (onFailure only for an unexpected error, which the
+     *                 transport layer surfaces as HTTP 500)
      */
-    public TriggerStatus triggerRun() {
+    public void triggerRun(ActionListener<TriggerStatus> listener) {
         // The retention job is a single cluster-wide, system-context janitor. Under multi-tenancy it still scans the
         // one global container registry (matchAllQuery) and cleans EVERY container regardless of tenant. Tenant
         // isolation is achieved per-container: each per-container search/delete is bounded by
@@ -203,65 +268,215 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     "Memory retention job skipped: remote metadata store is configured; the container registry is not "
                         + "in the local cluster, so the retention job cannot enumerate containers. See RFC #4859."
                 );
-            return TriggerStatus.REMOTE_METADATA_STORE;
+            listener.onResponse(TriggerStatus.REMOTE_METADATA_STORE);
+            return;
         }
 
         if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
-            return TriggerStatus.RETENTION_DISABLED;
+            listener.onResponse(TriggerStatus.RETENTION_DISABLED);
+            return;
         }
 
+        // Per-node single-flight guard. Claimed here; released by finishRun() (success/terminal/error) or
+        // immediately below if the cluster-wide lock is already held elsewhere / cannot be acquired.
         if (!isRunning.compareAndSet(false, true)) {
-            log.warn("Memory retention job already in progress, skipping this invocation");
-            return TriggerStatus.ALREADY_RUNNING;
+            log.warn("Memory retention job already in progress on this node, skipping this invocation");
+            listener.onResponse(TriggerStatus.ALREADY_RUNNING);
+            return;
+        }
+
+        LockService ls = lockService;
+        if (ls == null) {
+            // No cluster-wide lock available: degrade to per-node exclusion only. Safe on single-node; on
+            // multi-node this reopens the cross-node overlap window, but deletes are idempotent so it cannot
+            // corrupt data (duplicate work only).
+            log.warn("JobScheduler LockService unavailable; running memory retention with per-node mutual exclusion only");
+            kickOffPipeline(listener);
+            return;
         }
 
         try {
-            log.info("Memory retention job started");
-            resolveContainersWithPolicies(null);
-            return TriggerStatus.TRIGGERED;
+            ls.acquireLockWithId(ML_JOBS_INDEX, LOCK_DURATION_SECONDS, MLJobType.MEMORY_RETENTION.name(), ActionListener.wrap(lock -> {
+                if (lock == null) {
+                    // A run is already in progress cluster-wide (another node, or the scheduler, holds
+                    // the lock). Release the per-node guard and report already-running.
+                    isRunning.set(false);
+                    log.info("Memory retention job already running cluster-wide (lock held); skipping this invocation");
+                    listener.onResponse(TriggerStatus.ALREADY_RUNNING);
+                    return;
+                }
+                currentLock.set(lock);
+                startLockRenewal();
+                kickOffPipeline(listener);
+            }, e -> {
+                isRunning.set(false);
+                log.error("Failed to acquire cluster-wide lock for memory retention job", e);
+                listener.onFailure(e);
+            }));
         } catch (Exception e) {
-            log.error("Unexpected error starting memory retention job", e);
             isRunning.set(false);
-            throw e;
+            log.error("Failed to acquire cluster-wide lock for memory retention job", e);
+            listener.onFailure(e);
         }
     }
 
-    private void resolveContainersWithPolicies(Object[] searchAfterValues) {
-        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
-        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
-
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(QueryBuilders.matchAllQuery())
-            .size(CONTAINER_PAGE_SIZE)
-            .sort("_id", SortOrder.ASC)
-            .fetchSource(true);
-
-        if (searchAfterValues != null) {
-            sourceBuilder.searchAfter(searchAfterValues);
+    /**
+     * Kicks off the async delete pipeline. On a synchronous kickoff failure it tears down all held state
+     * ({@link #finishRun()}) and reports the failure; otherwise it reports {@link TriggerStatus#TRIGGERED}
+     * and the pipeline releases everything at its own terminal points. The in-progress guard is assumed
+     * already held by the caller.
+     */
+    private void kickOffPipeline(ActionListener<TriggerStatus> listener) {
+        try {
+            log.info("Memory retention job started");
+            resolveContainersWithPolicies(null);
+            listener.onResponse(TriggerStatus.TRIGGERED);
+        } catch (Exception e) {
+            log.error("Unexpected error starting memory retention job", e);
+            finishRun();
+            listener.onFailure(e);
         }
+    }
 
-        request.source(sourceBuilder);
+    /**
+     * Overrides the base kickoff-only locking. The base {@link MLJobProcessor#process} acquires the
+     * JobScheduler lock, calls {@code run()}, and releases the lock in a {@code finally} — but {@code run()}
+     * only DISPATCHES the fire-and-forget async pipeline and returns immediately, so that lock would be gone
+     * long before the deletes finish, giving no real exclusion across the run. This processor acquires the
+     * SAME cluster-wide lock inside {@link #triggerRun(ActionListener)} and holds it for the whole pipeline,
+     * so taking the base lock here too would self-contend on the identical lock id and turn every scheduled
+     * run into a no-op {@code ALREADY_RUNNING}. We therefore dispatch {@code run()} directly (still off the
+     * scheduler thread, matching the base) and let {@code triggerRun} own the lock lifecycle.
+     */
+    @Override
+    public void process(ScheduledJobParameter scheduledJobParameter, JobExecutionContext jobExecutionContext) {
+        threadPool.generic().submit(this::run);
+    }
 
-        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.wrap(response -> {
-                SearchHits hits = response.getHits();
-                SearchHit[] hitArray = hits.getHits();
+    /** Starts periodic renewal of the held cluster-wide lock so a long pipeline never lets it expire. */
+    private void startLockRenewal() {
+        try {
+            Scheduler.Cancellable task = threadPool
+                .scheduleWithFixedDelay(this::renewCurrentLock, TimeValue.timeValueSeconds(LOCK_RENEWAL_SECONDS), ThreadPool.Names.GENERIC);
+            lockRenewalTask.set(task);
+        } catch (Exception e) {
+            // Renewal is best-effort; a failure to schedule it only risks the lock expiring after its TTL
+            // (bounding, not breaking, cluster-wide exclusion). Do not fail the run over it.
+            log.error("Failed to schedule cluster-wide memory retention lock renewal", e);
+        }
+    }
 
-                if (hitArray.length == 0) {
-                    onJobComplete();
-                    return;
+    /** Renews the currently-held lock, advancing {@link #currentLock} to the fresh (higher-version) model. */
+    private void renewCurrentLock() {
+        LockModel lock = currentLock.get();
+        LockService ls = lockService;
+        if (lock == null || ls == null) {
+            return;
+        }
+        try {
+            ls.renewLock(lock, ActionListener.wrap(renewed -> {
+                if (renewed != null) {
+                    // Only advance if the run is still holding the same lock; a failed CAS means finishRun()
+                    // already released it, so we must not resurrect it.
+                    currentLock.compareAndSet(lock, renewed);
+                    log.debug("Renewed cluster-wide memory retention lock");
+                } else {
+                    log.warn("Cluster-wide memory retention lock renewal returned null; the lock may have expired");
                 }
+            }, e -> log.error("Failed to renew cluster-wide memory retention lock", e)));
+        } catch (Exception e) {
+            log.error("Failed to renew cluster-wide memory retention lock", e);
+        }
+    }
 
-                processContainerChain(
-                    hitArray,
-                    0,
-                    hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null
-                );
-            }, e -> {
-                log.error("Failed to search for containers with retention policies", e);
-                onJobComplete();
-            }));
+    /**
+     * Single teardown for a run: stops lock renewal, releases the cluster-wide lock (best-effort; on failure
+     * the lock simply expires after its TTL), and releases the per-node guard. Idempotent for the lock/renewal
+     * (null-safe getAndSet), so the "already released" case is harmless. Replaces the former {@code onJobComplete()}.
+     *
+     * <p>The lock is dropped via {@link LockService#deleteLock(String, ActionListener)} keyed on the stable
+     * lock doc id, NOT via {@code release(lockModel, ...)}. {@code release} issues a seqNo/primaryTerm-gated
+     * update, so a renewal still in flight when we tear down (its {@code cancel()} cannot stop an
+     * already-dispatched call) would advance the doc's seqNo and make a gated release fail — leaving the lock
+     * held for its full TTL after the run already finished. {@code deleteLock} is unconditional and races
+     * cleanly against any in-flight renewal: a renewal landing before the delete is overwritten by it, and a
+     * renewal landing after is a seqNo-gated update against a now-missing doc, which no-ops. Either way the
+     * lock doc ends up gone. The doc id is identical for the on-demand and scheduled paths, so this always
+     * targets the one lock this run holds.
+     */
+    private void finishRun() {
+        // Cancel renewals first to minimise the in-flight-renewal window; deleteLock handles any that slip through.
+        Scheduler.Cancellable renewal = lockRenewalTask.getAndSet(null);
+        if (renewal != null) {
+            renewal.cancel();
+        }
+        LockModel lock = currentLock.getAndSet(null);
+        LockService ls = lockService;
+        if (lock != null && ls != null) {
+            String lockId = LockModel.generateLockId(lock.getJobIndexName(), lock.getJobId());
+            try {
+                ls
+                    .deleteLock(
+                        lockId,
+                        ActionListener
+                            .wrap(
+                                deleted -> log.debug("Released cluster-wide memory retention lock (deleted={})", deleted),
+                                e -> log.error("Failed to release cluster-wide memory retention lock; it will expire after its TTL", e)
+                            )
+                    );
+            } catch (Exception e) {
+                log.error("Failed to release cluster-wide memory retention lock; it will expire after its TTL", e);
+            }
+        }
+        isRunning.set(false);
+        log.info("Memory retention job completed");
+    }
+
+    private void resolveContainersWithPolicies(Object[] searchAfterValues) {
+        // Guard the whole body: a synchronous throw here (e.g. threadpool rejection dispatching the search,
+        // or during node shutdown) must still tear the run down. Otherwise the escaped exception would leave
+        // isRunning stuck true AND the lock-renewal task alive, renewing the cluster-wide lock forever and
+        // wedging retention cluster-wide until node restart.
+        try {
+            SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+            request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+                .query(QueryBuilders.matchAllQuery())
+                .size(CONTAINER_PAGE_SIZE)
+                .sort("_id", SortOrder.ASC)
+                .fetchSource(true);
+
+            if (searchAfterValues != null) {
+                sourceBuilder.searchAfter(searchAfterValues);
+            }
+
+            request.source(sourceBuilder);
+
+            try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+                client.search(request, ActionListener.wrap(response -> {
+                    SearchHits hits = response.getHits();
+                    SearchHit[] hitArray = hits.getHits();
+
+                    if (hitArray.length == 0) {
+                        finishRun();
+                        return;
+                    }
+
+                    processContainerChain(
+                        hitArray,
+                        0,
+                        hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null
+                    );
+                }, e -> {
+                    log.error("Failed to search for containers with retention policies", e);
+                    finishRun();
+                }));
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error dispatching container search for memory retention", e);
+            finishRun();
         }
     }
 
@@ -290,15 +505,20 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     private void scheduleNext(SearchHit[] hits, int nextIndex, Object[] nextPageSortValues) {
         int throttleSeconds = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS);
         try {
-            threadPool
-                .schedule(
-                    () -> processContainerChain(hits, nextIndex, nextPageSortValues),
-                    TimeValue.timeValueSeconds(throttleSeconds),
-                    ThreadPool.Names.GENERIC
-                );
+            threadPool.schedule(() -> {
+                // Guard the scheduled task body too: it re-enters the driver (which may synchronously dispatch
+                // the next search), and a throw here runs on a scheduler thread with no other teardown in scope.
+                try {
+                    processContainerChain(hits, nextIndex, nextPageSortValues);
+                } catch (Exception e) {
+                    log.error("Unexpected error resuming container processing for memory retention", e);
+                    finishRun();
+                }
+            }, TimeValue.timeValueSeconds(throttleSeconds), ThreadPool.Names.GENERIC);
         } catch (Exception e) {
+            // Abandoning the run here: release the cluster-wide lock and per-node guard, don't just clear the flag.
             log.error("Failed to schedule next container processing", e);
-            isRunning.set(false);
+            finishRun();
         }
     }
 
@@ -1350,42 +1570,49 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
     }
 
     private void resolveOrphanSweepContainers(Object[] searchAfterValues) {
-        SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
-        request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
+        // Guarded like resolveContainersWithPolicies: a synchronous throw dispatching this search must tear
+        // the run down, or the lock-renewal task would keep the cluster-wide lock alive indefinitely.
+        try {
+            SearchRequest request = new SearchRequest(ML_MEMORY_CONTAINER_INDEX);
+            request.indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-        BoolQueryBuilder query = QueryBuilders
-            .boolQuery()
-            .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD))
-            .mustNot(QueryBuilders.termQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + DISABLE_SESSION_FIELD, true));
+            BoolQueryBuilder query = QueryBuilders
+                .boolQuery()
+                .must(QueryBuilders.existsQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + RETENTION_POLICY_FIELD))
+                .mustNot(QueryBuilders.termQuery(MEMORY_STORAGE_CONFIG_FIELD + "." + DISABLE_SESSION_FIELD, true));
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
-            .query(query)
-            .size(CONTAINER_PAGE_SIZE)
-            .sort("_id", SortOrder.ASC)
-            .fetchSource(true);
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+                .query(query)
+                .size(CONTAINER_PAGE_SIZE)
+                .sort("_id", SortOrder.ASC)
+                .fetchSource(true);
 
-        if (searchAfterValues != null) {
-            sourceBuilder.searchAfter(searchAfterValues);
-        }
+            if (searchAfterValues != null) {
+                sourceBuilder.searchAfter(searchAfterValues);
+            }
 
-        request.source(sourceBuilder);
+            request.source(sourceBuilder);
 
-        try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
-            client.search(request, ActionListener.wrap(response -> {
-                SearchHits hits = response.getHits();
-                SearchHit[] hitArray = hits.getHits();
+            try (ThreadContext.StoredContext ignored = client.threadPool().getThreadContext().stashContext()) {
+                client.search(request, ActionListener.wrap(response -> {
+                    SearchHits hits = response.getHits();
+                    SearchHit[] hitArray = hits.getHits();
 
-                if (hitArray.length == 0) {
-                    onJobComplete();
-                    return;
-                }
+                    if (hitArray.length == 0) {
+                        finishRun();
+                        return;
+                    }
 
-                Object[] nextPageSort = hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null;
-                processOrphanSweepContainerChain(hitArray, 0, nextPageSort);
-            }, e -> {
-                log.error("Failed to search containers for orphan sweep", e);
-                onJobComplete();
-            }));
+                    Object[] nextPageSort = hitArray.length == CONTAINER_PAGE_SIZE ? hitArray[hitArray.length - 1].getSortValues() : null;
+                    processOrphanSweepContainerChain(hitArray, 0, nextPageSort);
+                }, e -> {
+                    log.error("Failed to search containers for orphan sweep", e);
+                    finishRun();
+                }));
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error dispatching orphan-sweep container search for memory retention", e);
+            finishRun();
         }
     }
 
@@ -1394,7 +1621,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             if (nextPageSortValues != null) {
                 resolveOrphanSweepContainers(nextPageSortValues);
             } else {
-                onJobComplete();
+                finishRun();
             }
             return;
         }
@@ -2659,11 +2886,6 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     ActionListener.wrap(response -> listener.onResponse(response.getHits().getTotalHits().value()), listener::onFailure)
                 );
         }
-    }
-
-    private void onJobComplete() {
-        isRunning.set(false);
-        log.info("Memory retention job completed");
     }
 
     private static <T> List<List<T>> partition(List<T> list, int size) {

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -150,11 +150,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     @Override
     public void run() {
-        if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
-            log.warn("Memory retention job skipped: multi-tenancy is enabled and native client lacks tenant routing");
-            return;
-        }
-
+        // The scheduled retention job is a single cluster-wide, system-context janitor. Under multi-tenancy it still
+        // scans the one global container registry (matchAllQuery) and cleans EVERY container regardless of tenant.
+        // Tenant isolation is achieved per-container, not per-run: each per-container search/delete is bounded by
+        // termQuery(memory_container_id, ...), and container ids are globally unique with each mapping to exactly one
+        // tenant, so filtering by container_id transitively confines every read/delete to that container's own tenant.
+        // No tenant_id term filter is added (it would be redundant on sessions/working/history and outright wrong on
+        // long_term, whose mapping has no tenant_id field). See RFC #4859.
         if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -172,13 +172,14 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      * run's wall-clock time is roughly (containers-with-deletions &times; per-container throttle,
      * capped at 60s each) plus per-container I/O plus the orphan sweep, so on a very large cluster
      * with an elevated throttle a legitimate run could in principle approach 24h. The watchdog is
-     * deliberately conservative about that: on a suspected leak it only tears the guard down (via
-     * {@link #finishRun()}, which also stops lock renewal and releases the cluster-wide lock) and
-     * skips the current invocation — it never aborts the in-flight run and never starts a second run
-     * itself. The worst case of a false positive is therefore that the next scheduled run overlaps a
-     * still-live one, doing duplicate but idempotent deletes (same tolerated outcome as the cross-node
-     * overlap noted in the 3.9 handoff §5.1). Recovery from a genuine leak costs at most one job
-     * interval.
+     * deliberately conservative about that: on a suspected leak it reclaims ONLY the per-node guard
+     * (via {@link #releaseGuard()}) and skips the current invocation — it never touches the
+     * cluster-wide lock, never aborts the in-flight run, and never starts a second run itself.
+     * Leaving the cluster-wide lock untouched is what makes a false positive safe: if the run is
+     * actually still live it keeps its lock, so the next invocation hits the lock gate and reports
+     * {@link TriggerStatus#ALREADY_RUNNING} rather than starting a second, overlapping run. The
+     * watchdog therefore fails safe — worst case is a stalled interval (the next run skips), never a
+     * double-run. Recovery from a genuine leak costs at most one job interval.
      *
      * <p>This is a liveness <em>floor</em>, not a run timeout. Because {@code retention_job_interval_hours}
      * is operator-tunable (1–168h) and a legitimate run on a large cluster with an elevated throttle can
@@ -231,6 +232,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      * {@link #stuckGuardTimeoutMillis()}. Set when the guard is claimed and cleared by {@link #finishRun()}.
      */
     private final AtomicLong runStartMillis = new AtomicLong(Long.MIN_VALUE);
+
+    /**
+     * Set true when lock renewal is observed to have failed — {@code renewLock} returned null (the lock doc
+     * was gone / could not be advanced) or the renewal call errored. When true, cluster-wide exclusion may
+     * already have been lost: the lock could have expired and been re-acquired by another run, which now owns
+     * the lock doc under the same stable id. {@link #finishRun()} therefore SKIPS its {@code deleteLock} when
+     * this flag is set, so this run never deletes a lock doc that a different, still-live run may now hold.
+     * Reset to false when a new run freshly acquires the lock (before {@link #startLockRenewal()}). Volatile
+     * for cross-thread visibility between the renewal task (GENERIC pool) and the teardown path.
+     */
+    private volatile boolean lockLost = false;
 
     public static MemoryRetentionJobProcessor getInstance(ClusterService clusterService, Client client, ThreadPool threadPool) {
         if (instance != null) {
@@ -337,20 +349,24 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             return;
         }
 
-        // Per-node single-flight guard. Claimed here; released by finishRun() (success/terminal/error) or
-        // immediately below if the cluster-wide lock is already held elsewhere / cannot be acquired.
+        // Per-node single-flight guard. Claimed here; released by finishRun() (on the lock-owning paths) or
+        // by releaseGuard() on the pre-kickoff gating paths below (no lock owned yet).
         if (!isRunning.compareAndSet(false, true)) {
             // The guard is held. Normally that means a prior run is genuinely still in flight, so we
             // skip. But because the run is a fully async callback chain, an unhandled throw on a
             // thread we cannot wrap can leave the guard stuck true forever, silently disabling
             // retention until node restart. Detect that: if the holder acquired the guard longer ago
-            // than any run should plausibly last, assume it leaked and tear it down (finishRun() also
-            // stops lock renewal and releases the cluster-wide lock) so the NEXT invocation can start
-            // cleanly. We deliberately do NOT take over and start a run here: if this were a false
-            // positive (a genuinely long run), starting a second chain now — with no per-run ownership
-            // on the shared finishRun() teardown — could let the two runs race the guard and cascade
-            // into several concurrent runs. Clearing-and-skipping caps the worst case at one overlapping
-            // run of idempotent deletes on the following interval.
+            // than any run should plausibly last, assume it leaked and reclaim ONLY the per-node guard
+            // (releaseGuard()) so the NEXT invocation can start cleanly. We deliberately do NOT release
+            // the cluster-wide lock here and do NOT start a run: if this is a false positive (a
+            // genuinely long, still-live run), that run still owns its cluster-wide lock, so the next
+            // invocation hits the lock gate and reports ALREADY_RUNNING instead of overlapping it. That
+            // is exactly what keeps "at most one run, and only via the lock gate" true. Deleting the
+            // lock here (as a shared full teardown would) is precisely the bug: it would free a lock a
+            // live run still holds, let a second run acquire it, and the old run's eventual finishRun()
+            // would then tear down the NEW run — an unbounded cross-node cascade. releaseGuard() fails
+            // safe: the worst case of a false positive is a stalled interval (the next run skips),
+            // never a double-run.
             long heldSince = runStartMillis.get();
             long heldForMillis = System.currentTimeMillis() - heldSince;
             long stuckGuardTimeoutMillis = stuckGuardTimeoutMillis();
@@ -361,12 +377,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             }
             log
                 .error(
-                    "Memory retention job guard appears stuck (held for {} ms, exceeds {} ms); clearing it so the next "
-                        + "scheduled run can proceed. A prior run likely failed without releasing the guard.",
+                    "Memory retention job guard appears stuck (held for {} ms, exceeds {} ms); reclaiming the per-node "
+                        + "guard so the next scheduled run can proceed. The cluster-wide lock is left untouched: if a run "
+                        + "is still live it keeps its lock and the next invocation reports ALREADY_RUNNING.",
                     heldForMillis,
                     stuckGuardTimeoutMillis
                 );
-            finishRun();
+            releaseGuard();
             listener.onResponse(TriggerStatus.ALREADY_RUNNING);
             return;
         }
@@ -387,22 +404,29 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             ls.acquireLockWithId(ML_JOBS_INDEX, LOCK_DURATION_SECONDS, MLJobType.MEMORY_RETENTION.name(), ActionListener.wrap(lock -> {
                 if (lock == null) {
                     // A run is already in progress cluster-wide (another node, or the scheduler, holds
-                    // the lock). Release the per-node guard (and start-time stamp) and report already-running.
-                    finishRun();
+                    // the lock). This run never acquired the lock, so reclaim ONLY the per-node guard (and
+                    // start-time stamp); it must NOT touch the cluster-wide lock, which belongs to the other
+                    // run. Report already-running.
+                    releaseGuard();
                     log.info("Memory retention job already running cluster-wide (lock held); skipping this invocation");
                     listener.onResponse(TriggerStatus.ALREADY_RUNNING);
                     return;
                 }
+                // Freshly acquired the cluster-wide lock; clear any stale renewal-loss flag from a prior run
+                // before starting renewal so this run's finishRun() will delete the lock it now owns.
+                lockLost = false;
                 currentLock.set(lock);
                 startLockRenewal();
                 kickOffPipeline(listener);
             }, e -> {
-                finishRun();
+                // No lock was acquired on this error path, so reclaim only the per-node guard.
+                releaseGuard();
                 log.error("Failed to acquire cluster-wide lock for memory retention job", e);
                 listener.onFailure(e);
             }));
         } catch (Exception e) {
-            finishRun();
+            // Lock acquisition threw synchronously; no lock was acquired, so reclaim only the per-node guard.
+            releaseGuard();
             log.error("Failed to acquire cluster-wide lock for memory retention job", e);
             listener.onFailure(e);
         }
@@ -469,20 +493,54 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     currentLock.compareAndSet(lock, renewed);
                     log.debug("Renewed cluster-wide memory retention lock");
                 } else {
-                    log.warn("Cluster-wide memory retention lock renewal returned null; the lock may have expired");
+                    // Renewal returned null: the lock doc could not be advanced (likely expired and possibly
+                    // re-acquired by another run under the same stable id). Flag the loss so finishRun() will
+                    // NOT delete a lock doc that a different, still-live run may now own.
+                    lockLost = true;
+                    log
+                        .warn(
+                            "Cluster-wide memory retention lock renewal returned null; the lock may have expired and "
+                                + "cluster-wide exclusion may be lost. This run will not delete the lock doc on teardown."
+                        );
                 }
-            }, e -> log.error("Failed to renew cluster-wide memory retention lock", e)));
+            }, e -> {
+                // Renewal errored: treat as a possible loss of cluster-wide exclusion for the same reason as above.
+                lockLost = true;
+                log
+                    .error(
+                        "Failed to renew cluster-wide memory retention lock; cluster-wide exclusion may be lost. This "
+                            + "run will not delete the lock doc on teardown.",
+                        e
+                    );
+            }));
         } catch (Exception e) {
-            log.error("Failed to renew cluster-wide memory retention lock", e);
+            lockLost = true;
+            log
+                .error(
+                    "Failed to renew cluster-wide memory retention lock; cluster-wide exclusion may be lost. This run "
+                        + "will not delete the lock doc on teardown.",
+                    e
+                );
         }
     }
 
     /**
-     * Single teardown for a run: stops lock renewal, releases the cluster-wide lock (best-effort; on failure
-     * the lock simply expires after its TTL), and releases the per-node guard. Idempotent for the lock/renewal
-     * (null-safe getAndSet), so the "already released" case is harmless. Replaces the former {@code onJobComplete()}.
+     * FULL teardown for a run that OWNS the cluster-wide lock: stops lock renewal, releases the cluster-wide lock
+     * (best-effort; on failure the lock simply expires after its TTL), then reclaims the per-node guard via
+     * {@link #releaseGuard()}. Idempotent for the lock/renewal (null-safe getAndSet), so the "already released"
+     * case is harmless. Replaces the former {@code onJobComplete()}.
      *
-     * <p>The lock is dropped via {@link LockService#deleteLock(String, ActionListener)} keyed on the stable
+     * <p><b>Call only from lock-owning paths.</b> This is the full teardown and is invoked ONLY where the run has
+     * confirmed it acquired the cluster-wide lock — {@link #kickOffPipeline(ActionListener)}'s catch and every
+     * pipeline terminal/error exit downstream of a successful acquisition. The pre-kickoff gating paths (stuck-guard
+     * watchdog, lock-already-held, lock-acquire failure) must instead call {@link #releaseGuard()}, because deleting
+     * a lock those paths do not own could free a lock a still-live run holds and cascade into overlapping runs.
+     *
+     * <p><b>Renewal-loss guard.</b> If {@link #lockLost} is set (renewal failed, so the lock may have expired and
+     * been re-acquired elsewhere under the same stable id), the {@code deleteLock} is SKIPPED — this run must not
+     * delete a lock doc a different, still-live run may now own; the doc (if still ours) expires after its TTL.
+     *
+     * <p>Otherwise the lock is dropped via {@link LockService#deleteLock(String, ActionListener)} keyed on the stable
      * lock doc id, NOT via {@code release(lockModel, ...)}. {@code release} issues a seqNo/primaryTerm-gated
      * update, so a renewal still in flight when we tear down (its {@code cancel()} cannot stop an
      * already-dispatched call) would advance the doc's seqNo and make a gated release fail — leaving the lock
@@ -500,7 +558,17 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         }
         LockModel lock = currentLock.getAndSet(null);
         LockService ls = lockService;
-        if (lock != null && ls != null) {
+        if (lockLost) {
+            // Renewal was observed to have failed (see renewCurrentLock): the lock doc may have expired and been
+            // re-acquired by another run under the same stable id. Deleting it now could free a lock a DIFFERENT,
+            // still-live run owns, letting a third run start and cascade. Skip the delete and just fall through to
+            // releaseGuard(); if the lock doc really is still ours it simply expires after its TTL.
+            log
+                .warn(
+                    "Skipping cluster-wide memory retention lock deletion because renewal was lost; the lock doc (if still "
+                        + "present) will expire after its TTL rather than risk deleting a lock another run now owns."
+                );
+        } else if (lock != null && ls != null) {
             String lockId = LockModel.generateLockId(lock.getJobIndexName(), lock.getJobId());
             try {
                 ls
@@ -516,11 +584,22 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                 log.error("Failed to release cluster-wide memory retention lock; it will expire after its TTL", e);
             }
         }
-        // Clear the watchdog start-time stamp before releasing the guard so a subsequent invocation never sees a
-        // stale timestamp against a freshly-cleared guard.
+        releaseGuard();
+        log.info("Memory retention job completed");
+    }
+
+    /**
+     * Reclaims ONLY the per-node single-flight guard: clears the watchdog start-time stamp and then releases
+     * {@link #isRunning}. It does NOT cancel lock renewal and NEVER touches the cluster-wide lock, so it is safe
+     * to call from the pre-kickoff gating paths (stuck-guard watchdog, lock-already-held, lock-acquire failure)
+     * where this node does not own — and may be racing a still-live holder of — the cluster-wide lock. The
+     * start-time stamp is cleared BEFORE the guard so a subsequent invocation never sees a stale timestamp
+     * against a freshly-cleared guard. This is the fail-safe half of the Option-C split (see {@link #finishRun()}
+     * for the full teardown used only by lock-owning paths).
+     */
+    private void releaseGuard() {
         runStartMillis.set(Long.MIN_VALUE);
         isRunning.set(false);
-        log.info("Memory retention job completed");
     }
 
     private void resolveContainersWithPolicies(Object[] searchAfterValues) {

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -73,6 +73,7 @@ import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
 import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
@@ -150,9 +151,43 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
 
     @Override
     public void run() {
-        // The scheduled retention job is a single cluster-wide, system-context janitor. Under multi-tenancy it still
-        // scans the one global container registry (matchAllQuery) and cleans EVERY container regardless of tenant.
-        // Tenant isolation is achieved per-container, not per-run: each per-container search/delete is bounded by
+        // The scheduled path ignores the returned status (it is only logged inside triggerRun);
+        // the on-demand API path calls triggerRun() directly to surface the status to the caller.
+        // Both share the exact same guards and pipeline kickoff so behavior is identical. The
+        // scheduled path additionally swallows a synchronous kickoff failure (already logged and the
+        // in-progress guard already released inside triggerRun) exactly as it did before this method
+        // was refactored, so a fire-and-forget scheduled run never propagates.
+        try {
+            triggerRun();
+        } catch (Exception e) {
+            // Swallowed on purpose: preserves pre-refactor fire-and-forget scheduled semantics.
+            // triggerRun() has already error-logged and reset the in-progress guard before rethrowing.
+            log.trace("Scheduled memory retention run kickoff failed (already handled by triggerRun)", e);
+        }
+    }
+
+    /**
+     * Applies the retention job's gating (remote-metadata-store skip, retention_enabled, single-flight in-progress
+     * guard) and, when all pass, kicks off the full async retention pipeline via
+     * {@link #resolveContainersWithPolicies(Object[])} exactly as the scheduled run does. Returns
+     * promptly with a {@link TriggerStatus} describing the outcome; it does NOT block until the
+     * (fully async) delete pipeline completes. When {@link TriggerStatus#TRIGGERED} is returned the
+     * in-progress guard has been claimed and will be released by {@link #onJobComplete()} (or on a
+     * synchronous kickoff failure below); for every other status no guard is held and no state is
+     * mutated, so a caller can safely retry.
+     *
+     * <p>This is the single source of truth for both the scheduled {@link #run()} and the on-demand
+     * transport action, so the two can never diverge. The in-progress guard is a per-JVM
+     * {@link AtomicBoolean}: it serializes invocations on THIS node (the scheduler additionally holds a
+     * cluster-wide JobScheduler lock, but the on-demand path does not), so it does not by itself
+     * prevent a run on another node from overlapping.
+     *
+     * @return the job-level outcome of this invocation
+     */
+    public TriggerStatus triggerRun() {
+        // The retention job is a single cluster-wide, system-context janitor. Under multi-tenancy it still scans the
+        // one global container registry (matchAllQuery) and cleans EVERY container regardless of tenant. Tenant
+        // isolation is achieved per-container: each per-container search/delete is bounded by
         // termQuery(memory_container_id, ...), and container ids are globally unique with each mapping to exactly one
         // tenant, so filtering by container_id transitively confines every read/delete to that container's own tenant.
         // No tenant_id term filter is added (it would be redundant on sessions/working/history and outright wrong on
@@ -168,25 +203,27 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     "Memory retention job skipped: remote metadata store is configured; the container registry is not "
                         + "in the local cluster, so the retention job cannot enumerate containers. See RFC #4859."
                 );
-            return;
+            return TriggerStatus.REMOTE_METADATA_STORE;
         }
 
         if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
-            return;
+            return TriggerStatus.RETENTION_DISABLED;
         }
 
         if (!isRunning.compareAndSet(false, true)) {
             log.warn("Memory retention job already in progress, skipping this invocation");
-            return;
+            return TriggerStatus.ALREADY_RUNNING;
         }
 
         try {
             log.info("Memory retention job started");
             resolveContainersWithPolicies(null);
+            return TriggerStatus.TRIGGERED;
         } catch (Exception e) {
             log.error("Unexpected error starting memory retention job", e);
             isRunning.set(false);
+            throw e;
         }
     }
 

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -25,6 +25,7 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
 
@@ -177,10 +178,36 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      * itself. The worst case of a false positive is therefore that the next scheduled run overlaps a
      * still-live one, doing duplicate but idempotent deletes (same tolerated outcome as the cross-node
      * overlap noted in the 3.9 handoff §5.1). Recovery from a genuine leak costs at most one job
-     * interval. 24h comfortably exceeds any run on a normally-provisioned cluster while keeping the
-     * false-positive rate negligible.
+     * interval.
+     *
+     * <p>This is a liveness <em>floor</em>, not a run timeout. Because {@code retention_job_interval_hours}
+     * is operator-tunable (1–168h) and a legitimate run on a large cluster with an elevated throttle can
+     * take many hours, the effective threshold scales with the configured interval — see
+     * {@link #stuckGuardTimeoutMillis()}. The floor guarantees the threshold never drops so low on a
+     * short interval that it could false-positive a genuinely long run; the interval multiple keeps the
+     * threshold comfortably above any single run's plausible duration on clusters configured to run
+     * infrequently.
      */
-    static final long STUCK_GUARD_TIMEOUT_MILLIS = TimeUnit.HOURS.toMillis(24);
+    static final long STUCK_GUARD_TIMEOUT_FLOOR_MILLIS = TimeUnit.HOURS.toMillis(24);
+
+    /**
+     * Multiple of the configured job interval used as the stuck-guard threshold when it exceeds the floor.
+     * A run should never legitimately span more than one interval (the pipeline is single-flight and the
+     * next invocation folds any backlog into itself), so 2× the interval leaves generous headroom for a
+     * slow-but-live run before its guard is presumed leaked.
+     */
+    static final long STUCK_GUARD_INTERVAL_MULTIPLE = 2L;
+
+    /**
+     * Effective stuck-guard threshold: {@code max(24h floor, 2 × configured interval)}, read live from
+     * cluster settings so an operator raising the interval (up to 168h) also widens the leak-detection
+     * window and cannot have a long-but-legitimate run false-flagged as stuck.
+     */
+    long stuckGuardTimeoutMillis() {
+        int intervalHours = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS);
+        long intervalBasedMillis = TimeUnit.HOURS.toMillis((long) intervalHours * STUCK_GUARD_INTERVAL_MULTIPLE);
+        return Math.max(STUCK_GUARD_TIMEOUT_FLOOR_MILLIS, intervalBasedMillis);
+    }
 
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -201,7 +228,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
      * Wall-clock time (epoch millis) at which the current run acquired {@link #isRunning}, or
      * {@link Long#MIN_VALUE} when no run holds the guard. Read by the stuck-guard watchdog in
      * {@link #triggerRun(ActionListener)} to decide whether a still-set guard has outlived
-     * {@link #STUCK_GUARD_TIMEOUT_MILLIS}. Set when the guard is claimed and cleared by {@link #finishRun()}.
+     * {@link #stuckGuardTimeoutMillis()}. Set when the guard is claimed and cleared by {@link #finishRun()}.
      */
     private final AtomicLong runStartMillis = new AtomicLong(Long.MIN_VALUE);
 
@@ -326,7 +353,8 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             // run of idempotent deletes on the following interval.
             long heldSince = runStartMillis.get();
             long heldForMillis = System.currentTimeMillis() - heldSince;
-            if (heldSince == Long.MIN_VALUE || heldForMillis < STUCK_GUARD_TIMEOUT_MILLIS) {
+            long stuckGuardTimeoutMillis = stuckGuardTimeoutMillis();
+            if (heldSince == Long.MIN_VALUE || heldForMillis < stuckGuardTimeoutMillis) {
                 log.warn("Memory retention job already in progress on this node, skipping this invocation");
                 listener.onResponse(TriggerStatus.ALREADY_RUNNING);
                 return;
@@ -336,7 +364,7 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
                     "Memory retention job guard appears stuck (held for {} ms, exceeds {} ms); clearing it so the next "
                         + "scheduled run can proceed. A prior run likely failed without releasing the guard.",
                     heldForMillis,
-                    STUCK_GUARD_TIMEOUT_MILLIS
+                    stuckGuardTimeoutMillis
                 );
             finishRun();
             listener.onResponse(TriggerStatus.ALREADY_RUNNING);

--- a/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
+++ b/plugin/src/main/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessor.java
@@ -26,7 +26,6 @@ import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEM
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS;
-import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +72,7 @@ import org.opensearch.index.reindex.DeleteByQueryRequest;
 import org.opensearch.ml.common.memorycontainer.MemoryConfiguration;
 import org.opensearch.ml.common.memorycontainer.MemoryType;
 import org.opensearch.ml.common.memorycontainer.RetentionRule;
+import org.opensearch.ml.common.settings.MLCommonsSettings;
 import org.opensearch.ml.common.transport.memorycontainer.MemoryRetentionDryRunResult;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
@@ -157,6 +157,20 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
         // tenant, so filtering by container_id transitively confines every read/delete to that container's own tenant.
         // No tenant_id term filter is added (it would be redundant on sessions/working/history and outright wrong on
         // long_term, whose mapping has no tenant_id field). See RFC #4859.
+        //
+        // Exception: when metadata is stored in a REMOTE store (e.g. AWS OpenSearch Serverless / DynamoDB), the
+        // container registry lives remotely and this native-client scan of the local registry index would find zero
+        // containers and silently clean nothing. Skip in that mode rather than give a false impression of retention.
+        // Self-hosted multi-tenancy (local metadata) is fully supported and runs normally.
+        if (MLCommonsSettings.isRemoteMetadataStore(clusterService.getSettings())) {
+            log
+                .warn(
+                    "Memory retention job skipped: remote metadata store is configured; the container registry is not "
+                        + "in the local cluster, so the retention job cannot enumerate containers. See RFC #4859."
+                );
+            return;
+        }
+
         if (!clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_RETENTION_ENABLED)) {
             log.info("Memory retention job disabled via cluster setting plugins.ml_commons.memory.retention_enabled=false");
             return;
@@ -2022,13 +2036,13 @@ public class MemoryRetentionJobProcessor extends MLJobProcessor {
             int ttlDays = clusterService.getClusterSettings().get(ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS);
             DryRunContext ctx = new DryRunContext(containerId, policySource, System.currentTimeMillis(), effective.policy, ttlDays);
 
-            // Multi-tenancy hard-gates the scheduled job off - run() returns before any deletion when MT is
-            // enabled - so nothing would ever be deleted in this deployment mode. Skip the read-only passes and
-            // report an honest zero rather than scanning indices for counts the job can't act on.
-            // NOTE(PR-B): retention runs under multi-tenancy in PR-B; this becomes an isRemoteMetadataStore()
-            // gate there, but the skip-to-zero behavior is unchanged.
-            if (clusterService.getClusterSettings().get(ML_COMMONS_MULTI_TENANCY_ENABLED)) {
-                ctx.warnings.add("multi-tenancy is enabled; the scheduled retention job does not run, so nothing would be deleted");
+            // A remote metadata store hard-gates the scheduled job off - run() returns before any deletion when a
+            // remote metadata store is configured (see the isRemoteMetadataStore() gate in run()) - so nothing would
+            // ever be deleted in this deployment mode. Skip the read-only passes and report an honest zero rather than
+            // scanning indices for counts the job can't act on.
+            if (MLCommonsSettings.isRemoteMetadataStore(clusterService.getSettings())) {
+                ctx.warnings
+                    .add("a remote metadata store is configured; the scheduled retention job does not run, so nothing would be deleted");
                 listener.onResponse(buildDryRunResult(ctx));
                 return;
             }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -38,6 +38,9 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
+import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.IndexScopedSettings;
 import org.opensearch.common.settings.Setting;
@@ -59,6 +62,7 @@ import org.opensearch.indices.analysis.PreBuiltCacheFactory;
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension;
 import org.opensearch.jobscheduler.spi.ScheduledJobParser;
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.action.IndexInsight.GetIndexInsightConfigTransportAction;
 import org.opensearch.ml.action.IndexInsight.GetIndexInsightTransportAction;
 import org.opensearch.ml.action.IndexInsight.PutIndexInsightConfigTransportAction;
@@ -303,6 +307,7 @@ import org.opensearch.ml.helper.ConnectorAccessControlHelper;
 import org.opensearch.ml.helper.ModelAccessControlHelper;
 import org.opensearch.ml.jobs.MLJobParameter;
 import org.opensearch.ml.jobs.MLJobRunner;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.ml.memory.ConversationalMemoryHandler;
 import org.opensearch.ml.memory.action.conversation.CreateConversationAction;
 import org.opensearch.ml.memory.action.conversation.CreateConversationTransportAction;
@@ -1712,5 +1717,48 @@ public class MachineLearningPlugin extends Plugin
     @Override
     public ScheduledJobParser getJobParser() {
         return (parser, id, jobDocVersion) -> MLJobParameter.parse(parser);
+    }
+
+    @Override
+    public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
+        // Registers the holder so Guice constructs it and injects the JobScheduler LockService. The
+        // LockService impl lives in the job-scheduler plugin and is only reachable at runtime via this
+        // node-level binding (bound by JobSchedulerPluginModule); ml-commons compiles against the SPI
+        // interface only. This is the upstream-sanctioned way (used by security-analytics) for a guest
+        // plugin to obtain a LockService for use outside a scheduled job run.
+        return Collections.singletonList(GuiceHolder.class);
+    }
+
+    /**
+     * Guice service holder that captures the node's shared {@link LockService} and hands it to
+     * {@link MemoryRetentionJobProcessor}, so the on-demand retention trigger can acquire the SAME cluster-wide
+     * lock the scheduled run uses. Injection is the only supported way to reach the LockService implementation
+     * (which is provided at runtime by the job-scheduler plugin) from ml-commons code that is not itself a
+     * scheduled-job callback.
+     *
+     * <p>The LockService is wired via OPTIONAL METHOD injection, NOT constructor injection: a constructor
+     * parameter makes LockService a hard Guice binding, so on any harness where the job-scheduler plugin is not
+     * installed (e.g. integ-test clusters, some unit harnesses) node startup fails with an unsatisfied binding.
+     * An optional setter lets Guice skip the injection when no LockService binding exists, leaving the processor
+     * on its per-JVM {@link MemoryRetentionJobProcessor#isRunning} guard only. When job-scheduler IS present the
+     * setter fires at node start and the on-demand path gets the shared cluster-wide lock.
+     */
+    public static class GuiceHolder extends AbstractLifecycleComponent {
+
+        public GuiceHolder() {}
+
+        @Inject(optional = true)
+        public void setLockService(final LockService lockService) {
+            MemoryRetentionJobProcessor.setLockService(lockService);
+        }
+
+        @Override
+        protected void doStart() {}
+
+        @Override
+        protected void doStop() {}
+
+        @Override
+        protected void doClose() {}
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
+++ b/plugin/src/main/java/org/opensearch/ml/plugin/MachineLearningPlugin.java
@@ -109,6 +109,7 @@ import org.opensearch.ml.action.mcpserver.TransportMcpToolsRemoveAction;
 import org.opensearch.ml.action.mcpserver.TransportMcpToolsUpdateAction;
 import org.opensearch.ml.action.memorycontainer.TransportCreateMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.TransportDeleteMemoryContainerAction;
+import org.opensearch.ml.action.memorycontainer.TransportExecuteMemoryRetentionAction;
 import org.opensearch.ml.action.memorycontainer.TransportGetMemoryContainerAction;
 import org.opensearch.ml.action.memorycontainer.TransportMemoryRetentionDryRunAction;
 import org.opensearch.ml.action.memorycontainer.TransportSearchMemoryContainerAction;
@@ -221,6 +222,7 @@ import org.opensearch.ml.common.transport.mcpserver.action.MLMcpToolsRegisterAct
 import org.opensearch.ml.common.transport.mcpserver.action.MLMcpToolsRemoveAction;
 import org.opensearch.ml.common.transport.mcpserver.action.MLMcpToolsUpdateAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLCreateMemoryContainerAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerDeleteAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerGetAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLMemoryContainerSearchAction;
@@ -356,6 +358,7 @@ import org.opensearch.ml.rest.RestMLDeleteModelGroupAction;
 import org.opensearch.ml.rest.RestMLDeleteTaskAction;
 import org.opensearch.ml.rest.RestMLDeployModelAction;
 import org.opensearch.ml.rest.RestMLExecuteAction;
+import org.opensearch.ml.rest.RestMLExecuteMemoryRetentionAction;
 import org.opensearch.ml.rest.RestMLExecuteStreamAction;
 import org.opensearch.ml.rest.RestMLGetAgentAction;
 import org.opensearch.ml.rest.RestMLGetAgenticSearchTemplateAction;
@@ -610,6 +613,7 @@ public class MachineLearningPlugin extends Plugin
                 new ActionHandler<>(MLUpdateMemoryContainerAction.INSTANCE, TransportUpdateMemoryContainerAction.class),
                 new ActionHandler<>(MLMemoryContainerGetAction.INSTANCE, TransportGetMemoryContainerAction.class),
                 new ActionHandler<>(MLMemoryRetentionDryRunAction.INSTANCE, TransportMemoryRetentionDryRunAction.class),
+                new ActionHandler<>(MLExecuteMemoryRetentionAction.INSTANCE, TransportExecuteMemoryRetentionAction.class),
                 new ActionHandler<>(MLMemoryContainerSearchAction.INSTANCE, TransportSearchMemoryContainerAction.class),
                 new ActionHandler<>(MLMemoryContainerDeleteAction.INSTANCE, TransportDeleteMemoryContainerAction.class),
                 new ActionHandler<>(MLAddMemoriesAction.INSTANCE, TransportAddMemoriesAction.class),
@@ -1117,6 +1121,9 @@ public class MachineLearningPlugin extends Plugin
         RestMLMemoryRetentionDryRunAction restMLMemoryRetentionDryRunAction = new RestMLMemoryRetentionDryRunAction(
             mlFeatureEnabledSetting
         );
+        RestMLExecuteMemoryRetentionAction restMLExecuteMemoryRetentionAction = new RestMLExecuteMemoryRetentionAction(
+            mlFeatureEnabledSetting
+        );
         RestMLSearchMemoryContainerAction restMLSearchMemoryContainerAction = new RestMLSearchMemoryContainerAction(
             mlFeatureEnabledSetting
         );
@@ -1236,6 +1243,7 @@ public class MachineLearningPlugin extends Plugin
                 restMLUpdateMemoryContainerAction,
                 restMLGetMemoryContainerAction,
                 restMLMemoryRetentionDryRunAction,
+                restMLExecuteMemoryRetentionAction,
                 restMLSearchMemoryContainerAction,
                 restMLDeleteMemoryContainerAction,
                 restMLAddMemoriesAction,

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionAction.java
@@ -7,7 +7,6 @@ package org.opensearch.ml.rest;
 
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.EXECUTE_MEMORY_RETENTION_PATH;
 import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
-import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
 
 import java.io.IOException;
 import java.util.List;
@@ -58,13 +57,18 @@ public class RestMLExecuteMemoryRetentionAction extends BaseRestHandler {
         if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
             throw new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN);
         }
+        if (request.hasContent()) {
+            throw new OpenSearchStatusException(
+                "_execute does not accept a request body; it always runs cluster-wide.",
+                RestStatus.BAD_REQUEST
+            );
+        }
         MLExecuteMemoryRetentionRequest executeRequest = getRequest(request);
         return channel -> client.execute(MLExecuteMemoryRetentionAction.INSTANCE, executeRequest, new RestToXContentListener<>(channel));
     }
 
     @VisibleForTesting
     MLExecuteMemoryRetentionRequest getRequest(RestRequest request) throws IOException {
-        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
-        return MLExecuteMemoryRetentionRequest.builder().tenantId(tenantId).build();
+        return MLExecuteMemoryRetentionRequest.builder().build();
     }
 }

--- a/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.EXECUTE_MEMORY_RETENTION_PATH;
+import static org.opensearch.ml.common.settings.MLCommonsSettings.ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE;
+import static org.opensearch.ml.utils.TenantAwareHelper.getTenantID;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * REST handler that triggers the memory retention job on demand, cluster-wide.
+ *
+ * <p>Scope: cluster-wide only. The underlying {@link org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor}
+ * runs a single full-cluster pipeline (it iterates every container via a singleton in-progress guard)
+ * and exposes no per-container entry point. A per-container route (e.g.
+ * {@code POST .../memory_containers/{id}/_retention/_execute}) would require refactoring the pipeline
+ * to accept a container filter, which the task explicitly scoped out as a risky refactor, so it is
+ * intentionally not offered.
+ */
+public class RestMLExecuteMemoryRetentionAction extends BaseRestHandler {
+    private static final String ML_EXECUTE_MEMORY_RETENTION_ACTION = "ml_execute_memory_retention_action";
+    private final MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    public RestMLExecuteMemoryRetentionAction(MLFeatureEnabledSetting mlFeatureEnabledSetting) {
+        this.mlFeatureEnabledSetting = mlFeatureEnabledSetting;
+    }
+
+    @Override
+    public String getName() {
+        return ML_EXECUTE_MEMORY_RETENTION_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(new Route(RestRequest.Method.POST, EXECUTE_MEMORY_RETENTION_PATH));
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!mlFeatureEnabledSetting.isAgenticMemoryEnabled()) {
+            throw new OpenSearchStatusException(ML_COMMONS_AGENTIC_MEMORY_DISABLED_MESSAGE, RestStatus.FORBIDDEN);
+        }
+        MLExecuteMemoryRetentionRequest executeRequest = getRequest(request);
+        return channel -> client.execute(MLExecuteMemoryRetentionAction.INSTANCE, executeRequest, new RestToXContentListener<>(channel));
+    }
+
+    @VisibleForTesting
+    MLExecuteMemoryRetentionRequest getRequest(RestRequest request) throws IOException {
+        String tenantId = getTenantID(mlFeatureEnabledSetting.isMultiTenancyEnabled(), request);
+        return MLExecuteMemoryRetentionRequest.builder().tenantId(tenantId).build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.action.memorycontainer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
+import org.opensearch.tasks.Task;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCase {
+
+    private TransportExecuteMemoryRetentionAction action;
+
+    @Mock
+    private Client client;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private Task task;
+    @Mock
+    private ActionListener<MLExecuteMemoryRetentionResponse> actionListener;
+
+    // The mocked processor we inject into the singleton so getInstance() returns it.
+    @Mock
+    private MemoryRetentionJobProcessor mockProcessor;
+
+    @Captor
+    private ArgumentCaptor<MLExecuteMemoryRetentionResponse> responseCaptor;
+    @Captor
+    private ArgumentCaptor<Exception> exceptionCaptor;
+
+    private ActionRequest request;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        request = MLExecuteMemoryRetentionRequest.builder().build();
+
+        // Inject the mock into the singleton so the transport action's getInstance(...) call returns it
+        // instead of constructing a real processor. This lets us drive triggerRun()'s outcome directly.
+        setSingletonInstance(mockProcessor);
+
+        action = new TransportExecuteMemoryRetentionAction(
+            transportService,
+            actionFilters,
+            client,
+            clusterService,
+            threadPool,
+            mlFeatureEnabledSetting
+        );
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        MemoryRetentionJobProcessor.reset();
+    }
+
+    public void testTriggeredSuccess() {
+        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.TRIGGERED);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        verify(actionListener, never()).onFailure(any());
+        MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
+        assertEquals(TriggerStatus.TRIGGERED, response.getStatus());
+        assertTrue(response.getStatus().isTriggered());
+        assertNotNull(response.getMessage());
+    }
+
+    public void testAlreadyRunning() {
+        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.ALREADY_RUNNING);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
+        assertEquals(TriggerStatus.ALREADY_RUNNING, response.getStatus());
+        assertFalse(response.getStatus().isTriggered());
+    }
+
+    public void testRetentionDisabled() {
+        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.RETENTION_DISABLED);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
+        assertEquals(TriggerStatus.RETENTION_DISABLED, response.getStatus());
+        assertFalse(response.getStatus().isTriggered());
+    }
+
+    public void testMultiTenancyEnabled() {
+        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.MULTI_TENANCY_ENABLED);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
+        assertEquals(TriggerStatus.MULTI_TENANCY_ENABLED, response.getStatus());
+        assertFalse(response.getStatus().isTriggered());
+    }
+
+    public void testAgenticMemoryDisabledIsForbidden() {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, never()).onResponse(any());
+        verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        Exception e = exceptionCaptor.getValue();
+        assertTrue(e instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) e).status());
+        // The processor must never be touched when the feature is off.
+        verify(mockProcessor, never()).triggerRun();
+    }
+
+    public void testProcessorFailureIsInternalServerError() {
+        when(mockProcessor.triggerRun()).thenThrow(new RuntimeException("kickoff failed"));
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, never()).onResponse(any());
+        verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        Exception e = exceptionCaptor.getValue();
+        assertTrue(e instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) e).status());
+    }
+
+    public void testFromActionRequestConversion() {
+        // Drive doExecute with a generic ActionRequest (not the concrete type) to exercise the
+        // fromActionRequest path used by the transport layer for cross-node serialization.
+        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.TRIGGERED);
+        ActionRequest generic = mock(ActionRequest.class);
+
+        action.doExecute(task, generic, actionListener);
+
+        // doExecute does not itself convert (it delegates straight to the processor), so it still
+        // acknowledges; this guards that a non-concrete request does not blow up the handler.
+        verify(actionListener, times(1)).onResponse(any());
+    }
+
+    private void setSingletonInstance(MemoryRetentionJobProcessor processor) throws Exception {
+        Field instanceField = MemoryRetentionJobProcessor.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, processor);
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
@@ -32,6 +32,7 @@ import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
+import org.opensearch.ml.helper.MemoryContainerHelper;
 import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
@@ -90,13 +91,18 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
         // instead of constructing a real processor. This lets us drive triggerRun()'s outcome directly.
         setSingletonInstance(mockProcessor);
 
+        // isAdminUser() only inspects the passed User's roles and touches no helper fields, so a real
+        // helper constructed with nulls is sufficient to exercise the admin gate.
+        MemoryContainerHelper memoryContainerHelper = new MemoryContainerHelper(null, null, null, null);
+
         action = new TransportExecuteMemoryRetentionAction(
             transportService,
             actionFilters,
             client,
             clusterService,
             threadPool,
-            mlFeatureEnabledSetting
+            mlFeatureEnabledSetting,
+            memoryContainerHelper
         );
     }
 
@@ -150,17 +156,6 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
         verify(actionListener, times(1)).onResponse(responseCaptor.capture());
         MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
         assertEquals(TriggerStatus.RETENTION_DISABLED, response.getStatus());
-        assertFalse(response.getStatus().isTriggered());
-    }
-
-    public void testMultiTenancyEnabled() {
-        stubTriggerRunResponds(TriggerStatus.MULTI_TENANCY_ENABLED);
-
-        action.doExecute(task, request, actionListener);
-
-        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
-        MLExecuteMemoryRetentionResponse response = responseCaptor.getValue();
-        assertEquals(TriggerStatus.MULTI_TENANCY_ENABLED, response.getStatus());
         assertFalse(response.getStatus().isTriggered());
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
@@ -6,6 +6,8 @@
 package org.opensearch.ml.action.memorycontainer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -95,8 +97,21 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
         MemoryRetentionJobProcessor.reset();
     }
 
+    /**
+     * Stub the async {@code triggerRun(ActionListener)} so it synchronously reports {@code status} to its
+     * listener, mirroring the fast (already-gated / lock-uncontended) path.
+     */
+    @SuppressWarnings("unchecked")
+    private void stubTriggerRunResponds(TriggerStatus status) {
+        doAnswer(invocation -> {
+            ActionListener<TriggerStatus> l = invocation.getArgument(0);
+            l.onResponse(status);
+            return null;
+        }).when(mockProcessor).triggerRun(any(ActionListener.class));
+    }
+
     public void testTriggeredSuccess() {
-        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.TRIGGERED);
+        stubTriggerRunResponds(TriggerStatus.TRIGGERED);
 
         action.doExecute(task, request, actionListener);
 
@@ -109,7 +124,7 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
     }
 
     public void testAlreadyRunning() {
-        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.ALREADY_RUNNING);
+        stubTriggerRunResponds(TriggerStatus.ALREADY_RUNNING);
 
         action.doExecute(task, request, actionListener);
 
@@ -120,7 +135,7 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
     }
 
     public void testRetentionDisabled() {
-        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.RETENTION_DISABLED);
+        stubTriggerRunResponds(TriggerStatus.RETENTION_DISABLED);
 
         action.doExecute(task, request, actionListener);
 
@@ -131,7 +146,7 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
     }
 
     public void testMultiTenancyEnabled() {
-        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.MULTI_TENANCY_ENABLED);
+        stubTriggerRunResponds(TriggerStatus.MULTI_TENANCY_ENABLED);
 
         action.doExecute(task, request, actionListener);
 
@@ -152,11 +167,32 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
         assertTrue(e instanceof OpenSearchStatusException);
         assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) e).status());
         // The processor must never be touched when the feature is off.
-        verify(mockProcessor, never()).triggerRun();
+        verify(mockProcessor, never()).triggerRun(any(ActionListener.class));
     }
 
+    @SuppressWarnings("unchecked")
     public void testProcessorFailureIsInternalServerError() {
-        when(mockProcessor.triggerRun()).thenThrow(new RuntimeException("kickoff failed"));
+        // Async failure: triggerRun reports onFailure to its listener (e.g. lock acquisition failed).
+        doAnswer(invocation -> {
+            ActionListener<TriggerStatus> l = invocation.getArgument(0);
+            l.onFailure(new RuntimeException("kickoff failed"));
+            return null;
+        }).when(mockProcessor).triggerRun(any(ActionListener.class));
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, never()).onResponse(any());
+        verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        Exception e = exceptionCaptor.getValue();
+        assertTrue(e instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) e).status());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testProcessorSynchronousThrowIsInternalServerError() {
+        // A synchronous throw from triggerRun (before it can invoke the listener) is caught by doExecute's
+        // try/catch and surfaced as a 500.
+        doThrow(new RuntimeException("synchronous boom")).when(mockProcessor).triggerRun(any(ActionListener.class));
 
         action.doExecute(task, request, actionListener);
 
@@ -170,7 +206,7 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
     public void testFromActionRequestConversion() {
         // Drive doExecute with a generic ActionRequest (not the concrete type) to exercise the
         // fromActionRequest path used by the transport layer for cross-node serialization.
-        when(mockProcessor.triggerRun()).thenReturn(TriggerStatus.TRIGGERED);
+        stubTriggerRunResponds(TriggerStatus.TRIGGERED);
         ActionRequest generic = mock(ActionRequest.class);
 
         action.doExecute(task, generic, actionListener);

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportExecuteMemoryRetentionActionTests.java
@@ -71,10 +71,18 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
 
     private ActionRequest request;
 
+    private org.opensearch.common.util.concurrent.ThreadContext threadContext;
+
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.openMocks(this);
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        // Wire a real ThreadContext so RestActionUtils.getUserContext(client) can read the user header.
+        // No header set = security disabled (user == null) -> admin gate is a no-op, matching most tests.
+        threadContext = new org.opensearch.common.util.concurrent.ThreadContext(org.opensearch.common.settings.Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         request = MLExecuteMemoryRetentionRequest.builder().build();
 
@@ -168,6 +176,44 @@ public class TransportExecuteMemoryRetentionActionTests extends OpenSearchTestCa
         assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) e).status());
         // The processor must never be touched when the feature is off.
         verify(mockProcessor, never()).triggerRun(any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testNonAdminUserIsForbidden() throws Exception {
+        // A security-enabled, non-admin caller must be rejected: on-demand execute is cluster-wide and
+        // could force early deletion of data the caller cannot otherwise reach.
+        setUser("alice", "some_backend_role");
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, never()).onResponse(any());
+        verify(actionListener, times(1)).onFailure(exceptionCaptor.capture());
+        Exception e = exceptionCaptor.getValue();
+        assertTrue(e instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) e).status());
+        // The processor must never be touched when the caller is not an admin.
+        verify(mockProcessor, never()).triggerRun(any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAdminUserIsAllowed() throws Exception {
+        // An all_access admin passes the gate and the trigger proceeds.
+        setUser("admin", "all_access");
+        stubTriggerRunResponds(TriggerStatus.TRIGGERED);
+
+        action.doExecute(task, request, actionListener);
+
+        verify(actionListener, times(1)).onResponse(responseCaptor.capture());
+        verify(actionListener, never()).onFailure(any());
+        assertEquals(TriggerStatus.TRIGGERED, responseCaptor.getValue().getStatus());
+        verify(mockProcessor, times(1)).triggerRun(any(ActionListener.class));
+    }
+
+    /** Put a user + roles into the thread context in the format RestActionUtils.getUserContext expects. */
+    private void setUser(String name, String... roles) {
+        String rolesCsv = String.join(",", roles);
+        threadContext
+            .putTransient(org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, name + "||" + rolesCsv);
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/TransportMemoryRetentionDryRunActionTests.java
@@ -126,6 +126,9 @@ public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCas
                 )
         );
         lenient().when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, set));
+        // dryRunContainer consults the node-scoped remote-metadata setting via clusterService.getSettings();
+        // no remote store is configured here (REMOTE_METADATA_TYPE defaults to empty), so isRemoteMetadataStore == false.
+        lenient().when(clusterService.getSettings()).thenReturn(settings);
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         lenient().when(clusterService.state()).thenReturn(clusterState);
@@ -356,6 +359,126 @@ public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCas
         assertEquals(0, response.getSkippedCount());
     }
 
+    public void testSingleContainerTenantValidationFailure() {
+        // Multi-tenancy on + null tenantId -> validateTenantId short-circuits with FORBIDDEN before any get().
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertEquals(RestStatus.FORBIDDEN, ((OpenSearchStatusException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testSingleContainerGetFailureWrappedAsStatus() {
+        // A non-IndexNotFound get() failure is wrapped and surfaced (hits the log.error/wrapAsStatusException branch).
+        doAnswer(inv -> {
+            ActionListener<GetResponse> l = inv.getArgument(1);
+            l.onFailure(new RuntimeException("boom"));
+            return null;
+        }).when(client).get(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().memoryContainerId("c1").build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof OpenSearchStatusException);
+    }
+
+    public void testClusterWideWithContainersEvaluatesEach() {
+        // Two visible containers with no policy -> both evaluated, both produce a "none" result. Exercises the
+        // full cluster-wide processHitChain path (searchContainerPage -> processHitChain -> dryRunContainer).
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(containerHits("a", "b"));
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        MLMemoryRetentionDryRunResponse response = responseCaptor.getValue();
+        assertTrue(response.isClusterWide());
+        assertEquals(2, response.getResults().size());
+        assertEquals("none", response.getResults().get(0).getPolicySource());
+    }
+
+    public void testClusterWideSkipsAccessDeniedContainers() {
+        // Access denied on every container -> all silently skipped, empty results but still cluster-wide.
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(containerHits("a", "b"));
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(false);
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        assertTrue(responseCaptor.getValue().isClusterWide());
+        assertEquals(0, responseCaptor.getValue().getResults().size());
+    }
+
+    public void testClusterWideSkipsUnparseableContainers() {
+        // A hit whose source is not valid container JSON is skipped without failing the whole run.
+        SearchHit good = containerHit("a", CONTAINER_JSON);
+        SearchHit bad = containerHit("b", "{not valid json");
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onResponse(hitsOf(good, bad));
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        assertEquals(1, responseCaptor.getValue().getResults().size());
+    }
+
+    public void testClusterWideSearchErrorSurfaces() {
+        // A non-IndexNotFound search failure is surfaced as a status exception.
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            l.onFailure(new RuntimeException("search boom"));
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+        verify(listener).onFailure(exceptionCaptor.capture());
+        assertTrue(exceptionCaptor.getValue() instanceof OpenSearchStatusException);
+    }
+
+    public void testClusterWidePaginatesAcrossPages() {
+        // First page returns a full page (100 hits) so a follow-up searchContainerPage runs with searchAfter;
+        // second page is empty and terminates. Exercises the nextPageSort / searchAfter branch.
+        SearchHit[] full = new SearchHit[100];
+        for (int i = 0; i < 100; i++) {
+            full[i] = containerHit("c" + i, CONTAINER_JSON);
+        }
+        java.util.concurrent.atomic.AtomicInteger call = new java.util.concurrent.atomic.AtomicInteger();
+        doAnswer(inv -> {
+            ActionListener<SearchResponse> l = inv.getArgument(1);
+            if (call.getAndIncrement() == 0) {
+                l.onResponse(hitsOf(full));
+            } else {
+                l.onResponse(emptyHits());
+            }
+            return null;
+        }).when(client).search(any(), isA(ActionListener.class));
+        when(memoryContainerHelper.checkMemoryContainerAccess(any(), any())).thenReturn(true);
+
+        MLMemoryRetentionDryRunRequest request = MLMemoryRetentionDryRunRequest.builder().build();
+        action.doExecute(task, request, listener);
+
+        verify(listener).onResponse(responseCaptor.capture());
+        assertEquals(100, responseCaptor.getValue().getResults().size());
+        // 1 first page + 1 empty follow-up page.
+        assertEquals(2, call.get());
+    }
+
     private SearchResponse emptyCount() {
         SearchResponse r = mock(SearchResponse.class);
         SearchHits hits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
@@ -365,5 +488,28 @@ public class TransportMemoryRetentionDryRunActionTests extends OpenSearchTestCas
 
     private SearchResponse emptyHits() {
         return emptyCount();
+    }
+
+    /** Builds a SearchHit carrying the given id and JSON source, with a sort value so pagination can read it. */
+    private SearchHit containerHit(String id, String json) {
+        SearchHit hit = new SearchHit(0, id, null, java.util.Collections.emptyMap());
+        hit.sourceRef(new org.opensearch.core.common.bytes.BytesArray(json));
+        hit.sortValues(new Object[] { id }, new org.opensearch.search.DocValueFormat[] { org.opensearch.search.DocValueFormat.RAW });
+        return hit;
+    }
+
+    private SearchResponse hitsOf(SearchHit... hits) {
+        SearchResponse r = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 1.0f);
+        when(r.getHits()).thenReturn(searchHits);
+        return r;
+    }
+
+    private SearchResponse containerHits(String... ids) {
+        SearchHit[] hits = new SearchHit[ids.length];
+        for (int i = 0; i < ids.length; i++) {
+            hits[i] = containerHit(ids[i], CONTAINER_JSON);
+        }
+        return hitsOf(hits);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -699,6 +699,97 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
+    public void testDoExecute_SessionCreationWithNullOwnerId_SecurityDisabled() {
+        // Regression test: on a security-disabled cluster there is no authenticated user, so owner_id is null.
+        // The session-summary path previously built the session document with
+        // Map.of(OWNER_ID_FIELD, input.getOwnerId(), ...), and Map.of rejects null values, throwing an NPE the
+        // moment a container had an LLM configured. This verifies the session is created successfully and the
+        // owner_id field is simply omitted when null.
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello")).role("user").build();
+        List<MessageInput> messages = Arrays.asList(message);
+
+        Map<String, String> namespace = new HashMap<>();
+        // No session_id - triggers session creation
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("container-123");
+        when(input.getMessages()).thenReturn(messages);
+        when(input.isInfer()).thenReturn(false);
+        when(input.getNamespace()).thenReturn(namespace);
+        when(input.getOwnerId()).thenReturn(null); // security disabled: no authenticated user
+        when(input.getPayloadType()).thenReturn(PayloadType.CONVERSATIONAL);
+        when(input.getParameters()).thenReturn(new HashMap<>());
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+        when(config.getLlmId()).thenReturn("llm-123"); // required so the summary/session path runs
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        // Mock summarizeMessages - invokes the listener synchronously, which runs the (previously NPE-throwing) path
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onResponse("Session summary");
+            return null;
+        }).when(memoryProcessingService).summarizeMessages(any(), eq(config), eq(messages), any());
+
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            IndexRequest indexRequest = invocation.getArgument(1);
+            if (indexRequest.index().equals("session-index")) {
+                when(indexResponse.getId()).thenReturn("session-123");
+            } else {
+                when(indexResponse.getId()).thenReturn("working-mem-123");
+            }
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        // Pre-fix, the null owner_id in Map.of threw an NPE inside the summary listener's onResponse, which
+        // ActionListener.wrap routes to onFailure. Post-fix the flow completes: both writes happen and onResponse
+        // is called, never onFailure.
+        verify(memoryProcessingService).summarizeMessages(any(), eq(config), eq(messages), any());
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(memoryContainerHelper, org.mockito.Mockito.times(2))
+            .indexData(any(MemoryConfiguration.class), indexRequestCaptor.capture(), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+        verify(actionListener, org.mockito.Mockito.never()).onFailure(any());
+
+        // The session document must omit owner_id when it is null (rather than storing a null value).
+        IndexRequest sessionRequest = indexRequestCaptor
+            .getAllValues()
+            .stream()
+            .filter(r -> "session-index".equals(r.index()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("expected a write to the session index"));
+        Map<String, Object> sessionSource = sessionRequest.sourceAsMap();
+        assertFalse("owner_id must be omitted from the session doc when null", sessionSource.containsKey("owner_id"));
+        assertEquals("container-123", sessionSource.get("memory_container_id"));
+        assertEquals("Session summary", sessionSource.get("summary"));
+    }
+
+    @Test
     public void testDoExecute_SessionCreation_SummarizeFailure() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
 

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -185,7 +185,9 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
     }
 
-    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenMultiTenancyEnabled() {
+    public void testClusterChanged_MemoryRetentionJobStarted_WhenMultiTenancyEnabled() {
+        // RFC #4859: the retention job is a single cluster-wide, system-context janitor with per-container tenant
+        // isolation, so it must be SCHEDULED even when multi-tenancy is enabled. Multi-tenancy no longer gates it.
         setupClusterState(false, createDataNode("n1", Version.CURRENT));
         when(clusterService.getSettings())
             .thenReturn(org.opensearch.common.settings.Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
@@ -195,7 +197,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         listener.clusterChanged(event);
 
-        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
+        verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
@@ -355,7 +357,10 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
     }
 
-    public void testSettingsUpdateConsumer_SkippedWhenMultiTenancyEnabled() {
+    public void testSettingsUpdateConsumer_UpsertsWhenMultiTenancyEnabled() {
+        // RFC #4859: multi-tenancy no longer gates the retention job, so a live interval change on the elected
+        // cluster manager must still upsert the shared job doc even when multi-tenancy is enabled. All nodes on
+        // CURRENT so the rolling-upgrade guard (jobsIndexReadyForWrite) passes and multi-tenancy is the only variable.
         DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerConsumerState(dataNode);
         when(clusterService.getSettings()).thenReturn(Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build());
@@ -364,7 +369,7 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
 
         clusterSettings.applySettings(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 2).build());
 
-        verify(mlTaskManager, never()).upsertMemoryRetentionJob(anyInt());
+        verify(mlTaskManager).upsertMemoryRetentionJob(2);
     }
 
     public void testSettingsUpdateConsumer_SkippedWhenMixedVersionCluster() {

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -200,6 +200,28 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         verify(mlTaskManager).indexMemoryRetentionJob(24);
     }
 
+    public void testClusterChanged_MemoryRetentionJobNotStarted_WhenRemoteMetadataStoreConfigured() {
+        // RFC #4859: with a remote metadata store (e.g. AWS OpenSearch Serverless / DynamoDB), the container registry
+        // is not in the local cluster, so the native-client retention job cannot enumerate it. It must NOT be scheduled.
+        // Local-metadata multi-tenancy remains supported (see testClusterChanged_MemoryRetentionJobStarted_WhenMultiTenancyEnabled).
+        setupClusterState(false, createDataNode("n1", Version.CURRENT));
+        when(clusterService.getSettings())
+            .thenReturn(
+                org.opensearch.common.settings.Settings
+                    .builder()
+                    .put("plugins.ml_commons.multi_tenancy_enabled", true)
+                    .put("plugins.ml_commons.remote_metadata_type", "AWSOpenSearchService")
+                    .build()
+            );
+
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
+
+        listener.clusterChanged(event);
+
+        verify(mlTaskManager, never()).indexMemoryRetentionJob(anyInt());
+    }
+
     public void testClusterChanged_MemoryRetentionJobNotStarted_WhenAgenticMemoryDisabled() {
         setupClusterState(false, createDataNode("n1", Version.CURRENT));
         when(clusterService.getSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);

--- a/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/cluster/MLCommonsClusterEventListenerTests.java
@@ -270,9 +270,12 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
     public void testClusterChanged_MemoryRetentionReconcile_HonorsPersistedIntervalFromMetadata() {
         DiscoveryNode dataNode = createDataNode("dataNode", Version.CURRENT);
         setupElectedClusterManagerState(dataNode, false, true);
-        // Node bootstrap (opensearch.yml) has nothing; the interval was set via the cluster-settings API -> metadata.
+        // Node bootstrap (opensearch.yml) has nothing; the interval was set via `PUT _cluster/settings persistent:`,
+        // which lands in metadata.persistentSettings(). Fix #1 overlays those on top of node settings so dynamic
+        // values win — this asserts the reconcile reads the persisted value (1), not the default (24).
         when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
-        when(metadata.settings()).thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
+        when(metadata.persistentSettings())
+            .thenReturn(Settings.builder().put("plugins.ml_commons.memory.retention_job_interval_hours", 1).build());
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
         when(mlFeatureEnabledSetting.isMemoryRetentionEnabled()).thenReturn(true);
 
@@ -460,6 +463,8 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
         when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        when(metadata.persistentSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        when(metadata.transientSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
         setupStateReady();
     }
 
@@ -478,6 +483,8 @@ public class MLCommonsClusterEventListenerTests extends OpenSearchTestCase {
         when(clusterService.state()).thenReturn(clusterState);
         when(metadata.hasIndex(ML_JOBS_INDEX)).thenReturn(hasMLJobsIndex);
         when(metadata.settings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        when(metadata.persistentSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
+        when(metadata.transientSettings()).thenReturn(org.opensearch.common.settings.Settings.EMPTY);
         setupStateReady();
     }
 

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionDryRunTests.java
@@ -528,10 +528,12 @@ public class MemoryRetentionDryRunTests {
         assertNoDeletes();
     }
 
-    private Settings.Builder gateSettings(boolean multiTenancy, boolean retentionEnabled) {
-        return Settings
-            .builder()
-            .put("plugins.ml_commons.multi_tenancy_enabled", multiTenancy)
+    private Settings.Builder gateSettings(boolean remoteMetadataStore, boolean retentionEnabled) {
+        Settings.Builder builder = Settings.builder();
+        if (remoteMetadataStore) {
+            builder.put("plugins.ml_commons.remote_metadata_type", "AWSOpenSearchService");
+        }
+        return builder
             .put("plugins.ml_commons.memory.retention_enabled", retentionEnabled)
             .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
             .put("plugins.ml_commons.memory.default_session_retention_days", -1)
@@ -572,16 +574,17 @@ public class MemoryRetentionDryRunTests {
     }
 
     @Test
-    public void testDryRunShortCircuitsWhenMultiTenancyEnabled() {
-        // MT enabled hard-gates the scheduled job off, so the dry-run must short-circuit to total=0 even when the
-        // policy WOULD evict data. The mock returns evictable sessions; if the passes ran total would be > 0.
+    public void testDryRunShortCircuitsWhenRemoteMetadataStore() {
+        // A remote metadata store hard-gates the scheduled job off, so the dry-run must short-circuit to total=0 even
+        // when the policy WOULD evict data. The mock returns evictable sessions; if the passes ran total would be > 0.
+        // The remote-metadata short-circuit returns before the retention-disabled check, so that warning is absent.
         applySettings(gateSettings(true, true).build());
         mockSessionsWouldEvict();
 
         MemoryRetentionDryRunResult result = run(sessionConfig(7, 5), null);
 
         assertEquals(0, result.getTotalWouldDelete());
-        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("multi-tenancy is enabled")));
+        assertTrue(result.getWarnings().stream().anyMatch(w -> w.contains("a remote metadata store is configured")));
         assertFalse(result.getWarnings().stream().anyMatch(w -> w.contains("retention is disabled cluster-wide")));
         assertNotNull(result.getEffectivePolicy());
         assertNotNull(result.getPolicySource());
@@ -592,6 +595,7 @@ public class MemoryRetentionDryRunTests {
     public void testDryRunShortCircuitsWhenRetentionDisabled() {
         // retention_enabled=false gates the whole feature off, so the dry-run must short-circuit to total=0 even
         // when the policy WOULD evict data. The mock returns evictable sessions; if the passes ran total would be > 0.
+        // No remote metadata store here, so the run reaches the retention-disabled short-circuit.
         applySettings(gateSettings(false, false).build());
         mockSessionsWouldEvict();
 

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.ml.common.CommonValue.ML_MEMORY_CONTAINER_INDEX;
+import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.MEMORY_CONTAINER_ID_FIELD;
 import static org.opensearch.ml.common.memorycontainer.MemoryContainerConstants.ORPHAN_SWEEP_BASELINE_TIME_FIELD;
 
 import java.lang.reflect.Field;
@@ -155,8 +156,16 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
-    public void testRunSkipsWhenMultiTenancyEnabled() {
-        Settings settings = Settings.builder().put("plugins.ml_commons.multi_tenancy_enabled", true).build();
+    public void testRunExecutesWhenMultiTenancyEnabled() {
+        // RFC #4859: the retention job is a single cluster-wide, system-context janitor. Multi-tenancy no longer
+        // gates it; it must schedule/run and scan the global container registry regardless of the MT setting.
+        // Tenant isolation is achieved per-container via the memory_container_id filter (see the isolation test),
+        // not by refusing to run under MT.
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", true)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .build();
         when(clusterService.getSettings()).thenReturn(settings);
         java.util.Set<Setting<?>> s = new java.util.HashSet<>(
             java.util.Arrays
@@ -174,10 +183,119 @@ public class MemoryRetentionJobProcessorTests {
         );
         when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
 
+        // Return empty containers
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
         processor.run();
 
-        // Should not search for containers when multi-tenancy is enabled
-        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        // The job must scan the global container registry even when multi-tenancy is enabled.
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testMultiTenancyTenantIsolationViaContainerIdFilter() {
+        // RFC #4859 tenant-isolation guard: every per-container search/delete issued by a single cluster-wide run
+        // MUST be scoped by termQuery(memory_container_id, <containerId>). Container ids are globally unique in the
+        // shared registry and each maps to exactly one tenant, so this transitively confines every physical-index
+        // read/delete to that container's own tenant. If any future per-container query drops the container_id term,
+        // it would leak/delete across tenants in the shared default index; this test fails in that case.
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", true)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.memory.retention_job_throttle_seconds", 1)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        final String containerId = "tenant-a-container";
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            containerId,
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        java.util.List<SearchRequest> perContainerSearches = new java.util.ArrayList<>();
+
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    listener.onResponse(emptySearchResponse());
+                }
+            } else {
+                // Record every non-registry (per-container) search and return expired sessions to drive deletes.
+                perContainerSearches.add(request);
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHits sessionHits = new SearchHits(new SearchHit[] { hit1 }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        java.util.List<DeleteByQueryRequest> deleteByQueryRequests = new java.util.ArrayList<>();
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        lenient().when(cascadeResponse.getDeleted()).thenReturn(1L);
+        doAnswer(invocation -> {
+            deleteByQueryRequests.add(invocation.getArgument(1));
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // Every per-container search must be scoped by the container id term (never the registry index).
+        assertTrue("expected at least one per-container search", perContainerSearches.size() > 0);
+        for (SearchRequest req : perContainerSearches) {
+            String q = req.source().query().toString();
+            assertTrue("per-container search query must filter on memory_container_id: " + q, q.contains(MEMORY_CONTAINER_ID_FIELD));
+            assertTrue("per-container search query must reference container id " + containerId + ": " + q, q.contains(containerId));
+        }
+
+        // Every delete-by-query must likewise be scoped by the container id term.
+        assertTrue("expected at least one delete-by-query", deleteByQueryRequests.size() > 0);
+        for (DeleteByQueryRequest dbq : deleteByQueryRequests) {
+            String q = dbq.getSearchRequest().source().query().toString();
+            assertTrue("delete-by-query must filter on memory_container_id: " + q, q.contains(MEMORY_CONTAINER_ID_FIELD));
+            assertTrue("delete-by-query must reference container id " + containerId + ": " + q, q.contains(containerId));
+        }
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.lucene.search.TotalHits;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,12 +64,16 @@ import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.index.reindex.BulkByScrollResponse;
 import org.opensearch.index.reindex.DeleteByQueryAction;
 import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.jobscheduler.spi.LockModel;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.settings.MLCommonsSettings;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregations;
 import org.opensearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -91,9 +96,16 @@ public class MemoryRetentionJobProcessorTests {
 
     private MemoryRetentionJobProcessor processor;
 
+    // A mock LockService wired into the processor for every test. By default acquiring the cluster-wide lock
+    // succeeds (returns a non-null LockModel), renewal echoes the lock, and release succeeds. Individual tests
+    // that exercise contention override acquireLockWithId to return null.
+    private LockService lockService;
+    private LockModel lockModel;
+
     @Before
     public void setUp() {
         MemoryRetentionJobProcessor.reset();
+        MemoryRetentionJobProcessor.setLockService(null);
 
         // Default settings: multi-tenancy disabled, throttle = 1 second
         Settings settings = Settings
@@ -146,7 +158,56 @@ public class MemoryRetentionJobProcessorTests {
             return null;
         }).when(threadPool).schedule(any(Runnable.class), any(TimeValue.class), anyString());
 
+        // Lock renewal scheduling: return a no-op cancellable and do NOT auto-run (renewal is periodic; running
+        // it inline would recurse). Tests that assert renewal drive it explicitly.
+        lenient()
+            .when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class), anyString()))
+            .thenReturn(mock(Scheduler.Cancellable.class));
+
+        // Wire a mock cluster-wide LockService: acquire succeeds, renew echoes, release succeeds.
+        // LockModel is final and cannot be mocked, so use a real instance.
+        lockService = mock(LockService.class);
+        lockModel = new LockModel(".plugins-ml-jobs", "MEMORY_RETENTION", java.time.Instant.ofEpochMilli(0L), 120L, false);
+        lenient().doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(3);
+            l.onResponse(lockModel);
+            return null;
+        }).when(lockService).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+        lenient().doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(1);
+            l.onResponse(lockModel);
+            return null;
+        }).when(lockService).renewLock(any(LockModel.class), isA(ActionListener.class));
+        // Teardown deletes the lock by id (unconditional), not release(lockModel) — see finishRun().
+        lenient().doAnswer(invocation -> {
+            ActionListener<Boolean> l = invocation.getArgument(1);
+            l.onResponse(true);
+            return null;
+        }).when(lockService).deleteLock(anyString(), isA(ActionListener.class));
+        MemoryRetentionJobProcessor.setLockService(lockService);
+
         processor = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
+    }
+
+    @After
+    public void tearDown() {
+        MemoryRetentionJobProcessor.setLockService(null);
+        MemoryRetentionJobProcessor.reset();
+    }
+
+    /**
+     * Invokes the async {@link MemoryRetentionJobProcessor#triggerRun(ActionListener)} and returns the
+     * synchronously-reported status. All stubs in these tests complete their listeners inline, so the status
+     * is always available by the time triggerRun returns.
+     */
+    private TriggerStatus triggerRunSync() {
+        AtomicReference<TriggerStatus> statusRef = new AtomicReference<>();
+        AtomicReference<Exception> errorRef = new AtomicReference<>();
+        processor.triggerRun(ActionListener.wrap(statusRef::set, errorRef::set));
+        if (errorRef.get() != null) {
+            throw new RuntimeException(errorRef.get());
+        }
+        return statusRef.get();
     }
 
     @Test
@@ -164,13 +225,12 @@ public class MemoryRetentionJobProcessorTests {
         when(clusterService.getSettings()).thenReturn(settings);
         when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, gatingSettingsSet()));
 
-        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus status = processor.triggerRun();
+        TriggerStatus status = triggerRunSync();
 
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.REMOTE_METADATA_STORE,
-            status
-        );
+        assertEquals(TriggerStatus.REMOTE_METADATA_STORE, status);
         verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        // Gating short-circuits before any lock is requested.
+        verify(lockService, never()).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
     }
 
     @Test
@@ -183,13 +243,11 @@ public class MemoryRetentionJobProcessorTests {
         when(clusterService.getSettings()).thenReturn(settings);
         when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, gatingSettingsSet()));
 
-        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus status = processor.triggerRun();
+        TriggerStatus status = triggerRunSync();
 
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.RETENTION_DISABLED,
-            status
-        );
+        assertEquals(TriggerStatus.RETENTION_DISABLED, status);
         verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(lockService, never()).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
     }
 
     @Test
@@ -198,18 +256,21 @@ public class MemoryRetentionJobProcessorTests {
         // We stub search to NOT invoke the listener, leaving the job "in progress".
         doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
-        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus first = processor.triggerRun();
-        assertEquals(org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED, first);
+        TriggerStatus first = triggerRunSync();
+        assertEquals(TriggerStatus.TRIGGERED, first);
 
         // Second trigger while the first is still in progress must be rejected without double-running.
-        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus second = processor.triggerRun();
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.ALREADY_RUNNING,
-            second
-        );
+        // The per-node isRunning guard short-circuits before a second lock acquisition is attempted.
+        TriggerStatus second = triggerRunSync();
+        assertEquals(TriggerStatus.ALREADY_RUNNING, second);
 
         // Only the first trigger initiated a container search.
         verify(client, org.mockito.Mockito.times(1)).search(any(SearchRequest.class), isA(ActionListener.class));
+        // The cluster-wide lock was acquired exactly once (for the first, still-in-progress run) and never
+        // released, since that run never completed.
+        verify(lockService, org.mockito.Mockito.times(1))
+            .acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+        verify(lockService, never()).deleteLock(anyString(), isA(ActionListener.class));
     }
 
     @Test
@@ -221,53 +282,124 @@ public class MemoryRetentionJobProcessorTests {
             return null;
         }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
-            processor.triggerRun()
-        );
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
         // Guard released on completion -> a subsequent trigger is TRIGGERED again, not ALREADY_RUNNING.
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
-            processor.triggerRun()
-        );
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+
+        // Each completed run releases the cluster-wide lock exactly once (two runs -> two deletes).
+        verify(lockService, org.mockito.Mockito.times(2)).deleteLock(anyString(), isA(ActionListener.class));
     }
 
     @Test
-    public void testRunSwallowsSynchronousKickoffFailureAndReleasesGuard() {
-        // Make the very first container search throw synchronously on the calling thread, so
-        // resolveContainersWithPolicies(null) throws inside triggerRun()'s try block.
-        doThrow(new RuntimeException("synchronous kickoff boom")).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+    public void testTriggerRunReturnsAlreadyRunningWhenLockHeldClusterWide() {
+        // Simulate another node (or the scheduler) already holding the cluster-wide lock: acquire yields null.
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(3);
+            l.onResponse(null);
+            return null;
+        }).when(lockService).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
 
-        // run() (scheduled path) must NOT propagate the exception (fire-and-forget semantics).
-        processor.run();
+        assertEquals(TriggerStatus.ALREADY_RUNNING, triggerRunSync());
 
-        // The guard must have been reset before the rethrow inside triggerRun(), so retention is not
-        // permanently wedged: switch search to succeed and confirm a subsequent trigger is TRIGGERED,
-        // not ALREADY_RUNNING.
+        // No pipeline started, and the per-node guard was released so a later trigger can proceed.
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        // Confirm the guard is free: with the lock now acquirable again, a second trigger is TRIGGERED.
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(3);
+            l.onResponse(lockModel);
+            return null;
+        }).when(lockService).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+    }
+
+    @Test
+    public void testTriggerRunReportsFailureWhenLockAcquisitionFails() {
+        // Lock acquisition errors: the run must not start, the per-node guard must be released, and the
+        // failure must be reported to the listener (so the transport layer can surface a 500).
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(3);
+            l.onFailure(new RuntimeException("lock index unavailable"));
+            return null;
+        }).when(lockService).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+
+        AtomicReference<TriggerStatus> statusRef = new AtomicReference<>();
+        AtomicReference<Exception> errorRef = new AtomicReference<>();
+        processor.triggerRun(ActionListener.wrap(statusRef::set, errorRef::set));
+
+        assertNotNull(errorRef.get());
+        assertEquals(null, statusRef.get());
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Guard released: a subsequent trigger (lock now acquirable) is TRIGGERED, not ALREADY_RUNNING.
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(3);
+            l.onResponse(lockModel);
+            return null;
+        }).when(lockService).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+    }
+
+    @Test
+    public void testTriggerRunRunsWithoutLockServiceWhenUnavailable() {
+        // No cluster-wide LockService wired (e.g. job-scheduler absent): the run degrades to per-node
+        // exclusion and still executes the pipeline.
+        MemoryRetentionJobProcessor.setLockService(null);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(emptySearchResponse());
             return null;
         }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
-            processor.triggerRun()
-        );
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+        verify(client, atLeastOnce()).search(any(SearchRequest.class), isA(ActionListener.class));
+        // Restore for tearDown symmetry / other assertions.
+        MemoryRetentionJobProcessor.setLockService(lockService);
     }
 
     @Test
-    public void testTriggerRunRethrowsSynchronousKickoffFailure() {
-        // The on-demand path relies on triggerRun() rethrowing (so the transport layer can surface a
-        // 500) while still having reset the guard first.
+    public void testRunSwallowsSynchronousKickoffFailureAndReleasesGuard() {
+        // Make the very first container search throw synchronously on the calling thread, so
+        // resolveContainersWithPolicies(null) throws inside kickOffPipeline()'s try block.
         doThrow(new RuntimeException("synchronous kickoff boom")).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
 
-        try {
-            processor.triggerRun();
-            fail("triggerRun() should rethrow a synchronous kickoff failure");
-        } catch (RuntimeException expected) {
-            assertEquals("synchronous kickoff boom", expected.getMessage());
-        }
+        // run() (scheduled path) must NOT propagate the exception (fire-and-forget semantics).
+        processor.run();
+
+        // The guard and lock must have been released before the failure was reported, so retention is not
+        // permanently wedged: switch search to succeed and confirm a subsequent trigger is TRIGGERED.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+    }
+
+    @Test
+    public void testTriggerRunReportsSynchronousKickoffFailure() {
+        // The on-demand path relies on triggerRun() reporting the failure via its listener (so the transport
+        // layer can surface a 500) while still having released the guard and lock first.
+        doThrow(new RuntimeException("synchronous kickoff boom")).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        AtomicReference<TriggerStatus> statusRef = new AtomicReference<>();
+        AtomicReference<Exception> errorRef = new AtomicReference<>();
+        processor.triggerRun(ActionListener.wrap(statusRef::set, errorRef::set));
+
+        assertNotNull(errorRef.get());
+        assertEquals("synchronous kickoff boom", errorRef.get().getMessage());
+        // The lock acquired for this run must have been released (deleted by id) on the failure path.
+        verify(lockService, atLeastOnce()).deleteLock(anyString(), isA(ActionListener.class));
 
         // Guard released despite the failure.
         doAnswer(invocation -> {
@@ -275,10 +407,49 @@ public class MemoryRetentionJobProcessorTests {
             listener.onResponse(emptySearchResponse());
             return null;
         }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
-        assertEquals(
-            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
-            processor.triggerRun()
-        );
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+    }
+
+    @Test
+    public void testSynchronousThrowOnContinuationSearchStillReleasesLockAndGuard() {
+        // Regression for the pipeline-continuation leak: the first container search returns a full page (so
+        // the pipeline continues into a SECOND search dispatch), and that second dispatch throws synchronously.
+        // The run must still tear down (delete the lock, reset the guard) rather than leaving the lock-renewal
+        // task alive to renew the cluster-wide lock forever.
+        AtomicInteger searchCalls = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            int n = searchCalls.incrementAndGet();
+            if (n == 1) {
+                // A full page (CONTAINER_PAGE_SIZE=100) of no-config containers: processContainer skips each
+                // (no config field), the chain runs to the end of the page and, because a full page implies
+                // more, re-enters resolveContainersWithPolicies -> second search dispatch.
+                SearchHit[] page = new SearchHit[100];
+                for (int i = 0; i < page.length; i++) {
+                    page[i] = createHitWithSource("c" + i, Map.of());
+                }
+                SearchResponse full = mock(SearchResponse.class);
+                when(full.getHits()).thenReturn(new SearchHits(page, new TotalHits(page.length, TotalHits.Relation.EQUAL_TO), Float.NaN));
+                ActionListener<SearchResponse> listener = invocation.getArgument(1);
+                listener.onResponse(full);
+                return null;
+            }
+            // Second (continuation) search dispatch throws synchronously on the calling thread.
+            throw new RuntimeException("synchronous continuation boom");
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // Scheduled path swallows; the point is the teardown side effects.
+        processor.run();
+
+        // Lock released (deleted) and guard freed: a subsequent empty-container trigger is TRIGGERED, not
+        // ALREADY_RUNNING, proving the run did not wedge.
+        verify(lockService, atLeastOnce()).deleteLock(anyString(), isA(ActionListener.class));
+        searchCalls.set(0);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
     }
 
     private java.util.Set<Setting<?>> gatingSettingsSet() {

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -6,6 +6,7 @@
 package org.opensearch.ml.jobs.processors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +35,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.lucene.search.TotalHits;
@@ -3548,5 +3551,192 @@ public class MemoryRetentionJobProcessorTests {
 
         assertNotNull("collectOldestDocIds should have completed synchronously", result.get());
         assertEquals("collectOldestDocIds must not collect more than the per-run cap", cap, result.get().size());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Guard-leak regression tests: the isRunning guard must always reset, even when a run fails on a
+    // thread that no ActionListener wraps, so retention can never silently wedge until node restart.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testGuardResetsAfterMidRunThrowInScheduledContinuation() throws Exception {
+        // The primary leak vector: after a container with deletions, the chain resumes inside a
+        // threadPool.schedule() continuation that runs on the GENERIC pool, OUTSIDE any listener. A
+        // synchronous throw there (modeled here as the orphan-sweep search rejecting work) used to be
+        // swallowed by the executor, leaving isRunning stuck true forever. Emulate real executor
+        // isolation by swallowing the runnable's throw the way ThreadPool.schedule would, so this test
+        // reproduces the production leak rather than masking it behind the synchronous default mock.
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            try {
+                runnable.run();
+            } catch (Throwable ignored) {
+                // A real scheduled executor routes this to the uncaught-exception handler, not the caller.
+            }
+            return null;
+        }).when(threadPool).schedule(any(Runnable.class), any(TimeValue.class), anyString());
+
+        SearchResponse containerSearchResponse = createContainerSearchResponse(
+            "container-time",
+            "test-prefix",
+            true,
+            createRetentionPolicyMap("sessions", 7, null)
+        );
+
+        AtomicInteger containerSearchCount = new AtomicInteger(0);
+        doAnswer(invocation -> {
+            SearchRequest request = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+
+            if (request.indices()[0].equals(ML_MEMORY_CONTAINER_INDEX)) {
+                if (containerSearchCount.getAndIncrement() == 0) {
+                    // First container-index search returns one container with deletions, which drives
+                    // the chain into scheduleNext() and then into the scheduled orphan-sweep search.
+                    listener.onResponse(containerSearchResponse);
+                } else {
+                    // Second container-index search is the orphan sweep, reached inside the scheduled
+                    // continuation. Throw synchronously to simulate an unhandled mid-run failure.
+                    throw new RuntimeException("injected orphan-sweep failure inside scheduled continuation");
+                }
+            } else {
+                // Session search returns 3 expired sessions so container-0 reports deletions.
+                long oldTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+                SearchHit hit1 = createHitWithSource("expired-session-1", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit2 = createHitWithSource("expired-session-2", Map.of("last_updated_time", oldTimestamp));
+                SearchHit hit3 = createHitWithSource("expired-session-3", Map.of("last_updated_time", oldTimestamp));
+                SearchHits sessionHits = new SearchHits(
+                    new SearchHit[] { hit1, hit2, hit3 },
+                    new TotalHits(3, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN
+                );
+                SearchResponse sessionResponse = mock(SearchResponse.class);
+                when(sessionResponse.getHits()).thenReturn(sessionHits);
+                listener.onResponse(sessionResponse);
+            }
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        BulkByScrollResponse cascadeResponse = mock(BulkByScrollResponse.class);
+        lenient().when(cascadeResponse.getDeleted()).thenReturn(10L);
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(2);
+            listener.onResponse(cascadeResponse);
+            return null;
+        }).when(client).execute(eq(DeleteByQueryAction.INSTANCE), any(DeleteByQueryRequest.class), isA(ActionListener.class));
+
+        BulkResponse bulkResponse = mock(BulkResponse.class);
+        lenient().when(bulkResponse.hasFailures()).thenReturn(false);
+        lenient().when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> listener = invocation.getArgument(1);
+            listener.onResponse(bulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        // The mid-run throw was reached (orphan-sweep search was attempted) ...
+        assertTrue("orphan-sweep search should have been attempted inside the continuation", containerSearchCount.get() >= 2);
+        // ... and despite it, the guard was released so the next scheduled run is not blocked.
+        assertFalse("isRunning must reset after a mid-run throw in the scheduled continuation", isRunningFlag(processor));
+        assertEquals("runStartMillis must be cleared once the guard is released", Long.MIN_VALUE, runStartMillis(processor));
+
+        // Prove recovery end-to-end: a subsequent invocation is NOT skipped as "already in progress".
+        AtomicBoolean recoverySearched = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            recoverySearched.set(true);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        processor.run();
+        assertTrue("a fresh run after a leak must proceed, not skip", recoverySearched.get());
+        assertFalse("isRunning must be false after the recovering run completes", isRunningFlag(processor));
+    }
+
+    @Test
+    public void testGuardResetsWhenInitialSearchThrows() throws Exception {
+        // A synchronous throw from the very first search (kicked off directly inside run()) must be
+        // caught and reset the guard via the run() try/catch.
+        doAnswer(invocation -> { throw new RuntimeException("injected initial search failure"); })
+            .when(client)
+            .search(any(SearchRequest.class), isA(ActionListener.class));
+
+        processor.run();
+
+        assertFalse("isRunning must reset when the initial container search throws", isRunningFlag(processor));
+        assertEquals("runStartMillis must be cleared", Long.MIN_VALUE, runStartMillis(processor));
+    }
+
+    @Test
+    public void testStuckGuardWatchdogClearsGuardAndNextRunRecovers() throws Exception {
+        // Simulate a previously leaked guard: isRunning stuck true, acquired longer ago than any real
+        // run could last. The watchdog in run() must CLEAR the guard and skip THIS invocation (it must
+        // not take over and start a competing run), then the NEXT invocation must proceed cleanly.
+        setIsRunning(processor, true);
+        setRunStartMillis(processor, System.currentTimeMillis() - stuckTimeoutMillis() - TimeUnit.HOURS.toMillis(1));
+
+        AtomicBoolean searched = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            searched.set(true);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // First invocation: detects the leak, clears the guard, and does NOT start a run.
+        processor.run();
+        assertFalse("watchdog must not start a competing run on the stuck-guard invocation", searched.get());
+        assertFalse("isRunning must be cleared by the watchdog", isRunningFlag(processor));
+        assertEquals("runStartMillis must be cleared by the watchdog", Long.MIN_VALUE, runStartMillis(processor));
+
+        // Second invocation: guard is free, so this one runs normally.
+        processor.run();
+        assertTrue("the next scheduled run after a cleared leak must proceed", searched.get());
+        assertFalse("isRunning must be false after the recovering run completes", isRunningFlag(processor));
+        assertEquals("runStartMillis must be cleared after recovery", Long.MIN_VALUE, runStartMillis(processor));
+    }
+
+    @Test
+    public void testRecentGuardIsNotStolenByWatchdog() throws Exception {
+        // A genuinely in-flight run (guard acquired just now) must still cause a concurrent invocation
+        // to skip — the watchdog must not steal a healthy run.
+        setIsRunning(processor, true);
+        setRunStartMillis(processor, System.currentTimeMillis());
+
+        processor.run();
+
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        assertTrue("a healthy in-flight guard must remain held", isRunningFlag(processor));
+    }
+
+    private boolean isRunningFlag(MemoryRetentionJobProcessor p) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("isRunning");
+        f.setAccessible(true);
+        return ((AtomicBoolean) f.get(p)).get();
+    }
+
+    private void setIsRunning(MemoryRetentionJobProcessor p, boolean value) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("isRunning");
+        f.setAccessible(true);
+        ((AtomicBoolean) f.get(p)).set(value);
+    }
+
+    private long runStartMillis(MemoryRetentionJobProcessor p) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("runStartMillis");
+        f.setAccessible(true);
+        return ((AtomicLong) f.get(p)).get();
+    }
+
+    private void setRunStartMillis(MemoryRetentionJobProcessor p, long value) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("runStartMillis");
+        f.setAccessible(true);
+        ((AtomicLong) f.get(p)).set(value);
+    }
+
+    private long stuckTimeoutMillis() throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("STUCK_GUARD_TIMEOUT_MILLIS");
+        f.setAccessible(true);
+        return f.getLong(null);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -47,6 +48,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.action.bulk.BulkItemResponse;
@@ -454,6 +457,149 @@ public class MemoryRetentionJobProcessorTests {
             return null;
         }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
         assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+    }
+
+    @Test
+    public void testLockRenewalRunnableRenewsLockAndAdvancesCurrentLock() throws Exception {
+        // Keep the pipeline in flight (search never completes) so the run holds the lock and does not tear it
+        // down before we drive one renewal tick.
+        doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        // renewLock returns a fresh, higher-version model (distinct instance) that currentLock should adopt.
+        LockModel renewed = new LockModel(".plugins-ml-jobs", "MEMORY_RETENTION", java.time.Instant.ofEpochMilli(60000L), 120L, false);
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(1);
+            l.onResponse(renewed);
+            return null;
+        }).when(lockService).renewLock(any(LockModel.class), isA(ActionListener.class));
+
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+        assertSame("the run should be holding the freshly acquired lock", lockModel, currentLock(processor));
+
+        // Capture the periodic renewal task registered via scheduleWithFixedDelay and drive one tick by hand.
+        ArgumentCaptor<Runnable> cap = ArgumentCaptor.forClass(Runnable.class);
+        verify(threadPool).scheduleWithFixedDelay(cap.capture(), any(TimeValue.class), anyString());
+        cap.getValue().run();
+
+        verify(lockService, atLeastOnce()).renewLock(any(LockModel.class), isA(ActionListener.class));
+        assertSame("currentLock must advance to the renewed (higher-version) model", renewed, currentLock(processor));
+    }
+
+    @Test
+    public void testFinishRunCancelsRenewalBeforeDeletingLock() throws Exception {
+        // Hold a concrete cancellable so we can assert the teardown ordering.
+        Scheduler.Cancellable cancellable = mock(Scheduler.Cancellable.class);
+        when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class), anyString())).thenReturn(cancellable);
+        // Empty containers -> pipeline completes synchronously, so finishRun() runs on this thread.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+
+        // Ordering contract (see finishRun): the renewal task is cancelled BEFORE the lock is deleted, to
+        // minimise the window in which an in-flight renewal can race the delete.
+        InOrder order = inOrder(cancellable, lockService);
+        order.verify(cancellable).cancel();
+        order.verify(lockService).deleteLock(anyString(), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testRenewalReturningNullSetsLockLostAndFinishRunSkipsDeleteLock() throws Exception {
+        // Keep the run in flight so it holds the lock; then drive a renewal that returns null (the lock doc
+        // could not be advanced -- likely expired and possibly re-acquired elsewhere under the same id).
+        doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(1);
+            l.onResponse(null);
+            return null;
+        }).when(lockService).renewLock(any(LockModel.class), isA(ActionListener.class));
+
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+        assertFalse("lockLost starts false for a fresh acquisition", lockLost(processor));
+
+        ArgumentCaptor<Runnable> cap = ArgumentCaptor.forClass(Runnable.class);
+        verify(threadPool).scheduleWithFixedDelay(cap.capture(), any(TimeValue.class), anyString());
+        cap.getValue().run();
+        assertTrue("a null renewal must flag lockLost", lockLost(processor));
+
+        // finishRun() must now SKIP deleteLock: the doc may belong to a different, still-live run.
+        invokeFinishRun(processor);
+        verify(lockService, never()).deleteLock(anyString(), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testRenewalFailureSetsLockLostAndFinishRunSkipsDeleteLock() throws Exception {
+        // Same contract as the null case, but via the renewLock onFailure arm.
+        doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        doAnswer(invocation -> {
+            ActionListener<LockModel> l = invocation.getArgument(1);
+            l.onFailure(new RuntimeException("renew failed"));
+            return null;
+        }).when(lockService).renewLock(any(LockModel.class), isA(ActionListener.class));
+
+        assertEquals(TriggerStatus.TRIGGERED, triggerRunSync());
+
+        ArgumentCaptor<Runnable> cap = ArgumentCaptor.forClass(Runnable.class);
+        verify(threadPool).scheduleWithFixedDelay(cap.capture(), any(TimeValue.class), anyString());
+        cap.getValue().run();
+        assertTrue("a failed renewal must flag lockLost", lockLost(processor));
+
+        invokeFinishRun(processor);
+        verify(lockService, never()).deleteLock(anyString(), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testWatchdogReclaimsGuardWithoutTouchingClusterLock() throws Exception {
+        // Option C: a leaked per-node guard (held longer than any real run could last) is reclaimed by the
+        // watchdog reclaiming ONLY the per-node guard. It must NOT acquire, renew, or delete the cluster-wide
+        // lock -- a still-live run on another node may own it, and deleting it here would let a competing run
+        // start and cascade.
+        setIsRunning(processor, true);
+        setRunStartMillis(processor, System.currentTimeMillis() - stuckTimeoutMillis(processor) - TimeUnit.HOURS.toMillis(1));
+
+        processor.run();
+
+        assertFalse("watchdog must clear the per-node guard", isRunningFlag(processor));
+        assertEquals("watchdog must clear the start-time stamp", Long.MIN_VALUE, runStartMillis(processor));
+        // No run was started and the cluster-wide lock was left entirely untouched.
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(lockService, never()).deleteLock(anyString(), isA(ActionListener.class));
+        verify(lockService, never()).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testTriggerRunSkipsForRemoteOpenSearch() {
+        assertTriggerSkipsForRemoteMetadataType("RemoteOpenSearch");
+    }
+
+    @Test
+    public void testTriggerRunSkipsForAWSDynamoDB() {
+        assertTriggerSkipsForRemoteMetadataType("AWSDynamoDB");
+    }
+
+    @Test
+    public void testTriggerRunSkipsForAWSOpenSearchService() {
+        assertTriggerSkipsForRemoteMetadataType("AWSOpenSearchService");
+    }
+
+    /**
+     * Shared body for the REMOTE_METADATA_STORE trigger tests: with the given remote metadata type configured, the
+     * trigger must short-circuit to REMOTE_METADATA_STORE before any registry scan or lock acquisition.
+     */
+    private void assertTriggerSkipsForRemoteMetadataType(String remoteType) {
+        Settings settings = Settings.builder().put("plugins.ml_commons.remote_metadata_type", remoteType).build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, gatingSettingsSet()));
+
+        AtomicReference<TriggerStatus> statusRef = new AtomicReference<>();
+        processor
+            .triggerRun(ActionListener.wrap(statusRef::set, e -> fail("unexpected failure for " + remoteType + ": " + e.getMessage())));
+
+        assertEquals("remote metadata type " + remoteType + " must skip", TriggerStatus.REMOTE_METADATA_STORE, statusRef.get());
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+        verify(lockService, never()).acquireLockWithId(anyString(), any(Long.class), anyString(), isA(ActionListener.class));
     }
 
     private java.util.Set<Setting<?>> gatingSettingsSet() {
@@ -3770,5 +3916,24 @@ public class MemoryRetentionJobProcessorTests {
 
     private long stuckTimeoutMillis(MemoryRetentionJobProcessor p) {
         return p.stuckGuardTimeoutMillis();
+    }
+
+    @SuppressWarnings("unchecked")
+    private LockModel currentLock(MemoryRetentionJobProcessor p) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("currentLock");
+        f.setAccessible(true);
+        return ((AtomicReference<LockModel>) f.get(p)).get();
+    }
+
+    private boolean lockLost(MemoryRetentionJobProcessor p) throws Exception {
+        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("lockLost");
+        f.setAccessible(true);
+        return f.getBoolean(p);
+    }
+
+    private void invokeFinishRun(MemoryRetentionJobProcessor p) throws Exception {
+        Method m = MemoryRetentionJobProcessor.class.getDeclaredMethod("finishRun");
+        m.setAccessible(true);
+        m.invoke(p);
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -153,6 +154,148 @@ public class MemoryRetentionJobProcessorTests {
         MemoryRetentionJobProcessor instance1 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
         MemoryRetentionJobProcessor instance2 = MemoryRetentionJobProcessor.getInstance(clusterService, client, threadPool);
         assertSame(instance1, instance2);
+    }
+
+    @Test
+    public void testTriggerRunReturnsRemoteMetadataStore() {
+        // RFC #4859: multi-tenancy no longer gates the job (local-metadata MT runs tenant-isolated). The trigger
+        // skips only when a REMOTE metadata store is configured, returning REMOTE_METADATA_STORE.
+        Settings settings = Settings.builder().put("plugins.ml_commons.remote_metadata_type", "AWSOpenSearchService").build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, gatingSettingsSet()));
+
+        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus status = processor.triggerRun();
+
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.REMOTE_METADATA_STORE,
+            status
+        );
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testTriggerRunReturnsRetentionDisabled() {
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", false)
+            .put("plugins.ml_commons.memory.retention_enabled", false)
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, gatingSettingsSet()));
+
+        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus status = processor.triggerRun();
+
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.RETENTION_DISABLED,
+            status
+        );
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testTriggerRunReturnsTriggeredThenAlreadyRunning() throws Exception {
+        // First trigger: kick off the pipeline but never let it complete, so isRunning stays true.
+        // We stub search to NOT invoke the listener, leaving the job "in progress".
+        doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus first = processor.triggerRun();
+        assertEquals(org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED, first);
+
+        // Second trigger while the first is still in progress must be rejected without double-running.
+        org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus second = processor.triggerRun();
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.ALREADY_RUNNING,
+            second
+        );
+
+        // Only the first trigger initiated a container search.
+        verify(client, org.mockito.Mockito.times(1)).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
+    public void testTriggerRunReturnsTriggeredAndCompletesGuardReleased() {
+        // Empty containers -> pipeline completes synchronously, isRunning is reset, so a second trigger works.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
+            processor.triggerRun()
+        );
+        // Guard released on completion -> a subsequent trigger is TRIGGERED again, not ALREADY_RUNNING.
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
+            processor.triggerRun()
+        );
+    }
+
+    @Test
+    public void testRunSwallowsSynchronousKickoffFailureAndReleasesGuard() {
+        // Make the very first container search throw synchronously on the calling thread, so
+        // resolveContainersWithPolicies(null) throws inside triggerRun()'s try block.
+        doThrow(new RuntimeException("synchronous kickoff boom")).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        // run() (scheduled path) must NOT propagate the exception (fire-and-forget semantics).
+        processor.run();
+
+        // The guard must have been reset before the rethrow inside triggerRun(), so retention is not
+        // permanently wedged: switch search to succeed and confirm a subsequent trigger is TRIGGERED,
+        // not ALREADY_RUNNING.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
+            processor.triggerRun()
+        );
+    }
+
+    @Test
+    public void testTriggerRunRethrowsSynchronousKickoffFailure() {
+        // The on-demand path relies on triggerRun() rethrowing (so the transport layer can surface a
+        // 500) while still having reset the guard first.
+        doThrow(new RuntimeException("synchronous kickoff boom")).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+
+        try {
+            processor.triggerRun();
+            fail("triggerRun() should rethrow a synchronous kickoff failure");
+        } catch (RuntimeException expected) {
+            assertEquals("synchronous kickoff boom", expected.getMessage());
+        }
+
+        // Guard released despite the failure.
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(emptySearchResponse());
+            return null;
+        }).when(client).search(any(SearchRequest.class), isA(ActionListener.class));
+        assertEquals(
+            org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse.TriggerStatus.TRIGGERED,
+            processor.triggerRun()
+        );
+    }
+
+    private java.util.Set<Setting<?>> gatingSettingsSet() {
+        return new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_HISTORY_MAX_COUNT,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_ORPHAN_TTL_DAYS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_WORKING_MEMORY_TTL_DAYS
+                )
+        );
     }
 
     @Test

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -197,6 +197,35 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testRunSkipsWhenRemoteMetadataStoreConfigured() {
+        // RFC #4859: when a REMOTE metadata store is configured (e.g. AWS OpenSearch Serverless / DynamoDB), the
+        // container registry lives outside the local cluster, so the native-client janitor cannot enumerate it and
+        // would silently clean nothing. The job must skip entirely (no registry scan) rather than run against an
+        // empty local registry. Local-metadata multi-tenancy is unaffected (see testRunExecutesWhenMultiTenancyEnabled).
+        Settings settings = Settings
+            .builder()
+            .put("plugins.ml_commons.multi_tenancy_enabled", true)
+            .put("plugins.ml_commons.memory.retention_enabled", true)
+            .put("plugins.ml_commons.remote_metadata_type", "AWSOpenSearchService")
+            .build();
+        when(clusterService.getSettings()).thenReturn(settings);
+        java.util.Set<Setting<?>> s = new java.util.HashSet<>(
+            java.util.Arrays
+                .asList(
+                    MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
+                    MLCommonsSettings.REMOTE_METADATA_TYPE
+                )
+        );
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(settings, s));
+
+        processor.run();
+
+        // The job must NOT scan the container registry when metadata is stored remotely.
+        verify(client, never()).search(any(SearchRequest.class), isA(ActionListener.class));
+    }
+
+    @Test
     public void testMultiTenancyTenantIsolationViaContainerIdFilter() {
         // RFC #4859 tenant-isolation guard: every per-container search/delete issued by a single cluster-wide run
         // MUST be scoped by termQuery(memory_container_id, <containerId>). Container ids are globally unique in the

--- a/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/jobs/processors/MemoryRetentionJobProcessorTests.java
@@ -131,6 +131,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -462,6 +463,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -490,6 +492,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -562,6 +565,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -658,6 +662,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -700,6 +705,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -2088,6 +2094,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -2997,6 +3004,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -3066,6 +3074,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -3368,6 +3377,7 @@ public class MemoryRetentionJobProcessorTests {
                     MLCommonsSettings.ML_COMMONS_MULTI_TENANCY_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_ENABLED,
                     MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_THROTTLE_SECONDS,
+                    MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_RETENTION_DAYS,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_SESSION_MAX_COUNT,
                     MLCommonsSettings.ML_COMMONS_MEMORY_DEFAULT_LONG_TERM_MAX_COUNT,
@@ -3674,7 +3684,7 @@ public class MemoryRetentionJobProcessorTests {
         // run could last. The watchdog in run() must CLEAR the guard and skip THIS invocation (it must
         // not take over and start a competing run), then the NEXT invocation must proceed cleanly.
         setIsRunning(processor, true);
-        setRunStartMillis(processor, System.currentTimeMillis() - stuckTimeoutMillis() - TimeUnit.HOURS.toMillis(1));
+        setRunStartMillis(processor, System.currentTimeMillis() - stuckTimeoutMillis(processor) - TimeUnit.HOURS.toMillis(1));
 
         AtomicBoolean searched = new AtomicBoolean(false);
         doAnswer(invocation -> {
@@ -3698,6 +3708,30 @@ public class MemoryRetentionJobProcessorTests {
     }
 
     @Test
+    public void testStuckGuardTimeoutScalesWithConfiguredInterval() {
+        // Liveness floor, not a run timeout: max(24h floor, 2 × interval). The floor keeps the detection
+        // window generous on short intervals; the interval multiple widens it on long intervals so a
+        // legitimately long-running weekly-interval run isn't false-flagged as stuck. With the DEFAULT 24h
+        // interval, 2 × 24h = 48h beats the 24h floor. The floor only binds for intervals <= 12h.
+        assertEquals("default 24h interval -> 2 × interval (48h) wins", TimeUnit.HOURS.toMillis(48), processor.stuckGuardTimeoutMillis());
+
+        // 1h interval: 2 × 1h = 2h, floored up to 24h.
+        Settings shortInterval = Settings
+            .builder()
+            .put(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.getKey(), 1)
+            .build();
+        clusterService.getClusterSettings().applySettings(shortInterval);
+        assertEquals("1h interval -> 24h floor wins over 2h", TimeUnit.HOURS.toMillis(24), processor.stuckGuardTimeoutMillis());
+
+        // 72h (3d) interval: 2 × 72h = 144h.
+        Settings longInterval = Settings
+            .builder()
+            .put(MLCommonsSettings.ML_COMMONS_MEMORY_RETENTION_JOB_INTERVAL_HOURS.getKey(), 72)
+            .build();
+        clusterService.getClusterSettings().applySettings(longInterval);
+        assertEquals("72h interval -> 2 × interval (144h) wins", TimeUnit.HOURS.toMillis(144), processor.stuckGuardTimeoutMillis());
+    }
+
     public void testRecentGuardIsNotStolenByWatchdog() throws Exception {
         // A genuinely in-flight run (guard acquired just now) must still cause a concurrent invocation
         // to skip — the watchdog must not steal a healthy run.
@@ -3734,9 +3768,7 @@ public class MemoryRetentionJobProcessorTests {
         ((AtomicLong) f.get(p)).set(value);
     }
 
-    private long stuckTimeoutMillis() throws Exception {
-        Field f = MemoryRetentionJobProcessor.class.getDeclaredField("STUCK_GUARD_TIMEOUT_MILLIS");
-        f.setAccessible(true);
-        return f.getLong(null);
+    private long stuckTimeoutMillis(MemoryRetentionJobProcessor p) {
+        return p.stuckGuardTimeoutMillis();
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/plugin/MachineLearningPluginTests.java
@@ -38,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionResponse;
@@ -46,11 +47,13 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.ingest.Processor;
 import org.opensearch.jobscheduler.spi.JobDocVersion;
+import org.opensearch.jobscheduler.spi.utils.LockService;
 import org.opensearch.ml.common.CommonValue;
 import org.opensearch.ml.common.spi.MLCommonsExtension;
 import org.opensearch.ml.common.spi.tools.Tool;
 import org.opensearch.ml.engine.tools.MLModelTool;
 import org.opensearch.ml.jobs.MLJobRunner;
+import org.opensearch.ml.jobs.processors.MemoryRetentionJobProcessor;
 import org.opensearch.ml.processor.MLInferenceIngestProcessor;
 import org.opensearch.ml.processor.MLInferenceSearchRequestProcessor;
 import org.opensearch.ml.processor.MLInferenceSearchResponseProcessor;
@@ -333,5 +336,35 @@ public class MachineLearningPluginTests {
         List<?> factories = plugin.getPreBuiltAnalyzerProviderFactories();
         assertNotNull(factories);
         assertEquals(2, factories.size());
+    }
+
+    @Test
+    public void testGetGuiceServiceClassesRegistersHolder() {
+        Collection<Class<? extends LifecycleComponent>> classes = plugin.getGuiceServiceClasses();
+        assertNotNull(classes);
+        assertEquals(1, classes.size());
+        assertTrue(classes.contains(MachineLearningPlugin.GuiceHolder.class));
+    }
+
+    @Test
+    public void testGuiceHolderInjectsLockServiceIntoProcessor() {
+        // The holder's optional setter is the only wiring that hands the node LockService to the retention
+        // processor; when job-scheduler is present Guice fires it at node start. Verify the setter propagates
+        // the LockService and that the lifecycle no-ops don't throw.
+        MemoryRetentionJobProcessor.reset();
+        try {
+            MachineLearningPlugin.GuiceHolder holder = new MachineLearningPlugin.GuiceHolder();
+            LockService lockService = mock(LockService.class);
+            // Setter is null-tolerant and idempotent; both propagate to the processor without throwing.
+            holder.setLockService(lockService);
+            holder.setLockService(null);
+            holder.setLockService(lockService);
+            // Lifecycle hooks are no-ops but must be exercised/safe.
+            holder.start();
+            holder.stop();
+            holder.close();
+        } finally {
+            MemoryRetentionJobProcessor.reset();
+        }
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
@@ -99,7 +99,7 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
         assertEquals(1, routes.size());
         RestHandler.Route route = routes.get(0);
         assertEquals(RestRequest.Method.POST, route.getMethod());
-        assertEquals("/_plugins/_ml/memory/_retention/_execute", route.getPath());
+        assertEquals("/_plugins/_ml/memory_containers/_retention/_execute", route.getPath());
     }
 
     public void testGetRequestMultiTenancyDisabled() throws IOException {
@@ -116,7 +116,7 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
         headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList("tenant-77"));
         RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(RestRequest.Method.POST)
-            .withPath("/_plugins/_ml/memory/_retention/_execute")
+            .withPath("/_plugins/_ml/memory_containers/_retention/_execute")
             .withHeaders(headers)
             .build();
 
@@ -151,7 +151,7 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
     private RestRequest createRestRequest() {
         return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
             .withMethod(RestRequest.Method.POST)
-            .withPath("/_plugins/_ml/memory/_retention/_execute")
+            .withPath("/_plugins/_ml/memory_containers/_retention/_execute")
             .build();
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
@@ -123,7 +123,10 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
             .withMethod(RestRequest.Method.POST)
             .withPath("/_plugins/_ml/memory_containers/_retention/_execute")
             .withHeaders(headers)
-            .withContent(new org.opensearch.core.common.bytes.BytesArray("{\"foo\":\"bar\"}"), org.opensearch.common.xcontent.XContentType.JSON)
+            .withContent(
+                new org.opensearch.core.common.bytes.BytesArray("{\"foo\":\"bar\"}"),
+                org.opensearch.common.xcontent.XContentType.JSON
+            )
             .build();
 
         thrown.expect(OpenSearchStatusException.class);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.ml.common.input.Constants;
+import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionAction;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
+import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.rest.FakeRestRequest;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.node.NodeClient;
+
+public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private RestMLExecuteMemoryRetentionAction restAction;
+
+    NodeClient client;
+    private ThreadPool threadPool;
+
+    @Mock
+    RestChannel channel;
+
+    @Mock
+    private MLFeatureEnabledSetting mlFeatureEnabledSetting;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(false);
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+        restAction = new RestMLExecuteMemoryRetentionAction(mlFeatureEnabledSetting);
+
+        threadPool = new TestThreadPool(this.getClass().getSimpleName() + "ThreadPool");
+        client = spy(new NodeClient(Settings.EMPTY, threadPool));
+
+        doAnswer(invocation -> {
+            ActionListener<MLExecuteMemoryRetentionResponse> actionListener = invocation.getArgument(2);
+            return null;
+        }).when(client).execute(eq(MLExecuteMemoryRetentionAction.INSTANCE), any(), any());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        client.close();
+    }
+
+    public void testConstructor() {
+        assertNotNull(new RestMLExecuteMemoryRetentionAction(mlFeatureEnabledSetting));
+    }
+
+    public void testGetName() {
+        String name = restAction.getName();
+        assertFalse(Strings.isNullOrEmpty(name));
+        assertEquals("ml_execute_memory_retention_action", name);
+    }
+
+    public void testRoutes() {
+        List<RestHandler.Route> routes = restAction.routes();
+        assertNotNull(routes);
+        assertEquals(1, routes.size());
+        RestHandler.Route route = routes.get(0);
+        assertEquals(RestRequest.Method.POST, route.getMethod());
+        assertEquals("/_plugins/_ml/memory/_retention/_execute", route.getPath());
+    }
+
+    public void testGetRequestMultiTenancyDisabled() throws IOException {
+        RestRequest request = createRestRequest();
+        MLExecuteMemoryRetentionRequest executeRequest = restAction.getRequest(request);
+        assertNotNull(executeRequest);
+        assertNull(executeRequest.getTenantId());
+    }
+
+    public void testGetRequestMultiTenancyEnabled() throws IOException {
+        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList("tenant-77"));
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory/_retention/_execute")
+            .withHeaders(headers)
+            .build();
+
+        MLExecuteMemoryRetentionRequest executeRequest = restAction.getRequest(request);
+        assertNotNull(executeRequest);
+        assertEquals("tenant-77", executeRequest.getTenantId());
+    }
+
+    public void testPrepareRequest() throws Exception {
+        RestRequest request = createRestRequest();
+        restAction.handleRequest(request, channel, client);
+
+        ArgumentCaptor<MLExecuteMemoryRetentionRequest> captor = ArgumentCaptor.forClass(MLExecuteMemoryRetentionRequest.class);
+        verify(client, times(1)).execute(eq(MLExecuteMemoryRetentionAction.INSTANCE), captor.capture(), any());
+        assertNotNull(captor.getValue());
+        assertNull(captor.getValue().getTenantId());
+    }
+
+    public void testPrepareRequestAgenticMemoryDisabled() throws IOException {
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(false);
+        RestRequest request = createRestRequest();
+
+        thrown.expect(OpenSearchStatusException.class);
+        thrown
+            .expectMessage(
+                "The Agentic Memory APIs are not enabled. To enable, please update the setting plugins.ml_commons.agentic_memory_enabled"
+            );
+
+        restAction.prepareRequest(request, client);
+    }
+
+    private RestRequest createRestRequest() {
+        return new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory/_retention/_execute")
+            .build();
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMLExecuteMemoryRetentionActionTests.java
@@ -30,7 +30,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.ml.common.input.Constants;
 import org.opensearch.ml.common.settings.MLFeatureEnabledSetting;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionAction;
 import org.opensearch.ml.common.transport.memorycontainer.MLExecuteMemoryRetentionRequest;
@@ -102,27 +101,10 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
         assertEquals("/_plugins/_ml/memory_containers/_retention/_execute", route.getPath());
     }
 
-    public void testGetRequestMultiTenancyDisabled() throws IOException {
+    public void testGetRequest() throws IOException {
         RestRequest request = createRestRequest();
         MLExecuteMemoryRetentionRequest executeRequest = restAction.getRequest(request);
         assertNotNull(executeRequest);
-        assertNull(executeRequest.getTenantId());
-    }
-
-    public void testGetRequestMultiTenancyEnabled() throws IOException {
-        when(mlFeatureEnabledSetting.isMultiTenancyEnabled()).thenReturn(true);
-
-        Map<String, List<String>> headers = new HashMap<>();
-        headers.put(Constants.TENANT_ID_HEADER, Collections.singletonList("tenant-77"));
-        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
-            .withMethod(RestRequest.Method.POST)
-            .withPath("/_plugins/_ml/memory_containers/_retention/_execute")
-            .withHeaders(headers)
-            .build();
-
-        MLExecuteMemoryRetentionRequest executeRequest = restAction.getRequest(request);
-        assertNotNull(executeRequest);
-        assertEquals("tenant-77", executeRequest.getTenantId());
     }
 
     public void testPrepareRequest() throws Exception {
@@ -132,7 +114,22 @@ public class RestMLExecuteMemoryRetentionActionTests extends OpenSearchTestCase 
         ArgumentCaptor<MLExecuteMemoryRetentionRequest> captor = ArgumentCaptor.forClass(MLExecuteMemoryRetentionRequest.class);
         verify(client, times(1)).execute(eq(MLExecuteMemoryRetentionAction.INSTANCE), captor.capture(), any());
         assertNotNull(captor.getValue());
-        assertNull(captor.getValue().getTenantId());
+    }
+
+    public void testPrepareRequestRejectsRequestBody() throws IOException {
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Collections.singletonList("application/json"));
+        RestRequest request = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY)
+            .withMethod(RestRequest.Method.POST)
+            .withPath("/_plugins/_ml/memory_containers/_retention/_execute")
+            .withHeaders(headers)
+            .withContent(new org.opensearch.core.common.bytes.BytesArray("{\"foo\":\"bar\"}"), org.opensearch.common.xcontent.XContentType.JSON)
+            .build();
+
+        thrown.expect(OpenSearchStatusException.class);
+        thrown.expectMessage("_execute does not accept a request body");
+
+        restAction.prepareRequest(request, client);
     }
 
     public void testPrepareRequestAgenticMemoryDisabled() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
@@ -17,7 +17,7 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.ml.utils.TestHelper;
 
 /**
- * Integration tests for the on-demand retention execute endpoint {@code POST /_plugins/_ml/memory/_retention/_execute},
+ * Integration tests for the on-demand retention execute endpoint {@code POST /_plugins/_ml/memory_containers/_retention/_execute},
  * which previously had zero IT coverage.
  *
  * <p>The highest-value test ({@link #testExecuteEvictsExpiredSessions()}) is a true end-to-end eviction: it uses a
@@ -29,7 +29,7 @@ public class RestMemoryRetentionExecuteIT extends MLCommonsRestTestCase {
 
     private static final String CREATE_PATH = "/_plugins/_ml/memory_containers/_create";
     private static final String CONTAINER_PATH = "/_plugins/_ml/memory_containers/";
-    private static final String EXECUTE_PATH = "/_plugins/_ml/memory/_retention/_execute";
+    private static final String EXECUTE_PATH = "/_plugins/_ml/memory_containers/_retention/_execute";
 
     @Before
     public void setup() throws IOException {

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.rest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.ml.utils.TestHelper;
+
+/**
+ * Integration tests for the on-demand retention execute endpoint {@code POST /_plugins/_ml/memory/_retention/_execute},
+ * which previously had zero IT coverage.
+ *
+ * <p>The highest-value test ({@link #testExecuteEvictsExpiredSessions()}) is a true end-to-end eviction: it uses a
+ * count-based ({@code max_count}) session policy, which is deterministic and requires NO external LLM/embedding model,
+ * so it runs on the credential-less ephemeral node. Because the retention pipeline is fully async, the eviction
+ * assertion polls via {@code assertBusy(...)} with a generous but bounded timeout rather than asserting immediately.
+ */
+public class RestMemoryRetentionExecuteIT extends MLCommonsRestTestCase {
+
+    private static final String CREATE_PATH = "/_plugins/_ml/memory_containers/_create";
+    private static final String CONTAINER_PATH = "/_plugins/_ml/memory_containers/";
+    private static final String EXECUTE_PATH = "/_plugins/_ml/memory/_retention/_execute";
+
+    @Before
+    public void setup() throws IOException {
+        updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
+    }
+
+    @Test
+    public void testExecuteReturnsTriggeredWhenEnabled() throws Exception {
+        // The retention job is a cluster-wide singleton with an in-progress guard, so a run kicked off by an
+        // earlier test in this suite may still hold the guard and make a fresh trigger return "already_running".
+        // Poll until we observe a genuine "triggered" so the assertion is order-independent, not flaky.
+        Map<String, Object> body = triggerUntilAccepted();
+        assertEquals("triggered", body.get("status"));
+        assertEquals(Boolean.TRUE, body.get("triggered"));
+        assertEquals(Boolean.TRUE, body.get("acknowledged"));
+    }
+
+    @Test
+    public void testExecuteReturnsRetentionDisabledWhenDisabled() throws IOException {
+        try {
+            updateClusterSettings("plugins.ml_commons.memory.retention_enabled", false);
+            Map<String, Object> body = execute();
+            // Reads TransportExecuteMemoryRetentionAction / TriggerStatus: disabled is a benign HTTP 200 status,
+            // not an error, with triggered=false.
+            assertEquals("retention_disabled", body.get("status"));
+            assertEquals(Boolean.FALSE, body.get("triggered"));
+            assertEquals(Boolean.TRUE, body.get("acknowledged"));
+        } finally {
+            updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
+        }
+    }
+
+    @Test
+    public void testExecuteForbiddenWhenAgenticMemoryDisabled() throws IOException {
+        try {
+            updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", false);
+            try {
+                TestHelper.makeRequest(client(), "POST", EXECUTE_PATH, null, "", null);
+                fail("execute should be rejected with 403 when agentic memory is disabled");
+            } catch (ResponseException e) {
+                assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+            }
+        } finally {
+            updateClusterSettings("plugins.ml_commons.agentic_memory_enabled", true);
+        }
+    }
+
+    @Test
+    public void testExecuteEvictsExpiredSessions() throws Exception {
+        // max_count=1, count-based eviction: deterministic and model-free. 3 non-pinned + 1 pinned session.
+        String containerId = createContainer(
+            "{ \"name\": \"execute_evict_it_"
+                + System.currentTimeMillis()
+                + "\", \"configuration\": { \"retention_policy\": { \"sessions\": { \"max_count\": 1 } } } }"
+        );
+
+        createSession(containerId, "evict-1");
+        createSession(containerId, "evict-2");
+        createSession(containerId, "evict-3");
+        String pinnedSessionId = createSession(containerId, "evict-pinned");
+        pinSession(containerId, pinnedSessionId);
+
+        assertEquals("precondition: 4 sessions exist (3 non-pinned + 1 pinned)", 4L, countSessions(containerId));
+
+        // Poll for a genuine trigger (an earlier test's async run may still hold the singleton guard).
+        Map<String, Object> body = triggerUntilAccepted();
+        assertEquals("triggered", body.get("status"));
+
+        // Count-based eviction keeps max_count (1) most-recent non-pinned sessions and never touches pinned ones,
+        // so the surviving count converges to 2: the 1 retained non-pinned + the 1 pinned. The pipeline is async,
+        // so poll with a generous but bounded timeout rather than asserting immediately.
+        assertBusy(() -> {
+            long remaining = countSessions(containerId);
+            assertEquals("expected eviction down to (max_count=1) + (1 pinned) = 2 surviving sessions", 2L, remaining);
+        }, 60, TimeUnit.SECONDS);
+
+        // The pinned session must be one of the survivors.
+        assertTrue("pinned session must survive eviction", sessionExists(containerId, pinnedSessionId));
+    }
+
+    @Test
+    public void testConcurrentExecuteDoesNotError() throws IOException {
+        // A second immediate trigger must return cleanly (either "triggered" again or "already_running"),
+        // never an HTTP error. Both are benign HTTP 200 outcomes.
+        Map<String, Object> first = execute();
+        assertEquals(Boolean.TRUE, first.get("acknowledged"));
+
+        Map<String, Object> second = execute();
+        assertEquals(Boolean.TRUE, second.get("acknowledged"));
+        assertTrue(
+            "second execute should report a benign status, not an error",
+            List.of("triggered", "already_running").contains(second.get("status"))
+        );
+    }
+
+    // ---- helpers ----
+
+    private String createContainer(String body) throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", CREATE_PATH, null, TestHelper.toHttpEntity(body), null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        String containerId = (String) parseResponseToMap(response).get("memory_container_id");
+        assertNotNull("create should return a memory_container_id", containerId);
+        return containerId;
+    }
+
+    private String createSession(String containerId, String sessionId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                CONTAINER_PATH + containerId + "/memories/sessions",
+                null,
+                TestHelper.toHttpEntity("{ \"session_id\": \"" + sessionId + "\" }"),
+                null
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        String id = (String) parseResponseToMap(response).get("session_id");
+        assertNotNull("create session should return a session_id", id);
+        return id;
+    }
+
+    private void pinSession(String containerId, String sessionId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "PUT",
+                CONTAINER_PATH + containerId + "/memories/sessions/" + sessionId,
+                null,
+                TestHelper.toHttpEntity("{ \"pinned\": true }"),
+                null
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+
+    private Map<String, Object> execute() throws IOException {
+        Response response = TestHelper.makeRequest(client(), "POST", EXECUTE_PATH, null, "", null);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        return parseResponseToMap(response);
+    }
+
+    /**
+     * Triggers the retention job, retrying while a prior (possibly cross-test) run still holds the cluster-wide
+     * singleton guard and returns {@code already_running}. Returns the response once the trigger is genuinely
+     * accepted ({@code triggered}). Makes the "triggered" assertion independent of randomized test order.
+     */
+    private Map<String, Object> triggerUntilAccepted() throws Exception {
+        Map<String, Object>[] last = new Map[1];
+        assertBusy(() -> {
+            Map<String, Object> body = execute();
+            last[0] = body;
+            assertEquals("waiting for a prior retention run to release the guard", "triggered", body.get("status"));
+        }, 60, TimeUnit.SECONDS);
+        return last[0];
+    }
+
+    @SuppressWarnings("unchecked")
+    private long countSessions(String containerId) throws IOException {
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "POST",
+                CONTAINER_PATH + containerId + "/memories/sessions/_search",
+                null,
+                TestHelper.toHttpEntity("{ \"size\": 0, \"track_total_hits\": true, \"query\": { \"match_all\": {} } }"),
+                null
+            );
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        Map<String, Object> map = parseResponseToMap(response);
+        Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+        Map<String, Object> total = (Map<String, Object>) hits.get("total");
+        return ((Number) total.get("value")).longValue();
+    }
+
+    private boolean sessionExists(String containerId, String sessionId) throws IOException {
+        try {
+            Response response = TestHelper
+                .makeRequest(client(), "GET", CONTAINER_PATH + containerId + "/memories/sessions/" + sessionId, null, "", null);
+            return response.getStatusLine().getStatusCode() == 200;
+        } catch (ResponseException e) {
+            if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+                return false;
+            }
+            throw e;
+        }
+    }
+}

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryRetentionExecuteIT.java
@@ -57,7 +57,8 @@ public class RestMemoryRetentionExecuteIT extends MLCommonsRestTestCase {
             // not an error, with triggered=false.
             assertEquals("retention_disabled", body.get("status"));
             assertEquals(Boolean.FALSE, body.get("triggered"));
-            assertEquals(Boolean.TRUE, body.get("acknowledged"));
+            // acknowledged mirrors whether a run was actually triggered; a disabled job was not, so it is false.
+            assertEquals(Boolean.FALSE, body.get("acknowledged"));
         } finally {
             updateClusterSettings("plugins.ml_commons.memory.retention_enabled", true);
         }
@@ -114,19 +115,26 @@ public class RestMemoryRetentionExecuteIT extends MLCommonsRestTestCase {
     @Test
     public void testConcurrentExecuteDoesNotError() throws IOException {
         // A second immediate trigger must return cleanly (either "triggered" again or "already_running"),
-        // never an HTTP error. Both are benign HTTP 200 outcomes.
+        // never an HTTP error. Both are benign HTTP 200 outcomes. acknowledged mirrors triggered: it is true
+        // only when this call actually started a run, and false for a benign "already_running".
         Map<String, Object> first = execute();
-        assertEquals(Boolean.TRUE, first.get("acknowledged"));
+        assertBenignExecuteOutcome(first);
 
         Map<String, Object> second = execute();
-        assertEquals(Boolean.TRUE, second.get("acknowledged"));
-        assertTrue(
-            "second execute should report a benign status, not an error",
-            List.of("triggered", "already_running").contains(second.get("status"))
-        );
+        assertBenignExecuteOutcome(second);
     }
 
     // ---- helpers ----
+
+    /**
+     * Asserts an execute response is a benign HTTP 200 outcome ("triggered" or "already_running", never an error)
+     * and that {@code acknowledged} agrees with {@code triggered}: true only when a run was actually started.
+     */
+    private void assertBenignExecuteOutcome(Map<String, Object> body) {
+        Object status = body.get("status");
+        assertTrue("execute should report a benign status, not an error", List.of("triggered", "already_running").contains(status));
+        assertEquals("acknowledged must mirror triggered", body.get("triggered"), body.get("acknowledged"));
+    }
 
     private String createContainer(String body) throws IOException {
         Response response = TestHelper.makeRequest(client(), "POST", CREATE_PATH, null, TestHelper.toHttpEntity(body), null);


### PR DESCRIPTION
### Description

Part 2 of 2 for the agentic memory retention lifecycle (RFC #4859), building on the retention core + dry-run/interval work merged in #4952. This PR adds operational control and broader deployment support to the retention job. It changes none of the core deletion semantics; it governs *when* the job runs and *where* it can run.

**On-demand execution** — a new `POST /_plugins/_ml/memory_containers/_retention/_execute` endpoint triggers the retention job immediately instead of waiting for the scheduled interval. It reuses the scheduler's singleton path, so an on-demand run is identical to a scheduled one, and acknowledges asynchronously without blocking on deletions. Restricted to administrators (`all_access`), since it initiates a cluster-wide deletion run.

**Retention under self-hosted multi-tenancy** — the job previously refused to run when multi-tenancy was enabled. It now runs, isolating per container via `memory_container_id` (globally unique, single-tenant). It skips only when a remote metadata store (AOSS / DynamoDB) is configured, since the container registry then lives outside the local cluster.

**Job-execution hardening** — the cluster-wide JobScheduler lock is now held across the entire async delete pipeline (not just kickoff), with periodic renewal and a single guaranteed teardown that releases the lock and resets the in-progress guard on every terminal path and on unexpected mid-run failure. A stuck-guard watchdog (scaled to the configured interval) lets a wedged run self-recover instead of silently skipping future runs.

### Related Issues

RFC #4859

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request created.
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
