### PR TITLE
fix memory NPE on security-disabled cluster

### DIFF
--- a/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesAction.java
@@ -182,24 +182,18 @@ public class TransportAddMemoriesAction extends HandledTransportAction<MLAddMemo
                 // TODO: use LLM to summarize first user message
                 ActionListener<String> summaryListener = ActionListener.wrap(summary -> {
                     Instant now = Instant.now();
-                    indexRequest
-                        .source(
-                            Map
-                                .of(
-                                    OWNER_ID_FIELD,
-                                    input.getOwnerId(),
-                                    MEMORY_CONTAINER_ID_FIELD,
-                                    input.getMemoryContainerId(),
-                                    SUMMARY_FIELD,
-                                    summary,
-                                    NAMESPACE_FIELD,
-                                    input.getNamespace(),
-                                    CREATED_TIME_FIELD,
-                                    now.toEpochMilli(),
-                                    LAST_UPDATED_TIME_FIELD,
-                                    now.toEpochMilli()
-                                )
-                        );
+                    // Build the source with a mutable map: owner_id may be null when security is disabled, and Map.of
+                    // rejects null values (which previously NPE'd this auto-create session path).
+                    Map<String, Object> source = new HashMap<>();
+                    if (input.getOwnerId() != null) {
+                        source.put(OWNER_ID_FIELD, input.getOwnerId());
+                    }
+                    source.put(MEMORY_CONTAINER_ID_FIELD, input.getMemoryContainerId());
+                    source.put(SUMMARY_FIELD, summary);
+                    source.put(NAMESPACE_FIELD, input.getNamespace());
+                    source.put(CREATED_TIME_FIELD, now.toEpochMilli());
+                    source.put(LAST_UPDATED_TIME_FIELD, now.toEpochMilli());
+                    indexRequest.source(source);
                     indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     ActionListener<IndexResponse> responseActionListener = ActionListener.<IndexResponse>wrap(r -> {
                         input.getNamespace().put(SESSION_ID_FIELD, r.getId());

--- a/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/memorycontainer/memory/TransportAddMemoriesActionTests.java
@@ -699,6 +699,88 @@ public class TransportAddMemoriesActionTests {
     }
 
     @Test
+    public void testDoExecute_SessionCreation_NullOwnerId_SecurityDisabled() {
+        // Regression: on a security-disabled cluster owner_id is null; the auto-create session-source builder
+        // used Map.of(...) which throws NPE on null values. See paste 1786408766.
+        when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
+
+        MessageInput message = MessageInput.builder().content(createTestContent("Hello")).role("user").build();
+        List<MessageInput> messages = Arrays.asList(message);
+
+        Map<String, String> namespace = new HashMap<>();
+        namespace.put("user_id", "alice");
+
+        MLAddMemoriesInput input = mock(MLAddMemoriesInput.class);
+        when(input.getPinned()).thenReturn(null);
+        when(input.getMemoryContainerId()).thenReturn("container-123");
+        when(input.getMessages()).thenReturn(messages);
+        when(input.isInfer()).thenReturn(true);
+        when(input.getNamespace()).thenReturn(namespace);
+        when(input.getOwnerId()).thenReturn(null); // security disabled -> no authenticated user
+        when(input.getPayloadType()).thenReturn(PayloadType.CONVERSATIONAL);
+        when(input.getParameters()).thenReturn(new HashMap<>());
+
+        MLAddMemoriesRequest request = mock(MLAddMemoriesRequest.class);
+        when(request.getMlAddMemoryInput()).thenReturn(input);
+
+        MemoryConfiguration config = mock(MemoryConfiguration.class);
+        when(config.getParameters()).thenReturn(new HashMap<>());
+        when(config.getWorkingMemoryIndexName()).thenReturn("working-memory-index");
+        when(config.getSessionIndexName()).thenReturn("session-index");
+        when(config.isDisableSession()).thenReturn(false);
+        when(config.getLlmId()).thenReturn("llm-123");
+
+        MLMemoryContainer container = mock(MLMemoryContainer.class);
+        when(container.getConfiguration()).thenReturn(config);
+
+        doAnswer(invocation -> {
+            ActionListener<MLMemoryContainer> listener = invocation.getArgument(2);
+            listener.onResponse(container);
+            return null;
+        }).when(memoryContainerHelper).getMemoryContainer(eq("container-123"), any(), any());
+
+        when(memoryContainerHelper.checkMemoryContainerAccess(isNull(), eq(container))).thenReturn(true);
+
+        doAnswer(invocation -> {
+            ActionListener<String> listener = invocation.getArgument(3);
+            listener.onResponse("Session summary");
+            return null;
+        }).when(memoryProcessingService).summarizeMessages(any(), eq(config), eq(messages), any());
+
+        ArgumentCaptor<IndexRequest> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            IndexResponse indexResponse = mock(IndexResponse.class);
+            IndexRequest indexRequest = invocation.getArgument(1);
+            if (indexRequest.index().equals("session-index")) {
+                when(indexResponse.getId()).thenReturn("session-123");
+            } else {
+                when(indexResponse.getId()).thenReturn("working-mem-123");
+            }
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(memoryContainerHelper).indexData(any(MemoryConfiguration.class), indexRequestCaptor.capture(), any());
+
+        transportAddMemoriesAction.doExecute(task, request, actionListener);
+
+        // Session creation must have completed without NPE and produced a session-index write.
+        verify(memoryProcessingService).summarizeMessages(any(), eq(config), eq(messages), any());
+        verify(memoryContainerHelper, org.mockito.Mockito.times(2)).indexData(any(MemoryConfiguration.class), any(IndexRequest.class), any());
+        verify(actionListener).onResponse(any(MLAddMemoriesResponse.class));
+
+        // The session document source must omit owner_id (rather than storing null).
+        IndexRequest sessionIndexRequest = indexRequestCaptor.getAllValues()
+            .stream()
+            .filter(r -> "session-index".equals(r.index()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No session-index IndexRequest captured"));
+        Map<String, Object> sessionSource = sessionIndexRequest.sourceAsMap();
+        assertFalse("owner_id should be omitted when null", sessionSource.containsKey("owner_id"));
+        assertEquals("container-123", sessionSource.get("memory_container_id"));
+        assertEquals("Session summary", sessionSource.get("summary"));
+    }
+
+    @Test
     public void testDoExecute_SessionCreation_SummarizeFailure() {
         when(mlFeatureEnabledSetting.isAgenticMemoryEnabled()).thenReturn(true);
 


### PR DESCRIPTION
### Description
Adding a conversational memory with `infer: true` and no `session_id` fails with a 500 on a security-disabled cluster. The Add Memory API auto-creates a session, but builds the session document with `Map.of(...)`, which throws `NullPointerException` when `owner_id` is null (no authenticated user when security is disabled).

Fix: Replace `Map.of(...)` with a mutable `HashMap` that omits `owner_id` when null — mirroring the null-safe pattern already used in `upsertSessionThenProcess`. Also hardens the path against any other nullable field.

### Steps to reproduce
 
Add a conversational memory **without** a `session_id` in the namespace (so a session is
auto-created), with `infer: true`:
 
### Request
 
```json
POST /_plugins/_ml/memory_containers/<memory_container_id>/memories
{
  "messages": [
    { "role": "user", "content": [ { "text": "I prefer Rust for CLI tools.", "type": "text" } ] }
  ],
  "namespace": { "user_id": "alice" },
  "infer": true,
  "payload_type": "conversational"
}
```
 
### Response
 
```json
{
  "error": {
    "root_cause": [
      { "type": "status_exception", "reason": "Internal server error" }
    ],
    "type": "status_exception",
    "reason": "Internal server error"
  },
  "status": 500
}
```
 
### Server log / stack trace
 
```
[ERROR][o.o.m.a.m.m.TransportAddMemoriesAction] Failed to summarize messages for session creation
java.lang.NullPointerException
    at java.base/java.util.Objects.requireNonNull(Objects.java:220)
    at java.base/java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1437)
    at java.base/java.util.Map.of(Map.java:1485)
    at org.opensearch.ml.action.memorycontainer.memory.TransportAddMemoriesAction.lambda$createNewSessionIfAbsent$0(TransportAddMemoriesAction.java:170)
    at org.opensearch.core.action.ActionListener$1.onResponse(ActionListener.java:82)
    at org.opensearch.ml.action.memorycontainer.memory.MemoryProcessingService.lambda$summarizeMessages$0(MemoryProcessingService.java:532)
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
