### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,40 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".config",
+    ".png",
+    ".jar",
+    ".pem",
+    ".gz",
+    ".zip",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".policy",
+    ".properties",
+    ".ipynb",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "**/test/resources/",
+    "**/META-INF/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/common/src/main/java/org/opensearch/ml/common/exception/ExecuteException.java
+++ b/common/src/main/java/org/opensearch/ml/common/exception/ExecuteException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.exception;
 
 public class ExecuteException extends MLException {

--- a/common/src/main/java/org/opensearch/ml/common/output/model/ModelResultFilter.java
+++ b/common/src/main/java/org/opensearch/ml/common/output/model/ModelResultFilter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.output.model;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;

--- a/common/src/main/java/org/opensearch/ml/common/transport/search/MLSearchActionRequest.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/search/MLSearchActionRequest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.search;
 
 import static org.opensearch.ml.common.CommonValue.VERSION_2_19_0;

--- a/common/src/main/java/org/opensearch/ml/common/transport/task/MLTaskSearchAction.java
+++ b/common/src/main/java/org/opensearch/ml/common/transport/task/MLTaskSearchAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.task;
 
 import org.opensearch.action.ActionType;

--- a/common/src/test/java/org/opensearch/ml/common/agent/LLMSpecTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/LLMSpecTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.agent;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLMemorySpecTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLMemorySpecTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.agent;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/agent/MLToolSpecTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/agent/MLToolSpecTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.agent;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorClientConfigTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorClientConfigTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.connector;
 
 import java.io.IOException;

--- a/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/connector/ConnectorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.connector;
 
 import static org.opensearch.ml.common.connector.HttpConnectorTest.createHttpConnector;

--- a/common/src/test/java/org/opensearch/ml/common/contextmanager/ContextManagerContextTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/contextmanager/ContextManagerContextTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.contextmanager;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/contextmanager/ContextManagerHookProviderEnhancedTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/contextmanager/ContextManagerHookProviderEnhancedTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.contextmanager;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/dataset/AsymmetricTextEmbeddingParametersTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/AsymmetricTextEmbeddingParametersTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.dataset;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/dataset/remote/RemoteInferenceInputDataSetTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/dataset/remote/RemoteInferenceInputDataSetTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.dataset.remote;
 
 import static org.opensearch.ml.common.dataset.MLInputDataType.REMOTE;

--- a/common/src/test/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTaskTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/indexInsight/LogRelatedIndexCheckTaskTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.indexInsight;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/nlp/TextDocsMLInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.input.nlp;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/input/remote/RemoteInferenceMLInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/input/remote/RemoteInferenceMLInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.input.remote;
 
 import java.io.IOException;

--- a/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/ModelGuardrailTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.model;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/common/src/test/java/org/opensearch/ml/common/output/model/ModelResultFilterTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/model/ModelResultFilterTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.output.model;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorOutputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/output/model/ModelTensorOutputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.output.model;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/IndexInsight/MLIndexInsightConfigGetRequestTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/IndexInsight/MLIndexInsightConfigGetRequestTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.IndexInsight;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/IndexInsight/MLIndexInsightConfigGetResponseTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/IndexInsight/MLIndexInsightConfigGetResponseTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.IndexInsight;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodeResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelNodesResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/deploy/MLDeployModelResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.deploy;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.execute;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/execute/MLExecuteTaskResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.execute;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.forward;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.forward;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/forward/MLForwardResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.forward;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupDeleteRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLModelGroupDeleteRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.model_group;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.model_group;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLRegisterModelGroupRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.model_group;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLUpdateModelGroupInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLUpdateModelGroupInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.model_group;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLUpdateModelGroupRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/model_group/MLUpdateModelGroupRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.model_group;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.register;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.register;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/register/MLRegisterModelResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.register;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/search/MLSearchActionRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/search/MLSearchActionRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.search;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.sync;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.sync;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodeResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.sync;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpNodesResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.sync;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/sync/MLSyncUpResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.sync;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/task/MLCancelBatchJobRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/task/MLCancelBatchJobRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.task;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/task/MLCancelBatchJobResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/task/MLCancelBatchJobResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.task;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.task;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/task/MLTaskGetResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.task;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelInputTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelInputTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.undeploy;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodeResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodeResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.undeploy;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.undeploy;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesResponseTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelNodesResponseTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.undeploy;
 
 import static org.junit.Assert.assertEquals;

--- a/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsRequestTest.java
+++ b/common/src/test/java/org/opensearch/ml/common/transport/undeploy/MLUndeployModelsRequestTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.transport.undeploy;
 
 import static org.junit.Assert.*;

--- a/common/src/test/java/org/opensearch/ml/common/utils/mergeMetaDataUtils/MergeRuleHelperTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/utils/mergeMetaDataUtils/MergeRuleHelperTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.common.utils.mergeMetaDataUtils;
 
 import static org.junit.Assert.assertEquals;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 crypto.standard=FIPS-140-3

--- a/grpc/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.GrpcServiceFactory
+++ b/grpc/src/main/resources/META-INF/services/org.opensearch.transport.grpc.spi.GrpcServiceFactory
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.ml.grpc.MLGrpcServiceFactory

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * Copyright Aryn, Inc 2023
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/MultiTenantPredictable.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/MultiTenantPredictable.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine;
 
 import java.util.Map;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/agents/AgentContextUtil.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/agents/AgentContextUtil.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.agents;
 
 import static org.opensearch.ml.engine.algorithms.agent.MLAgentExecutor.QUESTION;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/DLModelExecute.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms;
 
 import static org.opensearch.ml.engine.ModelHelper.ONNX_FILE_EXTENSION;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/SentenceTransformerTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/SentenceTransformerTranslator.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms;
 
 import java.io.IOException;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/TextEmbeddingModel.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/TextEmbeddingModel.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms;
 
 import java.util.ArrayList;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/PromptTemplate.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.agent;
 
 import static org.opensearch.ml.engine.algorithms.agent.MLPlanExecuteAndReflectAgentRunner.COMPLETED_STEPS_FIELD;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_embedding/HuggingfaceTextEmbeddingTranslator.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/text_embedding/HuggingfaceTextEmbeddingTranslator.java
@@ -1,4 +1,9 @@
 /*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/processor/MLProcessor.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/processor/MLProcessor.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.processor;
 
 /**

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/tools/QueryPlanningPromptTemplate.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.tools;
 
 public class QueryPlanningPromptTemplate {

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/AgentModelsSearcher.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/AgentModelsSearcher.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.utils;
 
 import static org.opensearch.ml.common.CommonValue.ML_AGENT_INDEX;

--- a/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/MathUtil.java
+++ b/ml-algorithms/src/main/java/org/opensearch/ml/engine/utils/MathUtil.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.utils;
 
 import java.util.function.BiFunction;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLStaticMockBase.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/MLStaticMockBase.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine;
 
 import org.mockito.MockSettings;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/agents/AgentContextUtilTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/agents/AgentContextUtilTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.agents;
 
 import static org.junit.Assert.*;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/AbstractConnectorExecutorTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.junit.Assert.*;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/RemoteConnectorExecutor_RetryableActionExtensionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BaseStreamingHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BaseStreamingHandlerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote.streaming;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/remote/streaming/BedrockStreamingHandlerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.remote.streaming;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/sparse_encoding/TextEmbeddingSparseEncodingModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/sparse_encoding/TextEmbeddingSparseEncodingModelTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.sparse_encoding;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/tokenize/SparseTokenizerModelTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/algorithms/tokenize/SparseTokenizerModelTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.algorithms.tokenize;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/encryptor/EncryptorImplTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.encryptor;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/indices/MLIndicesHandlerTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/indices/MLIndicesHandlerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.indices;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/BaseMessageTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/BaseMessageTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.memory;
 
 import java.io.IOException;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/ConversationIndexMemoryTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/ConversationIndexMemoryTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.memory;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/ConversationIndexMessageTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/memory/ConversationIndexMessageTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.memory;
 
 import java.io.IOException;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/IndexInsightToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/IndexInsightToolTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.tools;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/ListIndexToolTests.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/tools/ListIndexToolTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.tools;
 
 import static org.junit.Assert.assertEquals;

--- a/ml-algorithms/src/test/java/org/opensearch/ml/engine/utils/ZipUtilsTest.java
+++ b/ml-algorithms/src/test/java/org/opensearch/ml/engine/utils/ZipUtilsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.ml.engine.utils;
 
 import java.io.File;

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
+++ b/plugin/src/main/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/plugin/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
+++ b/plugin/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.ml.resources.MLResourceSharingExtension

--- a/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilderTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersExtBuilderTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtilTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/searchext/MLInferenceRequestParametersUtilTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  *  The OpenSearch Contributors require contributions made to

--- a/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAParamUtilTests.java
+++ b/search-processors/src/test/java/org/opensearch/searchpipelines/questionanswering/generative/GenerativeQAParamUtilTests.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.searchpipelines.questionanswering.generative;
 
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
