### PR TITLE
Add opaque next_page_token for memory pagination APIs (BWC, additive)

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/conversation/ActionConstants.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/ActionConstants.java
@@ -40,6 +40,14 @@ public class ActionConstants {
     public final static String REQUEST_MAX_RESULTS_FIELD = "max_results";
     /** name of nextToken field name in all messages */
     public final static String NEXT_TOKEN_FIELD = "next_token";
+    /**
+     * name of the opaque pagination token field. Additive companion to {@link #NEXT_TOKEN_FIELD}: the same
+     * underlying offset, exposed as an opaque Base64 string so clients treat it as a handle instead of doing
+     * offset arithmetic. The field name follows the Google/AIP-158 {@code next_page_token} convention rather
+     * than core's own opaque token (which is named {@code next_token}), since {@code next_token} here already
+     * denotes the legacy integer offset.
+     */
+    public final static String NEXT_PAGE_TOKEN_FIELD = "next_page_token";
     /** name of input field in all requests */
     public final static String INPUT_FIELD = "input";
     /** name of AI response field in all respopnses */

--- a/common/src/main/java/org/opensearch/ml/common/conversation/PaginationTokenUtil.java
+++ b/common/src/main/java/org/opensearch/ml/common/conversation/PaginationTokenUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.conversation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Encodes/decodes the memory pagination offset as an opaque {@code next_page_token} string.
+ *
+ * <p>Pagination stays a 0-based int offset internally, so the wire/transport format is unchanged and
+ * this is backward compatible; the token is only an opaque REST-layer encoding of that offset that
+ * clients pass back verbatim rather than parse.
+ */
+public final class PaginationTokenUtil {
+
+    private PaginationTokenUtil() {}
+
+    /** Returns the opaque token for a non-negative offset, or {@code null} for a negative offset (no next page). */
+    public static String encodeOffset(int offset) {
+        if (offset < 0) {
+            return null;
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(Integer.toString(offset).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Decodes an opaque token back to its offset; throws {@link IllegalArgumentException} if malformed or negative. */
+    public static int decodeOffset(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new IllegalArgumentException("Invalid " + ActionConstants.NEXT_PAGE_TOKEN_FIELD + ": token must not be empty");
+        }
+        final int offset;
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(token);
+            offset = Integer.parseInt(new String(decoded, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid " + ActionConstants.NEXT_PAGE_TOKEN_FIELD + ": " + token, e);
+        }
+        if (offset < 0) {
+            throw new IllegalArgumentException("Invalid " + ActionConstants.NEXT_PAGE_TOKEN_FIELD + ": " + token);
+        }
+        return offset;
+    }
+
+    /**
+     * Resolves the offset from the two accepted params: opaque {@code next_page_token} wins over legacy
+     * {@code next_token}; returns {@code null} if neither is set. Takes raw strings (not {@code RestRequest})
+     * so {@code common} keeps no REST dependency.
+     */
+    public static Integer resolveOffset(String pageToken, String legacyToken) {
+        if (pageToken != null) {
+            return decodeOffset(pageToken);
+        }
+        if (legacyToken != null) {
+            return Integer.parseInt(legacyToken);
+        }
+        return null;
+    }
+}

--- a/common/src/test/java/org/opensearch/ml/common/conversation/PaginationTokenUtilTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/conversation/PaginationTokenUtilTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.ml.common.conversation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Base64;
+
+import org.junit.Test;
+
+public class PaginationTokenUtilTests {
+
+    @Test
+    public void testEncodeDecode_roundTrip() {
+        for (int offset : new int[] { 0, 1, 2, 6, 7, 10, 999, Integer.MAX_VALUE }) {
+            String token = PaginationTokenUtil.encodeOffset(offset);
+            assertEquals(offset, PaginationTokenUtil.decodeOffset(token));
+        }
+    }
+
+    @Test
+    public void testEncode_knownValues() {
+        // Base64url of "2" is "Mg", of "6" is "Ng"
+        assertEquals("Mg", PaginationTokenUtil.encodeOffset(2));
+        assertEquals("Ng", PaginationTokenUtil.encodeOffset(6));
+    }
+
+    @Test
+    public void testEncode_negativeOffset_returnsNull() {
+        assertNull(PaginationTokenUtil.encodeOffset(-1));
+    }
+
+    @Test
+    public void testDecode_isOpaque_notPlainInteger() {
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset("2"));
+    }
+
+    @Test
+    public void testDecode_null_thenFail() {
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset(null));
+    }
+
+    @Test
+    public void testDecode_empty_thenFail() {
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset(""));
+    }
+
+    @Test
+    public void testDecode_malformedBase64_thenFail() {
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset("!!!not-base64!!!"));
+    }
+
+    @Test
+    public void testDecode_nonNumericPayload_thenFail() {
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString("abc".getBytes());
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset(token));
+    }
+
+    @Test
+    public void testDecode_negativePayload_thenFail() {
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString("-5".getBytes());
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.decodeOffset(token));
+    }
+
+    @Test
+    public void testResolveOffset_neither_returnsNull() {
+        assertNull(PaginationTokenUtil.resolveOffset(null, null));
+    }
+
+    @Test
+    public void testResolveOffset_legacyOnly() {
+        assertEquals(Integer.valueOf(7), PaginationTokenUtil.resolveOffset(null, "7"));
+    }
+
+    @Test
+    public void testResolveOffset_pageTokenOnly() {
+        // "Ng" = offset 6
+        assertEquals(Integer.valueOf(6), PaginationTokenUtil.resolveOffset("Ng", null));
+    }
+
+    @Test
+    public void testResolveOffset_pageTokenTakesPrecedenceOverLegacy() {
+        // "Ng" = offset 6, wins over legacy 99
+        assertEquals(Integer.valueOf(6), PaginationTokenUtil.resolveOffset("Ng", "99"));
+    }
+
+    @Test
+    public void testResolveOffset_invalidPageToken_thenFail() {
+        // malformed page token fails hard; no fallback to the valid legacy token
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.resolveOffset("!!!not-base64!!!", "99"));
+    }
+
+    @Test
+    public void testResolveOffset_invalidLegacyToken_thenFail() {
+        assertThrows(IllegalArgumentException.class, () -> PaginationTokenUtil.resolveOffset(null, "not-an-int"));
+    }
+}

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetConversationsRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetConversationsRequest.java
@@ -26,6 +26,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 import org.opensearch.rest.RestRequest;
 
 import lombok.Getter;
@@ -90,6 +91,9 @@ public class GetConversationsRequest extends ActionRequest {
         if (this.maxResults <= 0) {
             exception = addValidationError("Can't list 0 or negative conversations", exception);
         }
+        if (this.from < 0) {
+            exception = addValidationError("The starting position must be nonnegative", exception);
+        }
         return exception;
     }
 
@@ -100,20 +104,15 @@ public class GetConversationsRequest extends ActionRequest {
      * @throws IOException if something breaks
      */
     public static GetConversationsRequest fromRestRequest(RestRequest request) throws IOException {
-        if (request.hasParam(ActionConstants.NEXT_TOKEN_FIELD)) {
-            int maxResults = request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)
-                ? Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD))
-                : ActionConstants.DEFAULT_MAX_RESULTS;
+        int maxResults = request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)
+            ? Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD))
+            : ActionConstants.DEFAULT_MAX_RESULTS;
 
-            int nextToken = Integer.parseInt(request.param(ActionConstants.NEXT_TOKEN_FIELD));
-
-            return new GetConversationsRequest(maxResults, nextToken);
-        } else {
-            int maxResults = request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)
-                ? Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD))
-                : ActionConstants.DEFAULT_MAX_RESULTS;
-
-            return new GetConversationsRequest(maxResults);
+        Integer from = PaginationTokenUtil
+            .resolveOffset(request.param(ActionConstants.NEXT_PAGE_TOKEN_FIELD), request.param(ActionConstants.NEXT_TOKEN_FIELD));
+        if (from != null) {
+            return new GetConversationsRequest(maxResults, from);
         }
+        return new GetConversationsRequest(maxResults);
     }
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponse.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponse.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.conversation.ActionConstants;
 import org.opensearch.ml.common.conversation.ConversationMeta;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -80,6 +81,7 @@ public class GetConversationsResponse extends ActionResponse implements ToXConte
         builder.endArray();
         if (hasMoreTokens) {
             builder.field(ActionConstants.NEXT_TOKEN_FIELD, nextToken);
+            builder.field(ActionConstants.NEXT_PAGE_TOKEN_FIELD, PaginationTokenUtil.encodeOffset(nextToken));
         }
         builder.endObject();
         return builder;

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetInteractionsRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetInteractionsRequest.java
@@ -26,6 +26,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 import org.opensearch.rest.RestRequest;
 
 import lombok.Getter;
@@ -114,22 +115,16 @@ public class GetInteractionsRequest extends ActionRequest {
      */
     public static GetInteractionsRequest fromRestRequest(RestRequest request) throws IOException {
         String cid = request.param(ActionConstants.MEMORY_ID);
-        if (request.hasParam(ActionConstants.NEXT_TOKEN_FIELD)) {
-            int from = Integer.parseInt(request.param(ActionConstants.NEXT_TOKEN_FIELD));
-            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
-                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
-                return new GetInteractionsRequest(cid, maxResults, from);
-            } else {
-                return new GetInteractionsRequest(cid, ActionConstants.DEFAULT_MAX_RESULTS, from);
-            }
-        } else {
-            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
-                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
-                return new GetInteractionsRequest(cid, maxResults);
-            } else {
-                return new GetInteractionsRequest(cid);
-            }
+        int maxResults = request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)
+            ? Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD))
+            : ActionConstants.DEFAULT_MAX_RESULTS;
+
+        Integer from = PaginationTokenUtil
+            .resolveOffset(request.param(ActionConstants.NEXT_PAGE_TOKEN_FIELD), request.param(ActionConstants.NEXT_TOKEN_FIELD));
+        if (from != null) {
+            return new GetInteractionsRequest(cid, maxResults, from);
         }
+        return new GetInteractionsRequest(cid, maxResults);
     }
 
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetInteractionsResponse.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetInteractionsResponse.java
@@ -28,6 +28,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.conversation.ActionConstants;
 import org.opensearch.ml.common.conversation.Interaction;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -80,6 +81,7 @@ public class GetInteractionsResponse extends ActionResponse implements ToXConten
         builder.endArray();
         if (hasMoreTokens) {
             builder.field(ActionConstants.NEXT_TOKEN_FIELD, nextToken);
+            builder.field(ActionConstants.NEXT_PAGE_TOKEN_FIELD, PaginationTokenUtil.encodeOffset(nextToken));
         }
         builder.endObject();
         return builder;

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesRequest.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesRequest.java
@@ -14,6 +14,7 @@ import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.ml.common.conversation.ActionConstants;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 import org.opensearch.rest.RestRequest;
 
 import lombok.Getter;
@@ -103,22 +104,16 @@ public class GetTracesRequest extends ActionRequest {
      */
     public static GetTracesRequest fromRestRequest(RestRequest request) throws IOException {
         String cid = request.param(ActionConstants.RESPONSE_INTERACTION_ID_FIELD);
-        if (request.hasParam(ActionConstants.NEXT_TOKEN_FIELD)) {
-            int from = Integer.parseInt(request.param(ActionConstants.NEXT_TOKEN_FIELD));
-            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
-                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
-                return new GetTracesRequest(cid, maxResults, from);
-            } else {
-                return new GetTracesRequest(cid, ActionConstants.DEFAULT_MAX_RESULTS, from);
-            }
-        } else {
-            if (request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)) {
-                int maxResults = Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD));
-                return new GetTracesRequest(cid, maxResults);
-            } else {
-                return new GetTracesRequest(cid);
-            }
+        int maxResults = request.hasParam(ActionConstants.REQUEST_MAX_RESULTS_FIELD)
+            ? Integer.parseInt(request.param(ActionConstants.REQUEST_MAX_RESULTS_FIELD))
+            : ActionConstants.DEFAULT_MAX_RESULTS;
+
+        Integer from = PaginationTokenUtil
+            .resolveOffset(request.param(ActionConstants.NEXT_PAGE_TOKEN_FIELD), request.param(ActionConstants.NEXT_TOKEN_FIELD));
+        if (from != null) {
+            return new GetTracesRequest(cid, maxResults, from);
         }
+        return new GetTracesRequest(cid, maxResults);
     }
 
 }

--- a/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesResponse.java
+++ b/memory/src/main/java/org/opensearch/ml/memory/action/conversation/GetTracesResponse.java
@@ -16,6 +16,7 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.common.conversation.ActionConstants;
 import org.opensearch.ml.common.conversation.Interaction;
+import org.opensearch.ml.common.conversation.PaginationTokenUtil;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -69,6 +70,7 @@ public class GetTracesResponse extends ActionResponse implements ToXContentObjec
         builder.endArray();
         if (hasMoreTokens) {
             builder.field(ActionConstants.NEXT_TOKEN_FIELD, nextToken);
+            builder.field(ActionConstants.NEXT_PAGE_TOKEN_FIELD, PaginationTokenUtil.encodeOffset(nextToken));
         }
         builder.endObject();
         return builder;

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsRequestTests.java
@@ -63,6 +63,13 @@ public class GetConversationsRequestTests extends OpenSearchTestCase {
         assert (req.validate().validationErrors().get(0).equals("Can't list 0 or negative conversations"));
     }
 
+    public void testNegativeFrom_thenFail() {
+        GetConversationsRequest req = new GetConversationsRequest(5, -2);
+        assert (req.validate() != null);
+        assert (req.validate().validationErrors().size() == 1);
+        assert (req.validate().validationErrors().get(0).equals("The starting position must be nonnegative"));
+    }
+
     public void testFromRestRequest() throws IOException {
         Map<String, String> maxResOnly = Map.of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "4");
         Map<String, String> nextTokOnly = Map.of(ActionConstants.NEXT_TOKEN_FIELD, "6");
@@ -80,5 +87,35 @@ public class GetConversationsRequestTests extends OpenSearchTestCase {
         assert (gcr1.getFrom() == 0 && gcr2.getFrom() == 0 && gcr3.getFrom() == 6 && gcr4.getFrom() == 7);
         assert (gcr1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gcr2.getMaxResults() == 4);
         assert (gcr3.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gcr4.getMaxResults() == 2);
+    }
+
+    public void testFromRestRequest_withOpaquePageToken() throws IOException {
+        // "Ng" = offset 6
+        Map<String, String> pageTokenOnly = Map.of(ActionConstants.NEXT_PAGE_TOKEN_FIELD, "Ng");
+        Map<String, String> bothMaxAndPageToken = Map
+            .of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "2", ActionConstants.NEXT_PAGE_TOKEN_FIELD, "Ng");
+        RestRequest req1 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(pageTokenOnly).build();
+        RestRequest req2 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(bothMaxAndPageToken).build();
+        GetConversationsRequest gcr1 = GetConversationsRequest.fromRestRequest(req1);
+        GetConversationsRequest gcr2 = GetConversationsRequest.fromRestRequest(req2);
+
+        assert (gcr1.validate() == null && gcr2.validate() == null);
+        assert (gcr1.getFrom() == 6 && gcr2.getFrom() == 6);
+        assert (gcr1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gcr2.getMaxResults() == 2);
+    }
+
+    public void testFromRestRequest_opaquePageTokenTakesPrecedenceOverLegacy() throws IOException {
+        // "Ng" = offset 6, wins over legacy 99
+        Map<String, String> both = Map.of(ActionConstants.NEXT_PAGE_TOKEN_FIELD, "Ng", ActionConstants.NEXT_TOKEN_FIELD, "99");
+        RestRequest req = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(both).build();
+        GetConversationsRequest gcr = GetConversationsRequest.fromRestRequest(req);
+        assert (gcr.validate() == null);
+        assert (gcr.getFrom() == 6);
+    }
+
+    public void testFromRestRequest_invalidOpaquePageToken_thenFail() {
+        Map<String, String> badToken = Map.of(ActionConstants.NEXT_PAGE_TOKEN_FIELD, "!!!not-base64!!!");
+        RestRequest req = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(badToken).build();
+        expectThrows(IllegalArgumentException.class, () -> GetConversationsRequest.fromRestRequest(req));
     }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetConversationsResponseTests.java
@@ -77,7 +77,7 @@ public class GetConversationsResponseTests extends OpenSearchTestCase {
             + conversation.getCreatedTime()
             + "\"updated_time\":\""
             + conversation.getUpdatedTime()
-            + "\",\"name\":\"name0\",\"user\":\"user0\"}],\"next_token\":2}";
+            + "\",\"name\":\"name0\",\"user\":\"user0\"}],\"next_token\":2,\"next_page_token\":\"Mg\"}";
         log.info("FINDME");
         log.info(result);
         log.info(expected);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsRequestTests.java
@@ -125,4 +125,27 @@ public class GetInteractionsRequestTests extends OpenSearchTestCase {
         assert (gir1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gir2.getMaxResults() == 4);
         assert (gir3.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gir4.getMaxResults() == 2);
     }
+
+    public void testFromRestRequest_withOpaquePageToken() throws IOException {
+        // "Ng" = offset 6
+        Map<String, String> pageTokenOnly = Map.of(ActionConstants.MEMORY_ID, "cid1", ActionConstants.NEXT_PAGE_TOKEN_FIELD, "Ng");
+        Map<String, String> bothMaxAndPageToken = Map
+            .of(
+                ActionConstants.MEMORY_ID,
+                "cid2",
+                ActionConstants.REQUEST_MAX_RESULTS_FIELD,
+                "2",
+                ActionConstants.NEXT_PAGE_TOKEN_FIELD,
+                "Ng"
+            );
+        RestRequest req1 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(pageTokenOnly).build();
+        RestRequest req2 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(bothMaxAndPageToken).build();
+        GetInteractionsRequest gir1 = GetInteractionsRequest.fromRestRequest(req1);
+        GetInteractionsRequest gir2 = GetInteractionsRequest.fromRestRequest(req2);
+
+        assert (gir1.validate() == null && gir2.validate() == null);
+        assert (gir1.getConversationId().equals("cid1") && gir2.getConversationId().equals("cid2"));
+        assert (gir1.getFrom() == 6 && gir2.getFrom() == 6);
+        assert (gir1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gir2.getMaxResults() == 2);
+    }
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetInteractionsResponseTests.java
@@ -107,7 +107,7 @@ public class GetInteractionsResponseTests extends OpenSearchTestCase {
             + interaction.getCreateTime()
             + "\"update_time\":\""
             + interaction.getUpdatedTime()
-            + "\",\"input\":\"input\",\"prompt_template\":\"pt\",\"response\":\"response\",\"origin\":\"origin\",\"additional_info\":{\"metadata\":\"some meta\"}}],\"next_token\":2}";
+            + "\",\"input\":\"input\",\"prompt_template\":\"pt\",\"response\":\"response\",\"origin\":\"origin\",\"additional_info\":{\"metadata\":\"some meta\"}}],\"next_token\":2,\"next_page_token\":\"Mg\"}";
         // Sometimes there's an extra trailing 0 in the time stringification, so just assert closeness
         LevenshteinDistance ld = new LevenshteinDistance();
         assert (ld.getDistance(result, expected) > 0.95);

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesRequestTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesRequestTests.java
@@ -98,4 +98,29 @@ public class GetTracesRequestTests extends OpenSearchTestCase {
         assert (gir1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gir2.getMaxResults() == 4);
         assert (gir3.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gir4.getMaxResults() == 2);
     }
+
+    public void testFromRestRequest_withOpaquePageToken() throws IOException {
+        // "Ng" = offset 6
+        Map<String, String> pageTokenOnly = Map
+            .of(ActionConstants.RESPONSE_INTERACTION_ID_FIELD, "iid1", ActionConstants.NEXT_PAGE_TOKEN_FIELD, "Ng");
+        Map<String, String> bothMaxAndPageToken = Map
+            .of(
+                ActionConstants.RESPONSE_INTERACTION_ID_FIELD,
+                "iid2",
+                ActionConstants.REQUEST_MAX_RESULTS_FIELD,
+                "2",
+                ActionConstants.NEXT_PAGE_TOKEN_FIELD,
+                "Ng"
+            );
+        RestRequest req1 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(pageTokenOnly).build();
+        RestRequest req2 = new FakeRestRequest.Builder(NamedXContentRegistry.EMPTY).withParams(bothMaxAndPageToken).build();
+        GetTracesRequest gtr1 = GetTracesRequest.fromRestRequest(req1);
+        GetTracesRequest gtr2 = GetTracesRequest.fromRestRequest(req2);
+
+        assert (gtr1.validate() == null && gtr2.validate() == null);
+        assert (gtr1.getInteractionId().equals("iid1") && gtr2.getInteractionId().equals("iid2"));
+        assert (gtr1.getFrom() == 6 && gtr2.getFrom() == 6);
+        assert (gtr1.getMaxResults() == ActionConstants.DEFAULT_MAX_RESULTS && gtr2.getMaxResults() == 2);
+    }
+
 }

--- a/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesResponseTests.java
+++ b/memory/src/test/java/org/opensearch/ml/memory/action/conversation/GetTracesResponseTests.java
@@ -100,7 +100,7 @@ public class GetTracesResponseTests extends OpenSearchTestCase {
             + trace.getCreateTime()
             + "\"update_time\":\""
             + trace.getUpdatedTime()
-            + ",\"input\":\"input\",\"prompt_template\":\"pt\",\"response\":\"response\",\"origin\":\"origin\",\"additional_info\":{\"metadata\":\"some meta\"},\"parent_message_id\":\"parent_id\",\"trace_number\":1}],\"next_token\":2}";
+            + ",\"input\":\"input\",\"prompt_template\":\"pt\",\"response\":\"response\",\"origin\":\"origin\",\"additional_info\":{\"metadata\":\"some meta\"},\"parent_message_id\":\"parent_id\",\"trace_number\":1}],\"next_token\":2,\"next_page_token\":\"Mg\"}";
         // Sometimes there's an extra trailing 0 in the time stringification, so just assert closeness
         LevenshteinDistance ld = new LevenshteinDistance();
         assert (ld.getDistance(result, expected) > 0.95);

--- a/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
+++ b/plugin/src/test/java/org/opensearch/ml/rest/RestMemoryGetConversationsActionIT.java
@@ -194,4 +194,53 @@ public class RestMemoryGetConversationsActionIT extends MLCommonsRestTestCase {
         assert (((String) conversations.get(0).get(CONVERSATION_ID_FIELD)).equals(id1));
         assert (((Double) map.get("next_token")).intValue() == 2);
     }
+
+    public void testGetConversations_nextPage_withOpaquePageToken() throws IOException, InterruptedException {
+        Response ccresponse1 = TestHelper.makeRequest(client(), "POST", ActionConstants.CREATE_CONVERSATION_REST_PATH, null, "", null);
+        assert (TestHelper.restStatus(ccresponse1) == RestStatus.OK);
+        Map ccmap1 = gson.fromJson(TestHelper.httpEntityToString(ccresponse1.getEntity()), Map.class);
+        String id1 = (String) ccmap1.get(CONVERSATION_ID_FIELD);
+
+        // ensure distinct update times
+        TimeUnit.MICROSECONDS.sleep(100);
+
+        Response ccresponse2 = TestHelper.makeRequest(client(), "POST", ActionConstants.CREATE_CONVERSATION_REST_PATH, null, "", null);
+        assert (TestHelper.restStatus(ccresponse2) == RestStatus.OK);
+
+        // page 1: capture the opaque next_page_token
+        Response response1 = TestHelper
+            .makeRequest(
+                client(),
+                "GET",
+                ActionConstants.GET_CONVERSATIONS_REST_PATH,
+                Map.of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "1"),
+                "",
+                null
+            );
+        assert (TestHelper.restStatus(response1) == RestStatus.OK);
+        Map map1 = gson.fromJson(TestHelper.httpEntityToString(response1.getEntity()), Map.class);
+        assert (map1.containsKey("next_token"));
+        assert (map1.containsKey(ActionConstants.NEXT_PAGE_TOKEN_FIELD));
+        String nextPageToken = (String) map1.get(ActionConstants.NEXT_PAGE_TOKEN_FIELD);
+        assert (nextPageToken != null && !nextPageToken.isEmpty());
+
+        // page 2: pass the token back verbatim
+        Response response = TestHelper
+            .makeRequest(
+                client(),
+                "GET",
+                ActionConstants.GET_CONVERSATIONS_REST_PATH,
+                Map.of(ActionConstants.REQUEST_MAX_RESULTS_FIELD, "1", ActionConstants.NEXT_PAGE_TOKEN_FIELD, nextPageToken),
+                "",
+                null
+            );
+        assert (TestHelper.restStatus(response) == RestStatus.OK);
+        Map map = gson.fromJson(TestHelper.httpEntityToString(response.getEntity()), Map.class);
+        @SuppressWarnings("unchecked")
+        ArrayList<Map> conversations = (ArrayList<Map>) map.get(RESPONSE_CONVERSATION_LIST_FIELD);
+        assert (conversations.size() == 1);
+        // opaque-token paging lands on the same item as the legacy flow
+        assert (((String) conversations.get(0).get(CONVERSATION_ID_FIELD)).equals(id1));
+        assert (((Double) map.get("next_token")).intValue() == 2);
+    }
 }


### PR DESCRIPTION
### Description

Adds an opaque, Base64-encoded pagination token to the memory/conversation list APIs (`GetConversations`, `GetInteractions`, `GetTraces`), aligning them with the page-token convention used by OpenSearch core (`org.opensearch.action.pagination.PageToken`). Addresses #4861.

The change is additive and backward-compatible rather than the breaking `int → String` swap the issue frames for 4.0, so the opaque-token experience can ship on 3.x:

- Responses continue to emit the legacy integer `next_token` and additionally emit `next_page_token`, an opaque Base64url string.
- Requests accept either `next_page_token` (preferred) or the legacy integer `next_token`. When both are present, `next_page_token` wins; a malformed `next_page_token` is rejected (it does not silently fall back to the legacy offset).
- A new helper, `PaginationTokenUtil` (in `common`), encodes/decodes the offset and centralizes the decode-and-precedence logic. It is a pure string utility, so `common` gains no REST dependency.

No transport/wire change: the token is only a REST-layer encoding of the existing integer offset. Node-to-node serialization still uses `writeInt`/`readInt`, so mixed-version clusters are unaffected and no version gating is required.

### Scope / known limitations

- `next_page_token` is a transitional field name. Core's opaque field is itself named `next_token`; the intended 4.0 follow-up is to converge `next_token` to the opaque String (core's name and type) and retire the `next_page_token` alias.
- Rolling-upgrade guidance (client-facing only): a client that adopts `next_page_token` while a cluster is mid-upgrade can hit a not-yet-upgraded node that ignores the param and serves from offset 0 — a silent duplicate page, not an error. Because the wire format is unchanged this is a client-adoption-timing concern, not a compatibility break. Clients should keep using `next_token` until every node is upgraded.
- Documentation and the API-spec companion change are follow-ups; this PR covers the plugin code and tests only.

**Validation:** unit tests for `PaginationTokenUtil` (round-trip, opacity, and malformed/negative rejection) and for all three request/response classes (opaque token, precedence, invalid-token failure), plus `RestMemoryGetConversationsActionIT`, which paginates end-to-end through the REST layer using the opaque token returned by page 1 and lands on the same item as the legacy offset flow. Verified locally with `spotlessJavaCheck` and the affected module tests green.

### Related Issues
Resolves #4861

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request created.
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
