### PR TITLE
Fix deletion of remote models stored without additional_config

### DIFF
--- a/common/src/main/java/org/opensearch/ml/common/MLModel.java
+++ b/common/src/main/java/org/opensearch/ml/common/MLModel.java
@@ -757,7 +757,9 @@ public class MLModel implements ToXContentObject {
                     } else if (FunctionName.TEXT_EMBEDDING.name().equals(algorithmName)) {
                         modelConfig = TextEmbeddingModelConfig.parse(parser);
                     } else if (FunctionName.REMOTE.name().equals(algorithmName)) {
-                        modelConfig = RemoteModelConfig.parse(parser);
+                        // Stored documents may predate the space_type requirement (issue #4999);
+                        // registration-time validation lives in MLRegisterModelInput / MLRegisterModelMetaInput.
+                        modelConfig = RemoteModelConfig.parse(parser, false);
                     } else {
                         modelConfig = BaseModelConfig.parse(parser);
                     }

--- a/common/src/main/java/org/opensearch/ml/common/model/RemoteModelConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/RemoteModelConfig.java
@@ -48,6 +48,20 @@ public class RemoteModelConfig extends BaseModelConfig {
         Integer modelMaxLength,
         Map<String, Object> additionalConfig
     ) {
+        this(modelType, embeddingDimension, frameworkType, allConfig, poolingMode, normalizeResult, modelMaxLength, additionalConfig, true);
+    }
+
+    private RemoteModelConfig(
+        String modelType,
+        Integer embeddingDimension,
+        BaseModelConfig.FrameworkType frameworkType,
+        String allConfig,
+        BaseModelConfig.PoolingMode poolingMode,
+        boolean normalizeResult,
+        Integer modelMaxLength,
+        Map<String, Object> additionalConfig,
+        boolean validate
+    ) {
         super(
             modelType,
             allConfig,
@@ -60,11 +74,21 @@ public class RemoteModelConfig extends BaseModelConfig {
             null,
             null
         );
-        validateNoDuplicateKeys(allConfig, additionalConfig);
-        validateTextEmbeddingConfig();
+        if (validate) {
+            validateNoDuplicateKeys(allConfig, additionalConfig);
+            validateTextEmbeddingConfig();
+        }
     }
 
     public static RemoteModelConfig parse(XContentParser parser) throws IOException {
+        return parse(parser, true);
+    }
+
+    /**
+     * Parses a remote model config. Pass {@code validate = false} when reading back a stored
+     * model document, which may predate the space_type requirement (issue #4999).
+     */
+    public static RemoteModelConfig parse(XContentParser parser, boolean validate) throws IOException {
         String modelType = null;
         Integer embeddingDimension = null;
         BaseModelConfig.FrameworkType frameworkType = null;
@@ -117,7 +141,8 @@ public class RemoteModelConfig extends BaseModelConfig {
             poolingMode,
             normalizeResult,
             modelMaxLength,
-            additionalConfig
+            additionalConfig,
+            validate
         );
     }
 

--- a/common/src/main/java/org/opensearch/ml/common/model/RemoteModelConfig.java
+++ b/common/src/main/java/org/opensearch/ml/common/model/RemoteModelConfig.java
@@ -75,7 +75,6 @@ public class RemoteModelConfig extends BaseModelConfig {
             null
         );
         if (validate) {
-            validateNoDuplicateKeys(allConfig, additionalConfig);
             validateTextEmbeddingConfig();
         }
     }

--- a/common/src/test/java/org/opensearch/ml/common/MLModelTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/MLModelTests.java
@@ -8,6 +8,7 @@ package org.opensearch.ml.common;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 
 import java.io.IOException;
@@ -22,9 +23,11 @@ import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.connector.Connector;
@@ -602,5 +605,33 @@ public class MLModelTests {
         streamInput.setVersion(CommonValue.VERSION_3_5_0);
         MLModel deserialized = new MLModel(streamInput);
         assertNull(deserialized.getProvisionedBy());
+    }
+
+    // Issue #4999: documents stored before the space_type requirement (#3786) must still parse back.
+    @Test
+    public void parseRemoteModel_legacyStoredDocWithoutSpaceType() throws IOException {
+        String legacySource = "{"
+            + "\"name\":\"legacy_remote_text_embedding_model\","
+            + "\"algorithm\":\"REMOTE\","
+            + "\"model_version\":\"19\","
+            + "\"model_state\":\"DEPLOY_FAILED\","
+            + "\"connector_id\":\"test_connector_id\","
+            + "\"model_group_id\":\"test_model_group_id\","
+            + "\"model_config\":{"
+            + "\"model_type\":\"TEXT_EMBEDDING\","
+            + "\"embedding_dimension\":768,"
+            + "\"framework_type\":\"SENTENCE_TRANSFORMERS\""
+            + "}"
+            + "}";
+        try (
+            XContentParser parser = jsonXContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, legacySource)
+        ) {
+            parser.nextToken();
+            MLModel parsed = MLModel.parse(parser, FunctionName.REMOTE.name());
+            assertEquals("legacy_remote_text_embedding_model", parsed.getName());
+            assertNotNull(parsed.getModelConfig());
+            assertEquals("TEXT_EMBEDDING", parsed.getModelConfig().getModelType());
+            assertNull(((BaseModelConfig) parsed.getModelConfig()).getAdditionalConfig());
+        }
     }
 }

--- a/common/src/test/java/org/opensearch/ml/common/model/RemoteModelConfigTests.java
+++ b/common/src/test/java/org/opensearch/ml/common/model/RemoteModelConfigTests.java
@@ -20,13 +20,19 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.ml.common.TestHelper;
 
 public class RemoteModelConfigTests {
+
+    private static final String LEGACY_TEXT_EMBEDDING_CONTENT = "{\"model_type\":\"text_embedding\","
+        + "\"embedding_dimension\":768,"
+        + "\"framework_type\":\"SENTENCE_TRANSFORMERS\"}";
 
     RemoteModelConfig config;
     Function<XContentParser, RemoteModelConfig> function;
@@ -136,6 +142,28 @@ public class RemoteModelConfigTests {
             + "\"additional_config\":{\"space_type\":\"l2\"},"
             + "\"wrong_filed\":\"test_value\"}";
         TestHelper.testParseFromString(config, content, function);
+    }
+
+    @Test
+    public void parse_textEmbeddingMissingSpaceType() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Space type must be provided in additional_config for remote text embedding model");
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, LEGACY_TEXT_EMBEDDING_CONTENT);
+        parser.nextToken();
+        RemoteModelConfig.parse(parser);
+    }
+
+    @Test
+    public void parseLenient_textEmbeddingMissingSpaceType() throws IOException {
+        XContentParser parser = XContentType.JSON
+            .xContent()
+            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, LEGACY_TEXT_EMBEDDING_CONTENT);
+        parser.nextToken();
+        RemoteModelConfig config = RemoteModelConfig.parse(parser, false);
+        assertEquals("text_embedding", config.getModelType());
+        assertNull(config.getAdditionalConfig());
     }
 
     @Test

--- a/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
+++ b/plugin/src/main/java/org/opensearch/ml/action/models/UpdateModelTransportAction.java
@@ -141,6 +141,16 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             ActionListener<UpdateResponse> wrappedListener = ActionListener.runBefore(actionListener, context::restore);
             mlModelManager.getModel(modelId, tenantId, null, excludes, ActionListener.wrap(mlModel -> {
+                if (mlModel == null) {
+                    wrappedListener
+                        .onFailure(
+                            new OpenSearchStatusException(
+                                "Failed to find model to update with the provided model id: " + modelId,
+                                RestStatus.NOT_FOUND
+                            )
+                        );
+                    return;
+                }
                 if (TenantAwareHelper.validateTenantResource(mlFeatureEnabledSetting, tenantId, mlModel.getTenantId(), actionListener)) {
                     if (!isModelDeploying(mlModel.getModelState())) {
                         FunctionName functionName = mlModel.getAlgorithm();
@@ -228,15 +238,7 @@ public class UpdateModelTransportAction extends HandledTransportAction<ActionReq
                             );
                     }
                 }
-            },
-                e -> wrappedListener
-                    .onFailure(
-                        new OpenSearchStatusException(
-                            "Failed to find model to update with the provided model id: " + modelId,
-                            RestStatus.NOT_FOUND
-                        )
-                    )
-            ));
+            }, e -> wrappedListener.onFailure(e)));
         } catch (Exception e) {
             log.error("Failed to update ML model for {}", modelId, e);
             actionListener.onFailure(e);

--- a/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/DeleteModelTransportActionTests.java
@@ -60,6 +60,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
@@ -1063,5 +1064,41 @@ public class DeleteModelTransportActionTests extends OpenSearchTestCase {
             actionListener.onResponse(getResponse);
             return null;
         }).when(client).get(any(), any());
+    }
+
+    // Issue #4999: models stored before the space_type requirement (#3786) must still be deletable.
+    @Test
+    public void testDeleteLegacyRemoteModel_withoutSpaceType_Success() throws IOException, InterruptedException {
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(client).delete(any(), any());
+
+        String legacySource = "{"
+            + "\"name\":\"legacy_remote_text_embedding_model\","
+            + "\"algorithm\":\"REMOTE\","
+            + "\"model_state\":\"REGISTERED\","
+            + "\"connector_id\":\"test_connector_id\","
+            + "\"model_config\":{"
+            + "\"model_type\":\"TEXT_EMBEDDING\","
+            + "\"embedding_dimension\":768,"
+            + "\"framework_type\":\"SENTENCE_TRANSFORMERS\""
+            + "}"
+            + "}";
+        GetResult getResult = new GetResult("indexName", "111", 111l, 111l, 111l, true, new BytesArray(legacySource), null, null);
+        GetResponse getResponse = new GetResponse(getResult);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(getResponse);
+            return null;
+        }).when(client).get(any(), any());
+
+        deleteModelTransportAction.doExecute(null, mlModelDeleteRequest, actionListener);
+
+        ArgumentCaptor<DeleteResponse> captor = ArgumentCaptor.forClass(DeleteResponse.class);
+        verify(actionListener).onResponse(captor.capture());
+        assertEquals(deleteResponse.getId(), captor.getValue().getId());
+        assertEquals(deleteResponse.getResult(), captor.getValue().getResult());
     }
 }

--- a/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
+++ b/plugin/src/test/java/org/opensearch/ml/action/models/UpdateModelTransportActionTests.java
@@ -723,6 +723,26 @@ public class UpdateModelTransportActionTests extends OpenSearchTestCase {
     }
 
     @Test
+    public void testUpdateModelWithGetModelFailurePropagated() {
+        doAnswer(invocation -> {
+            ActionListener<MLModel> listener = invocation.getArgument(4);
+            listener
+                .onFailure(
+                    new IllegalArgumentException("Space type must be provided in additional_config for remote text embedding model")
+                );
+            return null;
+        }).when(mlModelManager).getModel(eq("test_model_id"), any(), any(), any(), isA(ActionListener.class));
+
+        transportUpdateModelAction.doExecute(task, updateLocalModelRequest, actionListener);
+        ArgumentCaptor<Exception> argumentCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(actionListener).onFailure(argumentCaptor.capture());
+        assertEquals(
+            "Space type must be provided in additional_config for remote text embedding model",
+            argumentCaptor.getValue().getMessage()
+        );
+    }
+
+    @Test
     public void testUpdateModelWithFunctionNameFieldNotFound() {
         doAnswer(invocation -> {
             ActionListener<MLModel> listener = invocation.getArgument(4);


### PR DESCRIPTION
### Description
Remote text embedding models registered before the `space_type` requirement was introduced (#3786) have no `additional_config` in their stored document. `RemoteModelConfig` runs registration-time validation from its constructor, so reading such a document back from the model index fails with `IllegalArgumentException: Space type must be provided in additional_config for remote text embedding model`. The same parse call (`MLModel.parse`) sits in the delete / get / predict / deploy paths, so such a model cannot be deleted, updated, or undeployed (matches the `_undeploy` report in the issue).

This change keeps registration-time validation unchanged and skips it only when reading a stored document back:
- Added a `RemoteModelConfig.parse(parser, boolean validate)` overload. The existing `parse(parser)` still validates, so the user input paths (`MLRegisterModelInput` / `MLRegisterModelMetaInput`) behave exactly as before.
- `MLModel.parse` (stored documents) now uses the lenient overload.

### Testing
Regression tests at two levels, both reproduce the issue (fail before the fix, pass after):
- `MLModelTests.parseRemoteModel_legacyStoredDocWithoutSpaceType` — parse level, uses the stored document shape from the issue report
- `DeleteModelTransportActionTests.testDeleteLegacyRemoteModel_withoutSpaceType_Success` — action level

Existing `RemoteModelConfigTests` validation tests pass unchanged, confirming registration-time behavior is unaffected. Full `common` / `plugin` / `ml-algorithms` test suites pass locally.

### Notes for reviewers
- The `StreamInput` constructor already skips this validation, so this makes XContent deserialization of stored documents consistent with transport deserialization.
- One behavioral note: reading back a stored remote text embedding model no longer fails when `additional_config` is missing. Consumers that need `space_type` still need to handle its absence for pre-#3786 documents, as they did before that requirement existed.

### Related Issues
Resolves #4999

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/ml-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
