### PR TITLE
Use Jackson 3.x for JSON processing

### DIFF
--- a/grpc/build.gradle
+++ b/grpc/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 dependencies {
     implementation project(path: ":${rootProject.name}-common", configuration: 'shadow')
-    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+    implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
     compileOnly project(':opensearch-ml-algorithms')
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "software.amazon.awssdk:auth:${versions.aws}"

--- a/grpc/src/main/java/org/opensearch/ml/grpc/converters/ProtoRequestConverter.java
+++ b/grpc/src/main/java/org/opensearch/ml/grpc/converters/ProtoRequestConverter.java
@@ -22,12 +22,12 @@ import org.opensearch.protobufs.MlExecuteAgentStreamRequest;
 import org.opensearch.protobufs.MlPredictModelStreamRequest;
 import org.opensearch.protobufs.Parameters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 
 import lombok.extern.log4j.Log4j2;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Converts protobuf request messages to ML Commons request objects.
@@ -230,7 +230,7 @@ public class ProtoRequestConverter {
         }
         try {
             return OBJECT_MAPPER.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("Failed to convert value to JSON string", e);
             throw new IllegalArgumentException("Failed to serialize value to JSON", e);
         }


### PR DESCRIPTION
### Description
Use Jackson 3.x for JSON processing

### Related Issues
Somehow Jackson 2.x still sneaked in (see please https://github.com/opensearch-project/ml-commons/issues/4783)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
